### PR TITLE
Bump influxdb-client to 1.50.0 and update forecast dependencies for n…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "aiomqtt==2.5.0",
     "astral==3.2",
     "ephem==4.2",
-    "influxdb-client==1.49.0",
+    "influxdb-client==1.50.0",
     "jsonref==1.1.0",
     "loguru==0.7.3",
     "platformdirs==4.5.1",
@@ -54,10 +54,10 @@ dev = [
     "pytest-cov==7.0.0",
 ]
 forecast = [
-    "numpy==2.4.0",
-    "pandas==2.3.3",
+    "numpy==2.4.1",
+    "pandas==3.0.0",
     "scikit-learn==1.8.0",
-    "scipy==1.16.3"
+    "scipy==1.17.0"
 ]
 
 [build-system]


### PR DESCRIPTION
This pull request updates several dependencies in the `pyproject.toml` file to keep the project up to date with the latest stable versions. The updates affect both the main and forecast-related dependencies.

Dependency updates:

* Upgraded `influxdb-client` from version 1.49.0 to 1.50.0 in the main dependencies.
* Updated forecast dependencies: `numpy` from 2.4.0 to 2.4.1, `pandas` from 2.3.3 to 3.0.0, and `scipy` from 1.16.3 to 1.17.0