### PR TITLE
Add retain flags to messages

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,9 @@
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "20"
 		},
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "17"
+		},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/hspaans/devcontainer-features/pyupgrade:2.0.0": {},
 		"ghcr.io/devcontainers-extra/features/pylint:2": {}
@@ -21,8 +24,7 @@
 				"ms-python.python",
 				"ms-python.vscode-pylance",
 				"ms-azuretools.vscode-containers",
-				"ms-azuretools.vscode-docker",
-				"ms-python.isort"
+				"ms-azuretools.vscode-docker"
 			],
 			"settings": {
 				"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -5,7 +5,7 @@
 #SE2MQTT_INTERVAL=5
 
 # Set this to true if you have any additional producers to skip some validations
-#SE2MQTT_EXTERNAL_PRODUCTION=False
+#SE2MQTT_POWERFLOW__EXTERNAL_PRODUCTION=False
 
 # Set latitude of your location
 #SE2MQTT_LOCATION__LATITUDE=

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -128,5 +128,15 @@ SE2MQTT_INFLUXDB__BUCKET=solaredgedev
 # Set caching directory for forecast service (default <USER_CACHE_DIR>/se2mqtt_forecast)
 #SE2MQTT_FORECAST_CACHINGDIR=~/.cache/se2mqtt_forecast
 
+# By default, all messages are not retained. However, you can configure the retain flag for each message type individually:
+#SE2MQTT_ENERGY__RETAIN=false
+#SE2MQTT_FORECAST__RETAIN=false
+#SE2MQTT_HOMEASSISTANT__RETAIN=false
+#SE2MQTT_MODBUS__RETAIN=false
+#SE2MQTT_MONITORING__RETAIN=false
+#SE2MQTT_POWERFLOW__RETAIN=false
+#SE2MQTT_WALLBOX__RETAIN=false
+#SE2MQTT_WEATHER__RETAIN=false
+
 # Set your timezone
 TZ=Europe/Berlin

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 #SE2MQTT_INTERVAL=5
 
 # Set this to true if you have any additional producers to skip some validations
-#SE2MQTT_EXTERNAL_PRODUCTION=False
+#SE2MQTT_POWERFLOW__EXTERNAL_PRODUCTION=False
 
 # Set latitude of your location
 #SE2MQTT_LOCATION__LATITUDE=

--- a/.env.example
+++ b/.env.example
@@ -128,5 +128,15 @@ SE2MQTT_INFLUXDB__BUCKET=solaredgedev
 # Set caching directory for forecast service (default <USER_CACHE_DIR>/se2mqtt_forecast)
 #SE2MQTT_FORECAST_CACHINGDIR=~/.cache/se2mqtt_forecast
 
+# By default, all messages are not retained. However, you can configure the retain flag for each message type individually:
+#SE2MQTT_ENERGY__RETAIN=false
+#SE2MQTT_FORECAST__RETAIN=false
+#SE2MQTT_HOMEASSISTANT__RETAIN=false
+#SE2MQTT_MODBUS__RETAIN=false
+#SE2MQTT_MONITORING__RETAIN=false
+#SE2MQTT_POWERFLOW__RETAIN=false
+#SE2MQTT_WALLBOX__RETAIN=false
+#SE2MQTT_WEATHER__RETAIN=false
+
 # Set your timezone
 TZ=Europe/Berlin

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,61 @@
+# Copilot Coding Agent Instructions for SolarEdge2MQTT
+
+## Project Overview
+- **Purpose:** Integrates SolarEdge inverters with MQTT for home automation, logging, and forecasting.
+- **Major Components:**
+  - `solaredge2mqtt/`: Core logic, service orchestration, and integrations.
+    - `core/`: Event bus, logging, settings, MQTT, InfluxDB, timer, etc.
+    - `services/`: Modular services (energy, forecast, homeassistant, modbus, monitoring, powerflow, wallbox, weather).
+    - `__main__.py`: Entrypoint for CLI/console mode.
+  - `examples/`: Example configs for Docker Compose, Grafana, etc.
+  - `Dockerfile`, `docker-compose.yml`: Containerization and orchestration.
+
+## Architecture & Data Flow
+- **Event-driven:** Uses an internal event bus for cross-component communication (see `core/events` and `core/timer/events`).
+- **Service boundaries:** Each service (e.g., Modbus, MQTT, Forecast) is isolated in its own module under `services/` and configured via Pydantic models.
+- **Data flow:**
+  - Data is collected from inverters (Modbus, Monitoring, Wallbox)
+  - Aggregated, logged to InfluxDB, and published to MQTT
+  - Forecasting uses historical and weather data
+
+## Developer Workflows
+- **Build:**
+  - Standard: `pip install .[dev,forecast]` or `pip install -e .[dev,forecast]` (for editable/development mode)
+  - For package builds: `pip install build && python -m build`
+  - Docker: `docker build -t solaredge2mqtt .`
+- **Run:**
+  - Console: `python -m solaredge2mqtt` or `solaredge2mqtt` (after install)
+  - Docker Compose: `docker compose up -d`
+- **Test:**
+  - (If tests exist) Use `pytest` or similar; test structure may be under `tests/` (not present in current tree)
+- **Configuration:**
+  - Environment variables (see `.env.example` in repo and README)
+  - Pydantic models in `core/settings/models.py` and per-service `settings.py`
+
+## Project-Specific Patterns & Conventions
+- **Settings:**
+  - Deeply nested, environment-variable-driven, using double underscores for nesting (e.g., `SE2MQTT_MODBUS__HOST`).
+  - Secrets can be injected via Docker secrets (`/run/secrets`).
+- **Events:**
+  - Event classes in `core/events` and `core/timer/events` are used for decoupled communication.
+- **Logging:**
+  - Centralized via `core/logging`.
+- **Forecasting:**
+  - Machine learning pipeline in `services/forecast/` uses InfluxDB and weather data.
+  - Caching and security for forecast pipeline handled in `services/forecast/settings.py`.
+- **Extensibility:**
+  - New services should be added under `services/` and registered in the main service logic.
+
+## Integration Points
+- **MQTT:** Publishes inverter and sensor data for home automation (see `core/mqtt/`).
+- **InfluxDB:** Logs raw and aggregated data (see `core/influxdb/`).
+- **Home Assistant:** Auto-discovery support (see `services/homeassistant/`).
+- **Weather/Forecast:** Integrates with OpenWeatherMap and uses local cache for ML models.
+
+## Examples
+- See `examples/docker-compose-full-stack.yaml` for a full-stack deployment.
+- See `README.md` for environment variable documentation and usage scenarios.
+
+---
+
+**If you are unsure about a workflow or integration, check the README and the relevant service's `settings.py` for configuration details.**

--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -42,7 +42,7 @@ jobs:
           - "3.12"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -108,7 +108,7 @@ jobs:
         arch: [amd64, arm64, arm/v7]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Setting global variables
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         id: var
         with:
           script: |
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Setting global variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: var
         with:
           script: |
@@ -42,15 +42,15 @@ jobs:
           - "3.12"
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache Python packages
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: |
             ~/.cache/pip
@@ -71,7 +71,7 @@ jobs:
         run: python -m build
 
       - name: Save python artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: python-artifacts-${{ matrix.python-version }}-${{ env.REF_NAME }}
           path: |
@@ -79,13 +79,13 @@ jobs:
 
       - name: Publish package to pypi
         if: ${{github.event_name == 'release' && matrix.python-version == '3.12'}}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           packages-dir: dist/
 
       - name: Publish assets to github
         if: ${{github.event_name == 'release' && matrix.python-version == '3.12'}}
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13
         with:
           repo_token: ${{ github.token }}
           file: dist/*
@@ -108,7 +108,7 @@ jobs:
         arch: [amd64, arm64, arm/v7]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
 
@@ -122,17 +122,17 @@ jobs:
         run: python generate_requirements.py
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Log in to the Docker github container registry
         if: ${{github.event_name == 'release' || (github.event_name == 'push' && contains(fromJSON(vars.PACKAGE_BRANCHES), github.ref_name))}}
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           registry: ${{ env.REGISTRY_GITHUB }}
           username: ${{ github.actor }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Log in to the Docker container registry
         if: ${{github.event_name == 'release'}}
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: |
             ${{ env.GHCR_IMAGE }}
@@ -166,7 +166,7 @@ jobs:
             type=raw,value=${{ env.REF_NAME }}-${{ env.ARCH_TAG }},enable=${{ github.event_name != 'release' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -191,24 +191,24 @@ jobs:
       packages: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Log in to the Docker github container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           registry: ${{ env.REGISTRY_GITHUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: |
             ${{ env.GHCR_IMAGE }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "git.alwaysSignOff": true,
     "python.analysis.typeCheckingMode": "off",
     "python.analysis.autoImportCompletions": true,
+    "python.terminal.useEnvFile": true,
     "sonarlint.connectedMode.project": {
         "connectionId": "deroetzi",
         "projectKey": "DerOetzi_solaredge2mqtt"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Configure the service using environment variables. The available options are lis
 - **SE2MQTT_INTERVAL**: The frequency (in seconds) of data retrieval requests. Default is every 5 seconds.
 - **SE2MQTT_LOGGING_LEVEL**: Adjust the verbosity of logs. Options include DEBUG, INFO, WARNING, ERROR, and CRITICAL.
 - **SE2MQTT_LOCATION\_\_LATITUDE** and **SE2MQTT_LOCATION\_\_LONGITUDE**: Specify your location to enable weather and forecast services. These settings are essential for accurate environmental data and PV production forecasts.
-- **SE2MQTT_EXTERNAL_PRODUCTION**: Set this to true if you have any additional producers to skip some validations. Default is false
+- **SE2MQTT_POWERFLOW__EXTERNAL_PRODUCTION**: Set this to true if you have any additional producers to skip some validations. Default is false
 
 ### Basic Modbus configuration
 
@@ -97,6 +97,20 @@ This setup allows for comprehensive multi-inverter support in systems with casca
 - **SE2MQTT_MQTT\_\_PORT**: The port your MQTT broker listens on. Default is 1883.
 - **SE2MQTT_MQTT\_\_USERNAME** and **SE2MQTT_MQTT\_\_PASSWORD**: Credentials for connecting to your MQTT broker. It's recommended to use secrets for the password if deploying with Docker.
 - **SE2MQTT_MQTT\_\_TOPIC_PREFIX**: The prefix used for MQTT topics. Defaults to 'solaredge'.
+### Retain Configuration
+
+By default, all messages are not retained. However, you can configure the retain flag for each message type individually:
+
+- **SE2MQTT_ENERGY__RETAIN**: Default is `false`.
+- **SE2MQTT_FORECAST__RETAIN**: Default is `false`.
+- **SE2MQTT_HOMEASSISTANT__RETAIN**: Default is `false`.
+- **SE2MQTT_MODBUS__RETAIN**: Default is `false`.
+- **SE2MQTT_MONITORING__RETAIN**: Default is `false`.
+- **SE2MQTT_POWERFLOW__RETAIN**: Default is `false`.
+- **SE2MQTT_WALLBOX__RETAIN**: Default is `false`.
+- **SE2MQTT_WEATHER__RETAIN**: Default is `false`.
+
+This configuration allows you to control whether specific MQTT messages should be retained by the broker.
 
 ### Monitoring
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dependencies = [
     "influxdb-client==1.49.0",
     "jsonref==1.1.0",
     "loguru==0.7.3",
-    "platformdirs==4.3.8",
+    "platformdirs==4.4.0",
     "pydantic==2.11.7",
     "pyjwt==2.10.1",
-    "pymodbus==3.10.0",
+    "pymodbus==3.11.1",
     "tzlocal==5.3.1",
 ]
 
@@ -46,12 +46,11 @@ solaredge2mqtt = "solaredge2mqtt.service:run"
 dev = [
     "setuptools-scm[toml]>=8",
     "ruff",
-    "isort",
     "tomli",
 ]
 forecast = [
     "numpy==2.2.5",
-    "pandas==2.3.1",
+    "pandas==2.3.2",
     "scikit-learn==1.7.1",
     "scipy==1.16.1"
 ]
@@ -81,9 +80,4 @@ unfixable = []
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
-skip-magic-trailing-comma = false
-
-[tool.isort]
-profile = "black"
-line_length = 88
-known_first_party = ["solaredge2mqtt"]
+skip-magic-trailing-comma = false 

--- a/solaredge2mqtt/core/models.py
+++ b/solaredge2mqtt/core/models.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 import jsonref
-from pydantic import BaseModel, model_serializer
+from pydantic import BaseModel, model_serializer, model_validator
 
 from solaredge2mqtt import __version__
 
@@ -89,6 +89,15 @@ class BaseField(EnumModel):
 
 
 class Solaredge2MQTTBaseModel(BaseModel):
+    timestamp: datetime | None = None
+
+    @model_validator(mode="before")
+    def _set_always(cls, data: dict[str, any]) -> dict[str, any]:
+        data = dict(data or {})
+        if "timestamp" not in data or data["timestamp"] is None:
+            data["timestamp"] = datetime.now(tz=timezone.utc)
+        return data
+
     def model_dump_influxdb(self, exclude: list[str] | None = None) -> dict[str, any]:
         return self._flatten_dict(self.model_dump(exclude=exclude, exclude_none=True))
 

--- a/solaredge2mqtt/core/models.py
+++ b/solaredge2mqtt/core/models.py
@@ -99,16 +99,29 @@ class Solaredge2MQTTBaseModel(BaseModel):
         return data
 
     def model_dump_influxdb(self, exclude: list[str] | None = None) -> dict[str, any]:
-        return self._flatten_dict(self.model_dump(exclude=exclude, exclude_none=True))
+        return self._flatten_dict(
+            self.model_dump(exclude=exclude, exclude_none=True),
+            ignore_keys={"timestamp"}
+        )
 
     def _flatten_dict(
-        self, d: MutableMapping, join_chr: str = "_", parent_key: str = ""
+        self,
+        d: MutableMapping,
+        ignore_keys: set[str] = set(),
+        join_chr: str = "_",
+        parent_key: str = "",
     ) -> MutableMapping:
         items = []
         for k, v in d.items():
+            if k in ignore_keys:
+                continue
             new_key = parent_key + join_chr + k if parent_key else k
             if isinstance(v, MutableMapping):
-                items.extend(self._flatten_dict(v, join_chr, new_key).items())
+                items.extend(
+                    self._flatten_dict(
+                        v, ignore_keys, join_chr, new_key
+                    ).items()
+                )
             else:
                 if isinstance(v, int):
                     v = float(v)

--- a/solaredge2mqtt/core/models.py
+++ b/solaredge2mqtt/core/models.py
@@ -99,9 +99,10 @@ class Solaredge2MQTTBaseModel(BaseModel):
         return data
 
     def model_dump_influxdb(self, exclude: list[str] | None = None) -> dict[str, any]:
+        ignore_keys = {"timestamp"}
         return self._flatten_dict(
             self.model_dump(exclude=exclude, exclude_none=True),
-            ignore_keys={"timestamp"}
+            ignore_keys=ignore_keys
         )
 
     def _flatten_dict(

--- a/solaredge2mqtt/core/mqtt/__init__.py
+++ b/solaredge2mqtt/core/mqtt/__init__.py
@@ -139,7 +139,7 @@ class MQTTClient(Client):
         self,
         topic: str,
         payload: str | int | float | BaseModel,
-        retain: bool = False,
+        retain: bool,
         qos: int = 1,
         topic_prefix: str | None = None,
         exclude_none: bool = False,

--- a/solaredge2mqtt/core/mqtt/events.py
+++ b/solaredge2mqtt/core/mqtt/events.py
@@ -11,7 +11,7 @@ class MQTTPublishEvent(BaseEvent):
         self,
         topic: str,
         payload: str | int | float | BaseModel,
-        retain: bool = False,
+        retain: bool,
         qos: int = 0,
         topic_prefix: str | None = None,
         exclude_none: bool = False,

--- a/solaredge2mqtt/core/settings/models.py
+++ b/solaredge2mqtt/core/settings/models.py
@@ -7,11 +7,12 @@ from solaredge2mqtt.core.influxdb.settings import InfluxDBSettings
 from solaredge2mqtt.core.logging import logger
 from solaredge2mqtt.core.logging.models import LoggingLevelEnum
 from solaredge2mqtt.core.mqtt.settings import MQTTSettings
-from solaredge2mqtt.services.energy.settings import PriceSettings
+from solaredge2mqtt.services.energy.settings import EnergySettings, PriceSettings
 from solaredge2mqtt.services.forecast.settings import ForecastSettings
 from solaredge2mqtt.services.homeassistant.settings import HomeAssistantSettings
 from solaredge2mqtt.services.modbus.settings import ModbusSettings
 from solaredge2mqtt.services.monitoring.settings import MonitoringSettings
+from solaredge2mqtt.services.powerflow.settings import PowerflowSettings
 from solaredge2mqtt.services.wallbox.settings import WallboxSettings
 from solaredge2mqtt.services.weather.settings import WeatherSettings
 
@@ -27,10 +28,11 @@ class ServiceSettings(BaseModel):
     interval: int = Field(5)
     logging_level: LoggingLevelEnum = LoggingLevelEnum.INFO
 
-    external_production: bool = False
-
     modbus: ModbusSettings
     mqtt: MQTTSettings
+
+    powerflow: PowerflowSettings = PowerflowSettings()
+    energy: EnergySettings = EnergySettings()
 
     location: LocationSettings | None = None
     prices: PriceSettings = PriceSettings()

--- a/solaredge2mqtt/service.py
+++ b/solaredge2mqtt/service.py
@@ -73,7 +73,7 @@ class Service:
         )
 
         self.energy: EnergyService | None = (
-            EnergyService(self.event_bus, self.influxdb)
+            EnergyService(self.settings.energy, self.event_bus, self.influxdb)
             if self.settings.is_influxdb_configured
             else None
         )

--- a/solaredge2mqtt/service.py
+++ b/solaredge2mqtt/service.py
@@ -5,7 +5,7 @@
     The module also includes a run function to initialize and start the service.
 """
 
-import asyncio as aio
+import asyncio
 import platform
 import signal
 from time import time
@@ -38,14 +38,13 @@ LOCAL_TZ = get_localzone_name()
 def run():
     try:
         service = Service()
-        loop = aio.get_event_loop()
+        loop = asyncio.get_event_loop()
         loop.add_signal_handler(signal.SIGINT, service.cancel)
         loop.add_signal_handler(signal.SIGTERM, service.cancel)
         loop.run_until_complete(service.main_loop())
-        loop.run_until_complete(service.close())
     except ConfigurationException:
         logger.error("Configuration error")
-    except aio.exceptions.CancelledError:
+    except asyncio.CancelledError:
         logger.debug("Service cancelled")
     finally:
         loop.close()
@@ -62,8 +61,8 @@ class Service:
 
         self.mqtt: MQTTClient | None = None
 
-        self.cancel_request = aio.Event()
-        self.loops: set[aio.Task] = set()
+        self.cancel_request = asyncio.Event()
+        self.loops: set[asyncio.Task] = set()
 
         self.influxdb: InfluxDBAsync | None = (
             InfluxDBAsync(self.settings.influxdb,
@@ -117,9 +116,11 @@ class Service:
 
     def cancel(self):
         logger.info("Stopping SolarEdge2MQTT service...")
+
         self.cancel_request.set()
-        for tasks in aio.all_tasks():
-            tasks.cancel()
+
+        for task in list(self.loops):
+            task.cancel()
 
     async def main_loop(self):
         logger.info("Starting SolarEdge2MQTT service...")
@@ -149,16 +150,19 @@ class Service:
                     self._start_mqtt_listener()
                     self.schedule_loop(1, self.timer.loop)
 
-                    await aio.gather(*self.loops)
+                    await asyncio.gather(*self.loops)
             except MqttError:
                 logger.error("MQTT error, reconnecting in 5 seconds...")
-            except aio.exceptions.CancelledError:
+            except asyncio.CancelledError:
                 logger.debug("Loops cancelled")
+                raise
             finally:
                 await self.finalize()
 
-            if not self.cancel_request.is_set():
-                await aio.sleep(5)
+            if self.cancel_request.is_set():
+                break
+
+            await asyncio.sleep(5)
 
     async def finalize(self):
         try:
@@ -166,17 +170,16 @@ class Service:
         except MqttError:
             pass
 
-        self.event_bus.cancel_tasks()
+        await self.event_bus.cancel_tasks()
 
-        for task in self.loops:
-            task.cancel()
+        await self.close()
 
     def _start_mqtt_listener(self):
-        task = aio.create_task(self.mqtt.listen())
+        task = asyncio.create_task(self.mqtt.listen())
         self.loops.add(task)
         task.add_done_callback(self.loops.remove)
 
-        task = aio.create_task(self.mqtt.process_queue())
+        task = asyncio.create_task(self.mqtt.process_queue())
         self.loops.add(task)
         task.add_done_callback(self.loops.remove)
 
@@ -187,7 +190,7 @@ class Service:
         delay_start: int = 0,
         args: list[any] = None,
     ):
-        loop = aio.create_task(
+        loop = asyncio.create_task(
             self.run_loop(interval_in_seconds, handles, delay_start, args)
         )
         self.loops.add(loop)
@@ -203,7 +206,7 @@ class Service:
         if not isinstance(handles, list):
             handles = [handles]
 
-        await aio.sleep(delay_start)
+        await asyncio.sleep(delay_start)
 
         while not self.cancel_request.is_set():
             execution_time = 0
@@ -213,16 +216,27 @@ class Service:
             execution_time = time() - start_time
 
             if execution_time < interval_in_seconds:
-                await aio.sleep(interval_in_seconds - execution_time)
+                await asyncio.sleep(interval_in_seconds - execution_time)
             else:
-                await aio.sleep(interval_in_seconds)
+                await asyncio.sleep(interval_in_seconds)
 
     async def close(self):
-        if self.influxdb:
-            await self.influxdb.close()
-        if self.powerflow:
-            await self.powerflow.close()
-        if self.monitoring:
-            await self.monitoring.close()
-        if self.weather:
-            await self.weather.close()
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *[
+                        service.close()
+                        for service in [
+                            self.influxdb,
+                            self.powerflow,
+                            self.monitoring,
+                            self.weather,
+                        ]
+                        if service
+                    ]
+                ),
+                timeout=5
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timeout while closing tasks, proceeding with shutdown.")

--- a/solaredge2mqtt/services/energy/__init__.py
+++ b/solaredge2mqtt/services/energy/__init__.py
@@ -12,15 +12,18 @@ from solaredge2mqtt.services.energy.models import (
     HistoricPeriod,
     HistoricQuery,
 )
+from solaredge2mqtt.services.energy.settings import EnergySettings
 
 
 class EnergyService:
     def __init__(
         self,
+        settings: EnergySettings,
         event_bus: EventBus,
         influxdb: InfluxDBAsync,
     ):
         self.influxdb = influxdb
+        self.settings = settings
 
         self.event_bus = event_bus
         self._subscribe_events()
@@ -52,4 +55,10 @@ class EnergyService:
                 )
 
                 await self.event_bus.emit(EnergyReadEvent(energy))
-                await self.event_bus.emit(MQTTPublishEvent(energy.mqtt_topic(), energy))
+                await self.event_bus.emit(
+                    MQTTPublishEvent(
+                        energy.mqtt_topic(),
+                        energy,
+                        self.settings.energy.retain,
+                    )
+                )

--- a/solaredge2mqtt/services/energy/__init__.py
+++ b/solaredge2mqtt/services/energy/__init__.py
@@ -59,6 +59,6 @@ class EnergyService:
                     MQTTPublishEvent(
                         energy.mqtt_topic(),
                         energy,
-                        self.settings.energy.retain,
+                        self.settings.retain,
                     )
                 )

--- a/solaredge2mqtt/services/energy/settings.py
+++ b/solaredge2mqtt/services/energy/settings.py
@@ -25,3 +25,7 @@ class PriceSettings(BaseModel):
     @property
     def price_out(self) -> float:
         return self.delivery or 0.0
+
+
+class EnergySettings(BaseModel):
+    retain: bool = Field(False)

--- a/solaredge2mqtt/services/forecast/service.py
+++ b/solaredge2mqtt/services/forecast/service.py
@@ -214,7 +214,13 @@ class ForecastService:
                                 energy_period=energy_hours)
             logger.debug(forecast)
 
-            await self.event_bus.emit(MQTTPublishEvent(forecast.mqtt_topic(), forecast))
+            await self.event_bus.emit(
+                MQTTPublishEvent(
+                    forecast.mqtt_topic(),
+                    forecast,
+                    self.settings.retain,
+                )
+            )
             await self.event_bus.emit(ForecastEvent(forecast))
 
 

--- a/solaredge2mqtt/services/forecast/settings.py
+++ b/solaredge2mqtt/services/forecast/settings.py
@@ -10,6 +10,7 @@ class ForecastSettings(BaseModel):
     cachingdir: DirectoryPath | None = Field(
         default=str(Path(platformdirs.user_cache_dir("se2mqtt_forecast")))
     )
+    retain: bool = Field(False)
 
     @property
     def is_configured(self) -> bool:
@@ -23,12 +24,12 @@ class ForecastSettings(BaseModel):
     def ensure_secure_cache(cls, v: str | None, values: dict) -> str | None:
         if not values.get("enable", False) or v is None:
             return None
- 
+
         path = Path(v).resolve()
-        
+
         path.mkdir(parents=True, exist_ok=True, mode=0o700)
 
         if path.stat().st_mode & 0o077:
             raise ValueError(f"Insecure cache directory permissions: {path}")
-        
+
         return str(path)

--- a/solaredge2mqtt/services/homeassistant/__init__.py
+++ b/solaredge2mqtt/services/homeassistant/__init__.py
@@ -182,6 +182,7 @@ class HomeAssistantDiscovery:
                 MQTTPublishEvent(
                     topic=topic,
                     payload=entity,
+                    retain=self.settings.homeassistant.retain,
                     topic_prefix=self.settings.homeassistant.topic_prefix,
                     exclude_none=True,
                 )
@@ -198,6 +199,7 @@ class HomeAssistantDiscovery:
                         MQTTPublishEvent(
                             topic=topic,
                             payload=entity,
+                            retain=self.settings.homeassistant.retain,
                             topic_prefix=self.settings.homeassistant.topic_prefix,
                             exclude_none=True,
                         )

--- a/solaredge2mqtt/services/homeassistant/settings.py
+++ b/solaredge2mqtt/services/homeassistant/settings.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 class HomeAssistantSettings(BaseModel):
     enable: bool = Field(False)
     topic_prefix: str = Field("homeassistant")
+    retain: bool = Field(False)
 
     @property
     def is_configured(self) -> bool:

--- a/solaredge2mqtt/services/modbus/settings.py
+++ b/solaredge2mqtt/services/modbus/settings.py
@@ -59,6 +59,8 @@ class ModbusSettings(ModbusUnitSettings):
 
     follower: list[ModbusUnitSettings] = Field(default_factory=list)
 
+    retain: bool = Field(False)
+
     @model_validator(mode='before')
     @classmethod
     def fill_defaults(cls, values: dict) -> dict:

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -286,5 +286,9 @@ class MonitoringSite(HTTPClientAsync):
         )
 
         await self.event_bus.emit(
-            MQTTPublishEvent("monitoring/pv_energy_today", energy_total)
+            MQTTPublishEvent(
+                "monitoring/pv_energy_today",
+                energy_total,
+                self.settings.retain,
+            )
         )

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -275,6 +275,7 @@ class MonitoringSite(HTTPClientAsync):
                 MQTTPublishEvent(
                     f"monitoring/module/{module.info.serialnumber}",
                     module,
+                    self.settings.retain
                 )
             )
 

--- a/solaredge2mqtt/services/monitoring/settings.py
+++ b/solaredge2mqtt/services/monitoring/settings.py
@@ -5,6 +5,7 @@ class MonitoringSettings(BaseModel):
     site_id: str = Field(None)
     username: str = Field(None)
     password: SecretStr = Field(None)
+    retain: bool = Field(False)
 
     @property
     def is_configured(self) -> bool:

--- a/solaredge2mqtt/services/powerflow/__init__.py
+++ b/solaredge2mqtt/services/powerflow/__init__.py
@@ -93,7 +93,7 @@ class PowerflowService:
         else:
             powerflow = powerflows["leader"]
 
-        if not powerflow.is_valid(self.settings.external_production):
+        if not powerflow.is_valid(self.settings.powerflow.external_production):
             logger.info(powerflow)
             raise InvalidDataException("Invalid powerflow data")
 
@@ -125,34 +125,43 @@ class PowerflowService:
     async def publish_modbus(self, units):
         for key, unit in units.items():
             await self.event_bus.emit(
-                MQTTPublishEvent(unit.inverter.mqtt_topic(
-                    self.settings.modbus.has_followers), unit.inverter)
+                MQTTPublishEvent(
+                    unit.inverter.mqtt_topic(
+                        self.settings.modbus.has_followers),
+                    unit.inverter,
+                    retain=self.settings.modbus.retain)
             )
 
             for key, component in {**unit.meters, **unit.batteries}.items():
                 await self.event_bus.emit(
                     MQTTPublishEvent(
                         f"{component.mqtt_topic(self.settings.modbus.has_followers)}/{key.lower()}",
-                        component,
+                        component, retain=self.settings.modbus.retain
                     )
                 )
 
     async def publish_wallbox(self, wallbox_data):
         if wallbox_data is not None:
             await self.event_bus.emit(
-                MQTTPublishEvent(wallbox_data.mqtt_topic(), wallbox_data)
+                MQTTPublishEvent(
+                    wallbox_data.mqtt_topic(),
+                    wallbox_data,
+                    retain=self.settings.wallbox.retain
+                )
             )
 
     async def publish_powerflow(self, powerflows: dict[str, Powerflow]) -> None:
         if self.settings.modbus.has_followers:
             for pf in powerflows.values():
                 await self.event_bus.emit(
-                    MQTTPublishEvent(pf.mqtt_topic(), pf)
+                    MQTTPublishEvent(pf.mqtt_topic(), pf,
+                                     self.settings.powerflow.retain)
                 )
         else:
             powerflow = powerflows["leader"]
             await self.event_bus.emit(
-                MQTTPublishEvent(powerflow.mqtt_topic(), powerflow)
+                MQTTPublishEvent(powerflow.mqtt_topic(), powerflow,
+                                 self.settings.powerflow.retain)
             )
 
         await self.event_bus.emit(PowerflowGeneratedEvent(powerflows))

--- a/solaredge2mqtt/services/powerflow/__init__.py
+++ b/solaredge2mqtt/services/powerflow/__init__.py
@@ -129,14 +129,15 @@ class PowerflowService:
                     unit.inverter.mqtt_topic(
                         self.settings.modbus.has_followers),
                     unit.inverter,
-                    retain=self.settings.modbus.retain)
+                    self.settings.modbus.retain)
             )
 
             for key, component in {**unit.meters, **unit.batteries}.items():
                 await self.event_bus.emit(
                     MQTTPublishEvent(
                         f"{component.mqtt_topic(self.settings.modbus.has_followers)}/{key.lower()}",
-                        component, retain=self.settings.modbus.retain
+                        component,
+                        self.settings.modbus.retain
                     )
                 )
 
@@ -146,7 +147,7 @@ class PowerflowService:
                 MQTTPublishEvent(
                     wallbox_data.mqtt_topic(),
                     wallbox_data,
-                    retain=self.settings.wallbox.retain
+                    self.settings.wallbox.retain
                 )
             )
 
@@ -154,14 +155,20 @@ class PowerflowService:
         if self.settings.modbus.has_followers:
             for pf in powerflows.values():
                 await self.event_bus.emit(
-                    MQTTPublishEvent(pf.mqtt_topic(), pf,
-                                     self.settings.powerflow.retain)
+                    MQTTPublishEvent(
+                        pf.mqtt_topic(),
+                        pf,
+                        self.settings.powerflow.retain
+                    )
                 )
         else:
             powerflow = powerflows["leader"]
             await self.event_bus.emit(
-                MQTTPublishEvent(powerflow.mqtt_topic(), powerflow,
-                                 self.settings.powerflow.retain)
+                MQTTPublishEvent(
+                    powerflow.mqtt_topic(),
+                    powerflow,
+                    self.settings.powerflow.retain
+                )
             )
 
         await self.event_bus.emit(PowerflowGeneratedEvent(powerflows))

--- a/solaredge2mqtt/services/powerflow/settings.py
+++ b/solaredge2mqtt/services/powerflow/settings.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PowerflowSettings(BaseModel):
+    external_production: bool = Field(False)
+    retain: bool = Field(False)

--- a/solaredge2mqtt/services/wallbox/settings.py
+++ b/solaredge2mqtt/services/wallbox/settings.py
@@ -5,6 +5,7 @@ class WallboxSettings(BaseModel):
     host: str = Field(None)
     password: SecretStr = Field(None)
     serial: str = Field(None)
+    retain: bool = Field(False)
 
     @property
     def is_configured(self) -> bool:

--- a/solaredge2mqtt/services/weather/__init__.py
+++ b/solaredge2mqtt/services/weather/__init__.py
@@ -37,7 +37,13 @@ class WeatherClient(HTTPClientAsync):
     async def loop(self, _):
         weather = await self.get_weather()
         await self.event_bus.emit(WeatherUpdateEvent(weather))
-        await self.event_bus.emit(MQTTPublishEvent("weather/current", weather.current))
+        await self.event_bus.emit(
+            MQTTPublishEvent(
+                "weather/current",
+                weather.current,
+                self.settings.retain,
+            )
+        )
 
     async def get_weather(self) -> OpenWeatherMapOneCall:
         try:

--- a/solaredge2mqtt/services/weather/settings.py
+++ b/solaredge2mqtt/services/weather/settings.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, SecretStr
 class WeatherSettings(BaseModel):
     api_key: SecretStr | None = Field(None)
     language: str = Field("en")
+    retain: bool = Field(False)
 
     @property
     def is_configured(self) -> bool:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,3 @@
 sonar.exclusions=**/solaredge2mqtt/_version.py,**/versioneer.py
+sonar.projectKey=solaredge2mqtt
+sonar.python.version=3.11,3.12


### PR DESCRIPTION
This pull request introduces several improvements and configuration options to the SolarEdge2MQTT project, focusing on enhanced MQTT message control, improved developer documentation, dependency updates, and better modularity for service settings. The most significant change is the addition of per-service MQTT retain flag configuration, allowing users to control message retention for different service types. The pull request also adds a comprehensive Copilot agent instruction file, updates dependencies, and refines service initialization and settings.

### MQTT Retain Flag Configuration

* Added per-service MQTT retain flags (`retain`) to settings for Energy, Forecast, Home Assistant, Modbus, Monitoring, Powerflow, Wallbox, and Weather services, allowing users to control whether messages are retained by the broker. This includes updates to settings models, service logic, environment variable documentation, and example files. [[1]](diffhunk://#diff-bed67a8461c8c885b5b67387212eb79e0ae4e701cf04989a90ea25a76753b7b1R131-R140) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR131-R140) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R100-R113) [[4]](diffhunk://#diff-f69715ad66834811b68a4fa43efe570dc2b1a94970c7c769399bc50756333a18L55-R64) [[5]](diffhunk://#diff-415aab5d3e6b7d747f44d0efa08872665a89b7e02541ed5586b1b308656781b0R28-R31) [[6]](diffhunk://#diff-0556053a78f30bcc914bd45cf498cc40f0696d5898238eaf5486918b2e853f5bL217-R223) [[7]](diffhunk://#diff-3f887d4b8c46fa6217fed5cecbadd02eb99650171bf98f1a0aa2ddc964548379R13) [[8]](diffhunk://#diff-5a5b67303d7ecda39ef0e1efe31e89573493928923b22811a607062d23f7d4b2R185) [[9]](diffhunk://#diff-5a5b67303d7ecda39ef0e1efe31e89573493928923b22811a607062d23f7d4b2R202) [[10]](diffhunk://#diff-28cbc71acdb3ba8263d6da71ff26e3064468595694836f2f20e43d6c77eb6efeR7) [[11]](diffhunk://#diff-0da9e89b83d51fbbe0e54ba600378dbfd6b9c90b7e61a64df4761aed5e885c6fR62-R63)
* Changed MQTT publish logic to require explicit `retain` argument, removing the default value to ensure retain configuration is always specified. [[1]](diffhunk://#diff-fe719d1253e43574f2b40f91cddf7e669b9c811a2226525f003196f2acb22139L142-R142) [[2]](diffhunk://#diff-6dbcd1ca1e409c80f6a10c4f10458206d99022c5bb315bb76b9af7de72e6112aL14-R14)

### Documentation and Developer Experience

* Added a detailed Copilot agent instruction file (`.github/copilot-instructions.md`) describing project architecture, workflows, conventions, and integration points for easier onboarding and agent use.
* Updated `README.md` to document new retain configuration options and clarify existing settings (notably, moved `EXTERNAL_PRODUCTION` under `POWERFLOW`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R100-R113)

### Dependency and Tooling Updates

* Updated dependencies in `pyproject.toml`: `platformdirs` to 4.4.0, `pymodbus` to 3.11.1, and `pandas` to 2.3.2; removed `isort` from dev dependencies and config. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L29-R32) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L49-R53) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L85-L89)
* Updated GitHub Actions workflow to use newer `actions/checkout@v5`. [[1]](diffhunk://#diff-90d995347e0c0c89eb0958ded5f08313a79dc5fa09c2fa01044ee83dcfdec38eL45-R45) [[2]](diffhunk://#diff-90d995347e0c0c89eb0958ded5f08313a79dc5fa09c2fa01044ee83dcfdec38eL111-R111)
* Added Java 17 feature to `.devcontainer/devcontainer.json` for improved development environment support.

### Service Initialization and Settings Refactor

* Refactored service initialization to pass settings objects (e.g., `EnergySettings`, `PowerflowSettings`) directly to service constructors, improving modularity and configuration consistency. [[1]](diffhunk://#diff-171b74129fc83ea19ad105f00c2bcf6ca2e34f382af8099290fd93d92d9842c3L10-R15) [[2]](diffhunk://#diff-171b74129fc83ea19ad105f00c2bcf6ca2e34f382af8099290fd93d92d9842c3L30-R36) [[3]](diffhunk://#diff-401aadfe7e032c946fba569e42060283b4e4c290eab5467e6ce673ddd02a8f0fL76-R76) [[4]](diffhunk://#diff-f69715ad66834811b68a4fa43efe570dc2b1a94970c7c769399bc50756333a18R15-R26)

### Miscellaneous Improvements

* Added automatic UTC timestamp assignment to all models inheriting from `Solaredge2MQTTBaseModel` for consistent time tracking. [[1]](diffhunk://#diff-1d9cc5f3881ded6486a153945d876b94fe9ecd41c221dab190e787d9b7c718daL4-R8) [[2]](diffhunk://#diff-1d9cc5f3881ded6486a153945d876b94fe9ecd41c221dab190e787d9b7c718daR92-R100)
* Minor improvements to VSCode and devcontainer settings for better Python environment handling. [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R19) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L24-R27)