### PR TITLE
Change device_class of grid_status and payload_off and payload_on type

### DIFF
--- a/solaredge2mqtt/services/homeassistant/models.py
+++ b/solaredge2mqtt/services/homeassistant/models.py
@@ -46,7 +46,7 @@ class HomeAssistantEntityType(EnumModel):
     ENERGY_KWH = "energy_kwh", "sensor", "energy", "total_increasing", "kWh"
     ENERGY_WH = "energy_wh", "sensor", "energy", "total_increasing", "Wh"
     FREQUENCY_HZ = "frequency_hz", "sensor", "frequency", "measurement", "Hz"
-    GRID_STATUS = "grid_status", "binary_sensor", "grid_status", None, None
+    GRID_STATUS = "grid_status", "binary_sensor", "power", None, None
     MONETARY = "monetary", "sensor", "monetary", "total_increasing", None
     PERCENTAGE = "percentage", "sensor", None, "measurement", "%"
     PLUG = "plug", "binary_sensor", "plug", None, None
@@ -146,13 +146,13 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
 
     @computed_field
     @property
-    def payload_on(self) -> str | None:
-        return "true" if self.ha_type.typed == "binary_sensor" else None
+    def payload_on(self) -> bool | None:
+        return True if self.ha_type.typed == "binary_sensor" else None
 
     @computed_field
     @property
-    def payload_off(self) -> str | None:
-        return "false" if self.ha_type.typed == "binary_sensor" else None
+    def payload_off(self) -> bool | None:
+        return False if self.ha_type.typed == "binary_sensor" else None
 
     @computed_field
     @property


### PR DESCRIPTION
This pull request introduces updates to the `HomeAssistantEntityType` enum and modifies the `payload_on` and `payload_off` properties in the `HomeAssistantEntityType` model to improve data consistency and type accuracy.

### Updates to `HomeAssistantEntityType` enum:
* Changed the `GRID_STATUS` entity's device class from `"grid_status"` to `"power"` for better alignment with Home Assistant's device class standards. (`solaredge2mqtt/services/homeassistant/models.py`, [solaredge2mqtt/services/homeassistant/models.pyL49-R49](diffhunk://#diff-1d9921dafc502d532bd6fc8a758cad5b302538ec19bf710c564795d9c58d9763L49-R49))

### Type adjustments in `payload_on` and `payload_off` properties:
* Updated the return types of `payload_on` and `payload_off` from `str | None` to `bool | None` to better reflect their binary nature and ensure type consistency. (`solaredge2mqtt/services/homeassistant/models.py`, [solaredge2mqtt/services/homeassistant/models.pyL149-R155](diffhunk://#diff-1d9921dafc502d532bd6fc8a758cad5b302538ec19bf710c564795d9c58d9763L149-R155))