### PR TITLE
Fix MQTT reconnection when broker restarts

### DIFF
--- a/solaredge2mqtt/core/events/__init__.py
+++ b/solaredge2mqtt/core/events/__init__.py
@@ -101,9 +101,14 @@ class EventBus:
             return
         exc = task.exception()
         if exc is not None and isinstance(exc, MqttError):
-            # Store critical error to be raised on next emit
-            self._critical_error = exc
-
+            # Store critical error to be raised on next emit, but log if one is already set
+            if self._critical_error is None:
+                self._critical_error = exc
+            else:
+                logger.warning(
+                    "Additional critical error occurred before previous was handled: {exc}",
+                    exc=repr(exc)
+                )
     async def cancel_tasks(self) -> None:
         tasks = list(self._tasks)
         for t in tasks:


### PR DESCRIPTION
I found over the past few months during stable operation that solaredge2mqtt would lose contact with my MQTT broker and never reconnect. I didn’t think much of it, but today I went to reproduce the issue and found it reliably happens every time I restart my broker. 

Rather than restart se2mqtt it’d be nice if the reconnect logic actually worked :)

Hope this change is suitable. It’s not easy to bubble up an exception from a task like this but it works.