### PR TITLE
Update Python dependencies 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,6 @@
 				"mhutchie.git-graph"
 			],
 			"settings": {
-				"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
 				"python.terminal.activateEnvironment": true,
 				"editor.codeActionsOnSave": {
 					"source.fixAll.ruff": "explicit",

--- a/.devcontainer/worktree/devcontainer.json
+++ b/.devcontainer/worktree/devcontainer.json
@@ -34,7 +34,6 @@
 				"mhutchie.git-graph"
 			],
 			"settings": {
-				"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
 				"python.terminal.activateEnvironment": true,
 				"editor.codeActionsOnSave": {
 					"source.fixAll.ruff": "explicit",

--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -46,7 +46,6 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -46,6 +46,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,7 @@ skip-magic-trailing-comma = false
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-python_files = ["test_*.py"]
-python_functions = ["test_*"]
 addopts = "-v --tb=short"
-filterwarnings = [
-    "ignore::DeprecationWarning",
-]
 
 [tool.coverage.run]
 source = ["solaredge2mqtt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,14 @@ dependencies = [
     "aiohttp==3.13.3",
     "aiomqtt==2.5.0",
     "astral==3.2",
-    "ephem==4.2",
+    "ephem==4.2.1",
     "influxdb-client==1.50.0",
     "jsonref==1.1.0",
     "loguru==0.7.3",
-    "platformdirs==4.5.1",
+    "platformdirs==4.9.2",
     "pydantic==2.12.5",
     "pyjwt==2.11.0",
-    "pymodbus==3.11.4",
+    "pymodbus==3.12.1",
     "pyyaml==6.0.3",
     "tzlocal==5.3.1",
 ]
@@ -56,9 +56,9 @@ dev = [
 ]
 forecast = [
     "numpy==2.4.2",
-    "pandas==3.0.0",
+    "pandas==3.0.1",
     "scikit-learn==1.8.0",
-    "scipy==1.17.0"
+    "scipy==1.17.1"
 ]
 
 [build-system]


### PR DESCRIPTION
This pull request primarily updates several Python dependencies to newer versions and removes a deprecated Python interpreter setting from devcontainer configuration files. These changes help keep the development environment up to date and compatible with the latest library releases.

Dependency updates:

* Upgraded core dependencies in `pyproject.toml`, including `ephem` (4.2 → 4.2.1), `platformdirs` (4.5.1 → 4.9.2), and `pymodbus` (3.11.4 → 3.12.1), to incorporate bug fixes and improvements.
* Updated development dependencies: `pandas` (3.0.0 → 3.0.1) and `scipy` (1.17.0 → 1.17.1) for the `forecast` group.

Devcontainer configuration cleanup:

* Removed the deprecated `python.defaultInterpreterPath` setting from both `.devcontainer/devcontainer.json` and `.devcontainer/worktree/devcontainer.json` to rely on environment activation and avoid potential configuration conflicts. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L32) [[2]](diffhunk://#diff-ec0b49f827089d86d06912291eede915838e5d5d78f9e6bf554acc2231926a08L37)…evcontainer settings