### PR TITLE
Rename 'slave' parameter to 'device_id' for compatibility

### DIFF
--- a/solaredge2mqtt/services/modbus/__init__.py
+++ b/solaredge2mqtt/services/modbus/__init__.py
@@ -292,7 +292,7 @@ class Modbus:
 
             try:
                 result = await self.client.read_holding_registers(
-                    slave=unit,
+                    device_id=unit,
                     address=address_start,
                     count=register_or_bundle.length,
                 )
@@ -429,7 +429,7 @@ class Modbus:
                 await self.client.write_registers(
                     register.address,
                     value_decoded,
-                    slave=self.settings.unit,
+                    device_id=self.settings.unit,
                 )
 
         except ModbusException as error:


### PR DESCRIPTION
Update the parameter name from 'slave' to 'device_id' in Modbus functions to enhance compatibility.