### PR TITLE
Add external production setting for validation

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -4,6 +4,9 @@
 # Interval between requests in seconds
 #SE2MQTT_INTERVAL=5
 
+# Set this to true if you have any additional producers to skip some validations
+#SE2MQTT_EXTERNAL_PRODUCTION=False
+
 # Set latitude of your location
 #SE2MQTT_LOCATION__LATITUDE=
 

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # Interval between requests in seconds
 #SE2MQTT_INTERVAL=5
 
+# Set this to true if you have any additional producers to skip some validations
+#SE2MQTT_EXTERNAL_PRODUCTION=False
+
 # Set latitude of your location
 #SE2MQTT_LOCATION__LATITUDE=
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Configure the service using environment variables. The available options are lis
 - **SE2MQTT_INTERVAL**: The frequency (in seconds) of data retrieval requests. Default is every 5 seconds.
 - **SE2MQTT_LOGGING_LEVEL**: Adjust the verbosity of logs. Options include DEBUG, INFO, WARNING, ERROR, and CRITICAL.
 - **SE2MQTT_LOCATION\_\_LATITUDE** and **SE2MQTT_LOCATION\_\_LONGITUDE**: Specify your location to enable weather and forecast services. These settings are essential for accurate environmental data and PV production forecasts.
+- **SE2MQTT_EXTERNAL_PRODUCTION**: Set this to true if you have any additional producers to skip some validations. Default is false
 
 ### Basic Modbus configuration
 

--- a/solaredge2mqtt/core/settings/models.py
+++ b/solaredge2mqtt/core/settings/models.py
@@ -27,6 +27,8 @@ class ServiceSettings(BaseModel):
     interval: int = Field(5)
     logging_level: LoggingLevelEnum = LoggingLevelEnum.INFO
 
+    external_production: bool = False
+
     modbus: ModbusSettings
     mqtt: MQTTSettings
 

--- a/solaredge2mqtt/services/powerflow/__init__.py
+++ b/solaredge2mqtt/services/powerflow/__init__.py
@@ -93,7 +93,7 @@ class PowerflowService:
         else:
             powerflow = powerflows["leader"]
 
-        if not powerflow.is_valid:
+        if not powerflow.is_valid(self.settings.external_production):
             logger.info(powerflow)
             raise InvalidDataException("Invalid powerflow data")
 

--- a/solaredge2mqtt/services/powerflow/models.py
+++ b/solaredge2mqtt/services/powerflow/models.py
@@ -103,13 +103,13 @@ class Powerflow(Component):
             consumer=consumer,
         )
 
-    @property
-    def is_valid(self) -> bool:
+    def is_valid(self, external_production: bool) -> bool:
         valid = False
 
         if self.pv_production < 0:
             logger.warning("PV production is negative")
         elif (
+            not external_production and
             self.consumer.used_production + self.grid.delivery
             != self.inverter.production
         ):


### PR DESCRIPTION
Introduce the `SE2MQTT_EXTERNAL_PRODUCTION` environment variable to allow skipping certain validations in the `PowerflowService` and `Powerflow` model. Update validation logic to utilize this new setting.