### PR TITLE
feat: mqtt over tls

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ mqtt:
   username: mqtt_user              # MQTT username
   password: !secret mqtt_password  # Use !secret to reference secrets.yml
   topic_prefix: solaredge          # MQTT topic prefix
+  use_tls: false                   # Enable TLS encryption (default: false)
+  ca_certs: /path/to/ca.pem        # Path to CA certificate bundle
+  tls_verify: true                 # Verify TLS certificates (default: true)
 ```
 
 **Note**: Store your password securely in `secrets.yml`:

--- a/solaredge2mqtt/config/configuration.yml.example
+++ b/solaredge2mqtt/config/configuration.yml.example
@@ -54,6 +54,9 @@ mqtt:
   password: !secret mqtt_password  # Reference to secrets.yml
   topic_prefix: solaredge       # Prefix for MQTT topics
   retain: false                 # Retain MQTT messages
+# use_tls: false                # MQTT over TLS
+# ca_certs: path_to_CA          # Path to trusted CA boundle - usefull for self sign certificates
+# tls_verify: true              # Verify mqtt certificate. If set to false ignore certificate expiration, CN missmatch, etc.
 
 # Powerflow configuration
 powerflow:

--- a/solaredge2mqtt/core/mqtt/__init__.py
+++ b/solaredge2mqtt/core/mqtt/__init__.py
@@ -1,7 +1,8 @@
 import json
 from asyncio import Queue, QueueFull
+import ssl
 
-from aiomqtt import Client, Message, Will
+from aiomqtt import Client, Message, Will, TLSParameters
 from pydantic import BaseModel, ValidationError
 
 from solaredge2mqtt.core.events import EventBus
@@ -22,6 +23,11 @@ class MQTTClient(Client):
         self.port = settings.port
 
         self.topic_prefix = settings.topic_prefix
+        tls_params = TLSParameters(
+            # Self-signed cert or CA PEM
+            ca_certs=settings.ca_certs if settings.ca_certs else None,
+            cert_reqs=ssl.CERT_REQUIRED if settings.tls_verify == True else ssl.CERT_NONE,
+        ) if settings.use_tls else None
 
         logger.info(
             "Using MQTT broker: {broker}:{port}",
@@ -44,6 +50,7 @@ class MQTTClient(Client):
             self.broker,
             self.port,
             will=will,
+            tls_params=tls_params,
             **settings.kargs,
         )
 

--- a/solaredge2mqtt/core/mqtt/settings.py
+++ b/solaredge2mqtt/core/mqtt/settings.py
@@ -8,6 +8,9 @@ class MQTTSettings(BaseModel):
     username: str | None = Field(None)
     password: SecretStr | None = Field(None)
     topic_prefix: str = Field("solaredge")
+    use_tls: bool = Field(False)
+    ca_certs: str | None = Field(None)
+    tls_verify: bool | None = Field(True)
 
     @property
     def kargs(self) -> dict[str, str]:


### PR DESCRIPTION
Add functionality to use MQTT over TLS.

1. Add three additional MQTT settings:

- use_tls (default false) - indicates whether to use MQTT over TLS
- ca_certs - the path to CA bundle
- tls_verify (default true) - whether to verify server certificate

2. Based on those settings MQTTClient connection is made