### PR TITLE
Event bus

### DIFF
--- a/.devcontainer/worktree/devcontainer-lock.json
+++ b/.devcontainer/worktree/devcontainer-lock.json
@@ -1,0 +1,34 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/pylint:2": {
+      "version": "2.0.18",
+      "resolved": "ghcr.io/devcontainers-extra/features/pylint@sha256:c5aa6c40c6f98d86b8faa06900755243d31fb5bb173fd24ba2b07c2139b361c4",
+      "integrity": "sha256:c5aa6c40c6f98d86b8faa06900755243d31fb5bb173fd24ba2b07c2139b361c4"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/java@sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a",
+      "integrity": "sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
+    "ghcr.io/hspaans/devcontainer-features/pyupgrade:2.0.0": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/hspaans/devcontainer-features/pyupgrade@sha256:326fed1dbe3253369321f5ca27e300171870ed357b90ec6144156042446acac6",
+      "integrity": "sha256:326fed1dbe3253369321f5ca27e300171870ed357b90ec6144156042446acac6"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "fix-pr-sonarqube-actions",
+  "name": "solaredge2mqtt",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "solaredge2mqtt",
       "devDependencies": {
         "pyright": "1.1.410"
       }

--- a/solaredge2mqtt/core/events/__init__.py
+++ b/solaredge2mqtt/core/events/__init__.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Awaitable, Protocol, overload
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    ClassVar,
+    Protocol,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from aiomqtt import MqttError
 
@@ -9,113 +18,168 @@ from solaredge2mqtt.core.events.events import BaseEvent, TEvent, TEventContra
 from solaredge2mqtt.core.exceptions import InvalidDataException
 from solaredge2mqtt.core.logging import logger
 
+_EVENT_SUBSCRIPTIONS_ATTR = "_event_subscriptions"
+
 
 class Listener(Protocol[TEventContra]):
-    def __call__(self, event: TEventContra) -> Awaitable[None]: ...  # pragma: no cover
+    def __call__(
+        self, event: TEventContra
+    ) -> Awaitable[None]: ...  # pragma: no cover
 
 
 AnyListener = Listener[Any]
+TInstance = TypeVar("TInstance")
+ListenerMethod = Callable[[TInstance, TEvent], Awaitable[None]]
+ListenerDecorator = Callable[[
+    ListenerMethod[TInstance, TEvent]], ListenerMethod[TInstance, TEvent]]
 
 
 class EventBus:
-    def __init__(self) -> None:
-        self._listeners: dict[str, list[AnyListener]] = {}
-        self._subscribed_events: dict[str, type[BaseEvent]] = {}
-        self._tasks: set[asyncio.Task] = set()
-        self._critical_error: BaseException | None = None
+    _listeners: ClassVar[dict[str, list[Listener[Any]]]] = {}
+    _subscribed_events: ClassVar[dict[str, type[BaseEvent]]] = {}
+    _tasks: ClassVar[set[asyncio.Task]] = set()
+    _critical_error: ClassVar[BaseException | None] = None
 
     @overload
+    @classmethod
     def subscribe(
-        self, event: list[type[TEvent]], listener: Listener[TEvent]
+        cls,
+        event: type[TEvent] | list[type[TEvent]],
+        listener: Listener[TEvent],
     ) -> None: ...  # pragma: no cover
 
     @overload
+    @classmethod
     def subscribe(
-        self, event: type[TEvent], listener: Listener[TEvent]
-    ) -> None: ...  # pragma: no cover
+        cls,
+        event: type[TEvent] | list[type[TEvent]],
+    ) -> ListenerDecorator[TInstance, TEvent]: ...  # pragma: no cover
 
+    @classmethod
     def subscribe(
-        self,
+        cls,
+        event: type[TEvent] | list[type[TEvent]],
+        listener: Listener[TEvent] | None = None,
+    ) -> ListenerDecorator[TInstance, TEvent] | None:
+        if listener is not None:
+            cls._do_subscribe(event, listener)
+            return None
+
+        def decorator(
+            method: ListenerMethod[TInstance, TEvent],
+        ) -> ListenerMethod[TInstance, TEvent]:
+            events = event if isinstance(event, list) else [event]
+            existing: list[type[BaseEvent]] = getattr(
+                method, _EVENT_SUBSCRIPTIONS_ATTR, []
+            )
+            setattr(method, _EVENT_SUBSCRIPTIONS_ATTR, existing + events)
+            return method
+
+        return decorator
+
+    @classmethod
+    def _do_subscribe(
+        cls,
         event: type[TEvent] | list[type[TEvent]],
         listener: Listener[TEvent],
     ) -> None:
         if isinstance(event, list):
-            for _event in event:
-                self.subscribe(_event, listener)
+            for evt in event:
+                cls._do_subscribe(evt, listener)
             return
 
         event_key = event.event_key()
         logger.info(f"Event subscribed: {event_key}")
-        self._listeners.setdefault(event_key, []).append(listener)
-        self._subscribed_events[event_key] = event
+        cls._listeners.setdefault(event_key, []).append(
+            cast(AnyListener, listener))
+        cls._subscribed_events[event_key] = event
 
-    @property
-    def subscribed_events(self) -> set[type[BaseEvent]]:
-        return set(self._subscribed_events.values())
+    @classmethod
+    def register(cls, instance: Any) -> None:
+        for name in dir(type(instance)):
+            method = getattr(type(instance), name, None)
+            subscriptions: list[type[BaseEvent]] = getattr(
+                method, _EVENT_SUBSCRIPTIONS_ATTR, []
+            )
+            if subscriptions:
+                bound_method = getattr(instance, name)
+                cls._do_subscribe(subscriptions, bound_method)
+
+    @classmethod
+    def subscribed_events(cls) -> set[type[BaseEvent]]:
+        return set(cls._subscribed_events.values())
 
     @overload
+    @classmethod
     def unsubscribe(
-        self,
+        cls,
         event: TEvent,
-        listener: Listener[TEvent],
+        listener: Callable[[TEvent], Awaitable[None]],
     ) -> None: ...  # pragma: no cover
 
     @overload
+    @classmethod
     def unsubscribe(
-        self,
+        cls,
         event: type[TEvent],
-        listener: Listener[TEvent],
+        listener: Callable[[TEvent], Awaitable[None]],
     ) -> None: ...  # pragma: no cover
 
+    @classmethod
     def unsubscribe(
-        self,
+        cls,
         event: TEvent | type[TEvent],
-        listener: Listener[TEvent],
+        listener: Callable[[TEvent], Awaitable[None]],
     ) -> None:
         event_key = event.event_key()
-        if event_key in self._listeners:
+        if event_key in cls._listeners:
             try:
-                self._listeners[event_key].remove(listener)
+                cls._listeners[event_key].remove(cast(AnyListener, listener))
             except ValueError:
                 pass
 
-            if len(self._listeners[event_key]) == 0:
-                self._listeners.pop(event_key, None)
-                self._subscribed_events.pop(event_key, None)
+            if len(cls._listeners[event_key]) == 0:
+                cls._listeners.pop(event_key, None)
+                cls._subscribed_events.pop(event_key, None)
 
-    def unsubscribe_all(self, event: type[TEvent]) -> None:
+    @classmethod
+    def unsubscribe_all(cls, event: type[TEvent]) -> None:
         event_key = event.event_key()
-        if event_key in self._listeners:
-            self._listeners.pop(event_key, None)
-            self._subscribed_events.pop(event_key, None)
+        if event_key in cls._listeners:
+            cls._listeners.pop(event_key, None)
+            cls._subscribed_events.pop(event_key, None)
 
-    async def emit(self, event: BaseEvent) -> None:
-        if self._critical_error is not None:
-            error = self._critical_error
-            self._critical_error = None
+    @classmethod
+    async def emit(cls, event: BaseEvent) -> None:
+        if cls._critical_error is not None:
+            error = cls._critical_error
+            cls._critical_error = None
             raise error
 
         event_key = event.event_key()
         logger.trace(f"Event emitted: {event_key}")
-        listeners = self._resolve_listeners(type(event))
+        listeners = cls._resolve_listeners(type(event))
         if not listeners:
             return
         if event.AWAIT:
-            await self._notify_listeners(event, listeners)
+            await cls._notify_listeners(event, listeners)
         else:
-            task = asyncio.create_task(self._notify_listeners(event, listeners))
-            self._tasks.add(task)
-            task.add_done_callback(self._handle_task_done)
+            task = asyncio.create_task(cls._notify_listeners(event, listeners))
+            cls._tasks.add(task)
+            task.add_done_callback(cls._handle_task_done)
 
-    def _resolve_listeners(self, event_type: type[BaseEvent]) -> list[AnyListener]:
+    @classmethod
+    def _resolve_listeners(
+        cls, event_type: type[BaseEvent]
+    ) -> list[AnyListener]:
         listeners: list[AnyListener] = []
         seen_listeners: set[int] = set()
 
-        for cls in event_type.__mro__:
-            if not issubclass(cls, BaseEvent):
+        for klass in event_type.__mro__:
+            if not issubclass(klass, BaseEvent):
                 continue
-            event_key = cls.event_key()
-            for listener in self._listeners.get(event_key, []):
+            event_key = klass.event_key()
+            for listener in cls._listeners.get(event_key, []):
                 listener_id = id(listener)
                 if listener_id in seen_listeners:
                     continue
@@ -125,11 +189,12 @@ class EventBus:
 
         return listeners
 
+    @classmethod
     async def _notify_listeners(
-        self, event: BaseEvent, listeners: list[AnyListener]
+        cls, event: BaseEvent, listeners: list[AnyListener]
     ) -> None:
         results = await asyncio.gather(
-            *(self._notify_listener(listener, event) for listener in listeners),
+            *(cls._notify_listener(listener, event) for listener in listeners),
             return_exceptions=True,
         )
 
@@ -139,14 +204,20 @@ class EventBus:
             elif isinstance(r, Exception):
                 logger.error("Unhandled listener error: {exc}", exc=repr(r))
 
-    async def _notify_listener(self, listener: AnyListener, event: BaseEvent) -> None:
+    @classmethod
+    async def _notify_listener(
+        cls, listener: AnyListener, event: BaseEvent
+    ) -> None:
         try:
             await listener(event)
         except InvalidDataException as error:
-            logger.warning("{message}, skipping this loop", message=error.message)
+            logger.warning(
+                "{message}, skipping this loop", message=error.message
+            )
 
-    def _handle_task_done(self, task: asyncio.Task) -> None:
-        self._tasks.discard(task)
+    @classmethod
+    def _handle_task_done(cls, task: asyncio.Task) -> None:
+        cls._tasks.discard(task)
 
         if task.cancelled():
             return
@@ -156,25 +227,34 @@ class EventBus:
             return
 
         if isinstance(exc, MqttError):
-            if self._critical_error is None:
-                self._critical_error = exc
+            if cls._critical_error is None:
+                cls._critical_error = exc
             else:
                 logger.warning(
-                    "New critical error occurred before previous was handled: {exc}",
+                    "New critical error occurred before previous was handled:"
+                    " {exc}",
                     exc=repr(exc),
                 )
             return
 
         logger.error("Unhandled listener error: {exc}", exc=repr(exc))
 
-    async def cancel_tasks(self) -> None:
-        tasks = list(self._tasks)
+    @classmethod
+    async def cancel_tasks(cls) -> None:
+        tasks = list(cls._tasks)
         for t in tasks:
             t.cancel()
 
         await asyncio.gather(*tasks, return_exceptions=True)
 
-        self._tasks.clear()
-        self._critical_error = None
+        cls._tasks.clear()
+        cls._critical_error = None
 
         logger.info("Running tasks cancelled: {count}", count=len(tasks))
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._listeners = {}
+        cls._subscribed_events = {}
+        cls._tasks = set()
+        cls._critical_error = None

--- a/solaredge2mqtt/core/events/__init__.py
+++ b/solaredge2mqtt/core/events/__init__.py
@@ -22,16 +22,15 @@ _EVENT_SUBSCRIPTIONS_ATTR = "_event_subscriptions"
 
 
 class Listener(Protocol[TEventContra]):
-    def __call__(
-        self, event: TEventContra
-    ) -> Awaitable[None]: ...  # pragma: no cover
+    def __call__(self, event: TEventContra) -> Awaitable[None]: ...  # pragma: no cover
 
 
 AnyListener = Listener[Any]
 TInstance = TypeVar("TInstance")
 ListenerMethod = Callable[[TInstance, TEvent], Awaitable[None]]
-ListenerDecorator = Callable[[
-    ListenerMethod[TInstance, TEvent]], ListenerMethod[TInstance, TEvent]]
+ListenerDecorator = Callable[
+    [ListenerMethod[TInstance, TEvent]], ListenerMethod[TInstance, TEvent]
+]
 
 
 class EventBus:
@@ -90,8 +89,7 @@ class EventBus:
 
         event_key = event.event_key()
         logger.info(f"Event subscribed: {event_key}")
-        cls._listeners.setdefault(event_key, []).append(
-            cast(AnyListener, listener))
+        cls._listeners.setdefault(event_key, []).append(cast(AnyListener, listener))
         cls._subscribed_events[event_key] = event
 
     @classmethod
@@ -169,9 +167,7 @@ class EventBus:
             task.add_done_callback(cls._handle_task_done)
 
     @classmethod
-    def _resolve_listeners(
-        cls, event_type: type[BaseEvent]
-    ) -> list[AnyListener]:
+    def _resolve_listeners(cls, event_type: type[BaseEvent]) -> list[AnyListener]:
         listeners: list[AnyListener] = []
         seen_listeners: set[int] = set()
 
@@ -205,15 +201,11 @@ class EventBus:
                 logger.error("Unhandled listener error: {exc}", exc=repr(r))
 
     @classmethod
-    async def _notify_listener(
-        cls, listener: AnyListener, event: BaseEvent
-    ) -> None:
+    async def _notify_listener(cls, listener: AnyListener, event: BaseEvent) -> None:
         try:
             await listener(event)
         except InvalidDataException as error:
-            logger.warning(
-                "{message}, skipping this loop", message=error.message
-            )
+            logger.warning("{message}, skipping this loop", message=error.message)
 
     @classmethod
     def _handle_task_done(cls, task: asyncio.Task) -> None:
@@ -231,8 +223,7 @@ class EventBus:
                 cls._critical_error = exc
             else:
                 logger.warning(
-                    "New critical error occurred before previous was handled:"
-                    " {exc}",
+                    "New critical error occurred before previous was handled: {exc}",
                     exc=repr(exc),
                 )
             return

--- a/solaredge2mqtt/core/events/__init__.py
+++ b/solaredge2mqtt/core/events/__init__.py
@@ -242,10 +242,3 @@ class EventBus:
         cls._critical_error = None
 
         logger.info("Running tasks cancelled: {count}", count=len(tasks))
-
-    @classmethod
-    def reset(cls) -> None:
-        cls._listeners = {}
-        cls._subscribed_events = {}
-        cls._tasks = set()
-        cls._critical_error = None

--- a/solaredge2mqtt/core/influxdb/__init__.py
+++ b/solaredge2mqtt/core/influxdb/__init__.py
@@ -33,13 +33,9 @@ class InfluxDBAsync:
         self,
         settings: InfluxDBSettings,
         prices: PriceSettings,
-        event_bus: EventBus | None = None,
     ) -> None:
         self.settings: InfluxDBSettings = settings
         self.prices: PriceSettings = prices
-
-        self.event_bus = event_bus
-        self._subscribe_events()
 
         self.client_async: InfluxDBClientAsync | None = None
         self.client_sync: InfluxDBClient = InfluxDBClient(
@@ -48,9 +44,7 @@ class InfluxDBAsync:
 
         self.flux_cache: dict[str, str] = {}
 
-    def _subscribe_events(self) -> None:
-        if self.event_bus:
-            self.event_bus.subscribe(Interval10MinTriggerEvent, self.loop)
+        EventBus.register(self)
 
     def init(self) -> None:
         self.client_async = InfluxDBClientAsync(
@@ -84,8 +78,10 @@ class InfluxDBAsync:
     def buckets_api(self) -> BucketsApi:
         return self.client_sync.buckets_api()
 
+    @EventBus.subscribe(Interval10MinTriggerEvent)
     async def loop(self, event: Interval10MinTriggerEvent) -> None:
-        now = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
+        now = datetime.now(tz=timezone.utc).replace(
+            minute=0, second=0, microsecond=0)
 
         logger.info("Aggregate powerflow and energy raw data")
         aggregate_query = self._get_flux_query(
@@ -102,8 +98,7 @@ class InfluxDBAsync:
             ["powerflow_raw", "battery_raw"],
         )
 
-        if self.event_bus:
-            await self.event_bus.emit(InfluxDBAggregatedEvent())
+        await EventBus.emit(InfluxDBAggregatedEvent())
 
     @property
     def query_api(self) -> QueryApiAsync:
@@ -148,7 +143,8 @@ class InfluxDBAsync:
         self, period: HistoricPeriod, measurement: str
     ) -> list[dict[str, Any]] | None:
         results = await self.query(
-            period.query.query, {"UNIT": period.unit, "MEASUREMENT": measurement}
+            period.query.query, {"UNIT": period.unit,
+                                 "MEASUREMENT": measurement}
         )
 
         return results if len(results) > 0 else None

--- a/solaredge2mqtt/core/influxdb/__init__.py
+++ b/solaredge2mqtt/core/influxdb/__init__.py
@@ -80,8 +80,7 @@ class InfluxDBAsync:
 
     @EventBus.subscribe(Interval10MinTriggerEvent)
     async def loop(self, event: Interval10MinTriggerEvent) -> None:
-        now = datetime.now(tz=timezone.utc).replace(
-            minute=0, second=0, microsecond=0)
+        now = datetime.now(tz=timezone.utc).replace(minute=0, second=0, microsecond=0)
 
         logger.info("Aggregate powerflow and energy raw data")
         aggregate_query = self._get_flux_query(
@@ -143,8 +142,7 @@ class InfluxDBAsync:
         self, period: HistoricPeriod, measurement: str
     ) -> list[dict[str, Any]] | None:
         results = await self.query(
-            period.query.query, {"UNIT": period.unit,
-                                 "MEASUREMENT": measurement}
+            period.query.query, {"UNIT": period.unit, "MEASUREMENT": measurement}
         )
 
         return results if len(results) > 0 else None

--- a/solaredge2mqtt/core/mqtt/__init__.py
+++ b/solaredge2mqtt/core/mqtt/__init__.py
@@ -80,8 +80,7 @@ class MQTTClient(Client):
             async for message in self.messages:
                 topic = str(message.topic)
                 if topic not in self._subscribed_topics:
-                    logger.warning(
-                        f"Received message on unsubscribed topic: {topic}")
+                    logger.warning(f"Received message on unsubscribed topic: {topic}")
                     continue
                 if len(message.payload) > MAX_MQTT_PAYLOAD_SIZE:
                     logger.warning(
@@ -92,8 +91,7 @@ class MQTTClient(Client):
                 try:
                     self._received_message_queue.put_nowait(message)
                 except QueueFull:
-                    logger.warning(
-                        "MQTT processing queue full – dropping message")
+                    logger.warning("MQTT processing queue full – dropping message")
 
     async def process_queue(self) -> None:
         if self._subscribed_topics:
@@ -109,8 +107,7 @@ class MQTTClient(Client):
         try:
             event = self._subscribed_topics.get(topic)
             if not event:
-                logger.warning(
-                    f"Received message for unexpected topic: {topic}")
+                logger.warning(f"Received message for unexpected topic: {topic}")
                 return
 
             payload = message.payload.decode()
@@ -125,14 +122,12 @@ class MQTTClient(Client):
             if isinstance(input_raw, (dict, list, int, float, bool, str)):
                 parsed_input = model.model_validate(input_raw)
             else:
-                logger.warning(
-                    f"Received invalid payload type on topic: {topic}")
+                logger.warning(f"Received invalid payload type on topic: {topic}")
                 return
 
             await EventBus.emit(event(topic, parsed_input))
         except (ValidationError, json.JSONDecodeError, TypeError) as ex:
-            logger.warning(
-                f"Received invalid message on topic: {topic}, error: {ex}")
+            logger.warning(f"Received invalid message on topic: {topic}, error: {ex}")
 
     async def publish_status_online(self) -> None:
         await self.publish_to("status", "online", True)

--- a/solaredge2mqtt/core/mqtt/__init__.py
+++ b/solaredge2mqtt/core/mqtt/__init__.py
@@ -18,7 +18,7 @@ from solaredge2mqtt.core.mqtt.settings import MQTTSettings
 
 
 class MQTTClient(Client):
-    def __init__(self, settings: MQTTSettings, event_bus: EventBus):
+    def __init__(self, settings: MQTTSettings):
         self.broker = settings.broker
         self.port = settings.port
         self._is_connected = False
@@ -39,7 +39,6 @@ class MQTTClient(Client):
 
         self._received_message_queue: Queue[Message] = Queue(maxsize=10)
 
-        self.event_bus = event_bus
         self._subscribe_events()
 
         super().__init__(
@@ -64,11 +63,11 @@ class MQTTClient(Client):
         return await super().__aexit__(exc_type, exc_val, exc_tb)
 
     def _subscribe_events(self) -> None:
-        self.event_bus.unsubscribe_all(MQTTPublishEvent)
-        self.event_bus.unsubscribe_all(MQTTSubscribeEvent)
+        EventBus.unsubscribe_all(MQTTPublishEvent)
+        EventBus.unsubscribe_all(MQTTSubscribeEvent)
 
-        self.event_bus.subscribe(MQTTPublishEvent, self.event_listener)
-        self.event_bus.subscribe(MQTTSubscribeEvent, self._subscribe_topic)
+        EventBus.subscribe(MQTTPublishEvent, self.event_listener)
+        EventBus.subscribe(MQTTSubscribeEvent, self._subscribe_topic)
 
     async def _subscribe_topic(self, event: MQTTSubscribeEvent[Any]) -> None:
         if event.topic not in self._subscribed_topics:
@@ -81,7 +80,8 @@ class MQTTClient(Client):
             async for message in self.messages:
                 topic = str(message.topic)
                 if topic not in self._subscribed_topics:
-                    logger.warning(f"Received message on unsubscribed topic: {topic}")
+                    logger.warning(
+                        f"Received message on unsubscribed topic: {topic}")
                     continue
                 if len(message.payload) > MAX_MQTT_PAYLOAD_SIZE:
                     logger.warning(
@@ -92,7 +92,8 @@ class MQTTClient(Client):
                 try:
                     self._received_message_queue.put_nowait(message)
                 except QueueFull:
-                    logger.warning("MQTT processing queue full – dropping message")
+                    logger.warning(
+                        "MQTT processing queue full – dropping message")
 
     async def process_queue(self) -> None:
         if self._subscribed_topics:
@@ -108,7 +109,8 @@ class MQTTClient(Client):
         try:
             event = self._subscribed_topics.get(topic)
             if not event:
-                logger.warning(f"Received message for unexpected topic: {topic}")
+                logger.warning(
+                    f"Received message for unexpected topic: {topic}")
                 return
 
             payload = message.payload.decode()
@@ -123,12 +125,14 @@ class MQTTClient(Client):
             if isinstance(input_raw, (dict, list, int, float, bool, str)):
                 parsed_input = model.model_validate(input_raw)
             else:
-                logger.warning(f"Received invalid payload type on topic: {topic}")
+                logger.warning(
+                    f"Received invalid payload type on topic: {topic}")
                 return
 
-            await self.event_bus.emit(event(topic, parsed_input))
+            await EventBus.emit(event(topic, parsed_input))
         except (ValidationError, json.JSONDecodeError, TypeError) as ex:
-            logger.warning(f"Received invalid message on topic: {topic}, error: {ex}")
+            logger.warning(
+                f"Received invalid message on topic: {topic}, error: {ex}")
 
     async def publish_status_online(self) -> None:
         await self.publish_to("status", "online", True)

--- a/solaredge2mqtt/core/timer/__init__.py
+++ b/solaredge2mqtt/core/timer/__init__.py
@@ -11,31 +11,31 @@ from solaredge2mqtt.core.timer.events import (
 
 
 class Timer:
-    def __init__(self, event_bus: EventBus, base_interval: int) -> None:
-        self.event_bus = event_bus
+    def __init__(self, base_interval: int) -> None:
         self.base_interval = base_interval
+        EventBus.register(self)
 
     async def loop(self) -> None:
         timestamp = int(datetime.now().timestamp())
 
         if timestamp % self.base_interval == 0:
-            await self.event_bus.emit(IntervalBaseTriggerEvent())
+            await EventBus.emit(IntervalBaseTriggerEvent())
 
         timestamp -= self.base_interval - 1
 
         if timestamp % 60 == 0:
-            await self.event_bus.emit(Interval1MinTriggerEvent())
+            await EventBus.emit(Interval1MinTriggerEvent())
 
         timestamp -= self.base_interval
 
         if timestamp % 300 == 0:
-            await self.event_bus.emit(Interval5MinTriggerEvent())
+            await EventBus.emit(Interval5MinTriggerEvent())
 
         timestamp -= self.base_interval
 
         if timestamp % 600 == 0:
-            await self.event_bus.emit(Interval10MinTriggerEvent())
+            await EventBus.emit(Interval10MinTriggerEvent())
         timestamp -= self.base_interval
 
         if timestamp % 900 == 0:
-            await self.event_bus.emit(Interval15MinTriggerEvent())
+            await EventBus.emit(Interval15MinTriggerEvent())

--- a/solaredge2mqtt/service.py
+++ b/solaredge2mqtt/service.py
@@ -49,8 +49,7 @@ class Service:
         initialize_logging(self.settings.logging_level)
         logger.debug(self.settings)
 
-        self.event_bus = EventBus()
-        self.timer = Timer(self.event_bus, self.settings.interval)
+        self.timer = Timer(self.settings.interval)
 
         self.mqtt: MQTTClient | None = None
 
@@ -59,27 +58,27 @@ class Service:
         self._run_task: asyncio.Task | None = None
 
         self.influxdb: InfluxDBAsync | None = (
-            InfluxDBAsync(self.settings.influxdb, self.settings.prices, self.event_bus)
+            InfluxDBAsync(self.settings.influxdb, self.settings.prices)
             if self.settings.influxdb.is_configured
             else None
         )
 
         self.energy: EnergyService | None = (
-            EnergyService(self.settings.energy, self.event_bus, self.influxdb)
+            EnergyService(self.settings.energy, self.influxdb)
             if self.influxdb
             else None
         )
 
-        self.powerflow = PowerflowService(self.settings, self.event_bus, self.influxdb)
+        self.powerflow = PowerflowService(self.settings, self.influxdb)
 
         self.monitoring: MonitoringSite | None = (
-            MonitoringSite(self.settings.monitoring, self.event_bus, self.influxdb)
+            MonitoringSite(self.settings.monitoring, self.influxdb)
             if self.settings.monitoring.is_configured
             else None
         )
 
         self.weather: WeatherClient | None = (
-            WeatherClient(self.settings, self.event_bus)
+            WeatherClient(self.settings)
             if self.settings.is_weather_enabled
             else None
         )
@@ -90,17 +89,17 @@ class Service:
                 ForecastService(
                     self.settings.forecast,
                     self.settings.location,
-                    self.event_bus,
                     self.influxdb,
                 )
                 if self.influxdb and self.settings.is_forecast_enabled
                 else None
             )
         elif self.settings.is_forecast_enabled:
-            logger.warning("Forecast service not available, please refer to README")
+            logger.warning(
+                "Forecast service not available, please refer to README")
 
         self.homeassistant: HomeAssistantDiscovery | None = (
-            HomeAssistantDiscovery(self.settings, self.event_bus)
+            HomeAssistantDiscovery(self.settings)
             if self.settings.homeassistant.enable
             else None
         )
@@ -147,7 +146,7 @@ class Service:
 
         while not self.cancel_request.is_set():
             try:
-                self.mqtt = MQTTClient(self.settings.mqtt, self.event_bus)
+                self.mqtt = MQTTClient(self.settings.mqtt)
 
                 async with self.mqtt:
                     await self.mqtt.publish_status_online()
@@ -198,7 +197,7 @@ class Service:
             finally:
                 self.mqtt = None
 
-        await self.event_bus.cancel_tasks()
+        await EventBus.cancel_tasks()
 
     async def shutdown(self) -> None:
         await self.finalize()
@@ -271,4 +270,5 @@ class Service:
                 timeout=5,
             )
         except asyncio.TimeoutError:
-            logger.warning("Timeout while closing tasks, proceeding with shutdown.")
+            logger.warning(
+                "Timeout while closing tasks, proceeding with shutdown.")

--- a/solaredge2mqtt/service.py
+++ b/solaredge2mqtt/service.py
@@ -78,9 +78,7 @@ class Service:
         )
 
         self.weather: WeatherClient | None = (
-            WeatherClient(self.settings)
-            if self.settings.is_weather_enabled
-            else None
+            WeatherClient(self.settings) if self.settings.is_weather_enabled else None
         )
 
         self.forecast: ForecastService | None = None
@@ -95,8 +93,7 @@ class Service:
                 else None
             )
         elif self.settings.is_forecast_enabled:
-            logger.warning(
-                "Forecast service not available, please refer to README")
+            logger.warning("Forecast service not available, please refer to README")
 
         self.homeassistant: HomeAssistantDiscovery | None = (
             HomeAssistantDiscovery(self.settings)
@@ -270,5 +267,4 @@ class Service:
                 timeout=5,
             )
         except asyncio.TimeoutError:
-            logger.warning(
-                "Timeout while closing tasks, proceeding with shutdown.")
+            logger.warning("Timeout while closing tasks, proceeding with shutdown.")

--- a/solaredge2mqtt/services/energy/__init__.py
+++ b/solaredge2mqtt/services/energy/__init__.py
@@ -23,7 +23,7 @@ class EnergyService:
     ):
         self.influxdb = influxdb
         self.settings = settings
-        
+
         EventBus.register(self)
 
     @EventBus.subscribe(InfluxDBAggregatedEvent)

--- a/solaredge2mqtt/services/energy/__init__.py
+++ b/solaredge2mqtt/services/energy/__init__.py
@@ -19,18 +19,14 @@ class EnergyService:
     def __init__(
         self,
         settings: EnergySettings,
-        event_bus: EventBus,
         influxdb: InfluxDBAsync,
     ):
         self.influxdb = influxdb
         self.settings = settings
+        
+        EventBus.register(self)
 
-        self.event_bus = event_bus
-        self._subscribe_events()
-
-    def _subscribe_events(self) -> None:
-        self.event_bus.subscribe(InfluxDBAggregatedEvent, self.read_historic_energy)
-
+    @EventBus.subscribe(InfluxDBAggregatedEvent)
     async def read_historic_energy(self, event: InfluxDBAggregatedEvent | None) -> None:
         for period in HistoricPeriod:
             records = await self.influxdb.query_timeunit(period, "energy")
@@ -53,8 +49,8 @@ class EnergyService:
                     energy=energy,
                 )
 
-                await self.event_bus.emit(EnergyReadEvent(energy))
-                await self.event_bus.emit(
+                await EventBus.emit(EnergyReadEvent(energy))
+                await EventBus.emit(
                     MQTTPublishEvent(
                         energy.mqtt_topic(),
                         energy,

--- a/solaredge2mqtt/services/forecast/service.py
+++ b/solaredge2mqtt/services/forecast/service.py
@@ -60,8 +60,7 @@ class ForecastService:
         }
 
         self.last_weather_forecast: list[OpenWeatherMapForecastData] | None = None
-        self.last_hour_forecast: dict[int,
-                                      OpenWeatherMapForecastData] | None = None
+        self.last_hour_forecast: dict[int, OpenWeatherMapForecastData] | None = None
 
         EventBus.register(self)
 
@@ -92,8 +91,7 @@ class ForecastService:
         self, last_hour_weather_forecast: OpenWeatherMapForecastData
     ) -> None:
         now = datetime.now().astimezone()
-        last_hour = now.replace(
-            minute=0, second=0, microsecond=0) - timedelta(hours=1)
+        last_hour = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
 
         training_data = last_hour_weather_forecast.model_dump_estimation_data()
         training_data["time"] = last_hour
@@ -173,8 +171,7 @@ class ForecastService:
         ]
 
         data = DataFrame(estimation_data_list)
-        data["time"] = to_datetime(
-            data["time"], utc=True).dt.tz_convert(LOCAL_TZ)
+        data["time"] = to_datetime(data["time"], utc=True).dt.tz_convert(LOCAL_TZ)
 
         for typed, forecaster in self.forecasters.items():
             predicted_data = await forecaster.predict(data)
@@ -191,8 +188,7 @@ class ForecastService:
             point.field(typed.target_column, period[typed.target_column])
             period_time = period["time"]
             if not isinstance(period_time, datetime):
-                raise InvalidDataException(
-                    "Forecast period time must be datetime")
+                raise InvalidDataException("Forecast period time must be datetime")
 
             utc_time = period_time.astimezone(timezone.utc)
             point.time(utc_time)
@@ -204,8 +200,7 @@ class ForecastService:
     async def publish_forecast(self) -> None:
         forecast_data = await self.influxdb.query_dataframe("forecast")
         if not forecast_data.empty:
-            forecast_data["time"] = forecast_data["_time"].dt.tz_convert(
-                LOCAL_TZ)
+            forecast_data["time"] = forecast_data["_time"].dt.tz_convert(LOCAL_TZ)
             power_hours: dict[datetime, int] = {}
             energy_hours: dict[datetime, int] = {}
             for _, row in forecast_data.iterrows():
@@ -229,8 +224,7 @@ class ForecastService:
                 power_hours[row_time] = int(round(row_power))
                 energy_hours[row_time] = int(round(row_energy * 1000))
 
-            forecast = Forecast(power_period=power_hours,
-                                energy_period=energy_hours)
+            forecast = Forecast(power_period=power_hours, energy_period=energy_hours)
             logger.debug(forecast)
 
             await EventBus.emit(
@@ -304,8 +298,7 @@ class Forecaster:
         pipeline = self._prepare_model_pipeline(data.columns.to_list())
 
         if self.enable_hyperparameter_tuning:
-            self.model_pipeline = self._hyperparametertuning(
-                data, y_vector, pipeline)
+            self.model_pipeline = self._hyperparametertuning(data, y_vector, pipeline)
         else:
             self.model_pipeline = pipeline
 
@@ -367,8 +360,7 @@ class Forecaster:
                 (
                     "num",
                     "passthrough",
-                    self._extract_used_columns(
-                        self.NUMERIC_FEATURES, x_vector_columns),
+                    self._extract_used_columns(self.NUMERIC_FEATURES, x_vector_columns),
                 ),
                 (
                     "time",
@@ -412,8 +404,7 @@ class Forecaster:
         logger.info(
             "Training with best parameters: {params}", params=grid_search.best_params_
         )
-        logger.info(
-            "Training with best score: {score}", score=grid_search.best_score_)
+        logger.info("Training with best score: {score}", score=grid_search.best_score_)
 
         return cast(Pipeline, clone(grid_search.best_estimator_))
 

--- a/solaredge2mqtt/services/forecast/service.py
+++ b/solaredge2mqtt/services/forecast/service.py
@@ -48,13 +48,10 @@ class ForecastService:
         self,
         settings: ForecastSettings,
         location: LocationSettings,
-        event_bus: EventBus,
         influxdb: InfluxDBAsync,
     ) -> None:
         self.settings = settings
         self.location = location
-        self.event_bus = event_bus
-        self._subscribe_events()
 
         self.influxdb = influxdb
 
@@ -63,12 +60,12 @@ class ForecastService:
         }
 
         self.last_weather_forecast: list[OpenWeatherMapForecastData] | None = None
-        self.last_hour_forecast: dict[int, OpenWeatherMapForecastData] | None = None
+        self.last_hour_forecast: dict[int,
+                                      OpenWeatherMapForecastData] | None = None
 
-    def _subscribe_events(self) -> None:
-        self.event_bus.subscribe(WeatherUpdateEvent, self.weather_update)
-        self.event_bus.subscribe(Interval10MinTriggerEvent, self.forecast_loop)
+        EventBus.register(self)
 
+    @EventBus.subscribe(WeatherUpdateEvent)
     async def weather_update(self, event: WeatherUpdateEvent) -> None:
         self.last_weather_forecast = event.weather.hourly
 
@@ -95,7 +92,8 @@ class ForecastService:
         self, last_hour_weather_forecast: OpenWeatherMapForecastData
     ) -> None:
         now = datetime.now().astimezone()
-        last_hour = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
+        last_hour = now.replace(
+            minute=0, second=0, microsecond=0) - timedelta(hours=1)
 
         training_data = last_hour_weather_forecast.model_dump_estimation_data()
         training_data["time"] = last_hour
@@ -145,6 +143,7 @@ class ForecastService:
         for forecaster in self.forecasters.values():
             forecaster.train(data)
 
+    @EventBus.subscribe(Interval10MinTriggerEvent)
     async def forecast_loop(self, event: Interval10MinTriggerEvent) -> None:
         if (
             not self.forecasters[ForecasterType.ENERGY].is_trained
@@ -174,7 +173,8 @@ class ForecastService:
         ]
 
         data = DataFrame(estimation_data_list)
-        data["time"] = to_datetime(data["time"], utc=True).dt.tz_convert(LOCAL_TZ)
+        data["time"] = to_datetime(
+            data["time"], utc=True).dt.tz_convert(LOCAL_TZ)
 
         for typed, forecaster in self.forecasters.items():
             predicted_data = await forecaster.predict(data)
@@ -191,7 +191,8 @@ class ForecastService:
             point.field(typed.target_column, period[typed.target_column])
             period_time = period["time"]
             if not isinstance(period_time, datetime):
-                raise InvalidDataException("Forecast period time must be datetime")
+                raise InvalidDataException(
+                    "Forecast period time must be datetime")
 
             utc_time = period_time.astimezone(timezone.utc)
             point.time(utc_time)
@@ -203,7 +204,8 @@ class ForecastService:
     async def publish_forecast(self) -> None:
         forecast_data = await self.influxdb.query_dataframe("forecast")
         if not forecast_data.empty:
-            forecast_data["time"] = forecast_data["_time"].dt.tz_convert(LOCAL_TZ)
+            forecast_data["time"] = forecast_data["_time"].dt.tz_convert(
+                LOCAL_TZ)
             power_hours: dict[datetime, int] = {}
             energy_hours: dict[datetime, int] = {}
             for _, row in forecast_data.iterrows():
@@ -227,17 +229,18 @@ class ForecastService:
                 power_hours[row_time] = int(round(row_power))
                 energy_hours[row_time] = int(round(row_energy * 1000))
 
-            forecast = Forecast(power_period=power_hours, energy_period=energy_hours)
+            forecast = Forecast(power_period=power_hours,
+                                energy_period=energy_hours)
             logger.debug(forecast)
 
-            await self.event_bus.emit(
+            await EventBus.emit(
                 MQTTPublishEvent(
                     forecast.mqtt_topic(),
                     forecast,
                     self.settings.retain,
                 )
             )
-            await self.event_bus.emit(ForecastEvent(forecast))
+            await EventBus.emit(ForecastEvent(forecast))
 
 
 class Forecaster:
@@ -301,7 +304,8 @@ class Forecaster:
         pipeline = self._prepare_model_pipeline(data.columns.to_list())
 
         if self.enable_hyperparameter_tuning:
-            self.model_pipeline = self._hyperparametertuning(data, y_vector, pipeline)
+            self.model_pipeline = self._hyperparametertuning(
+                data, y_vector, pipeline)
         else:
             self.model_pipeline = pipeline
 
@@ -363,7 +367,8 @@ class Forecaster:
                 (
                     "num",
                     "passthrough",
-                    self._extract_used_columns(self.NUMERIC_FEATURES, x_vector_columns),
+                    self._extract_used_columns(
+                        self.NUMERIC_FEATURES, x_vector_columns),
                 ),
                 (
                     "time",
@@ -407,7 +412,8 @@ class Forecaster:
         logger.info(
             "Training with best parameters: {params}", params=grid_search.best_params_
         )
-        logger.info("Training with best score: {score}", score=grid_search.best_score_)
+        logger.info(
+            "Training with best score: {score}", score=grid_search.best_score_)
 
         return cast(Pipeline, clone(grid_search.best_estimator_))
 

--- a/solaredge2mqtt/services/homeassistant/service.py
+++ b/solaredge2mqtt/services/homeassistant/service.py
@@ -57,7 +57,8 @@ class HomeAssistantDiscovery:
             ForecastEvent,
             EnergyReadEvent,
             WallboxReadEvent,
-        ])
+        ]
+    )
     async def component_discovery(
         self, event: ForecastEvent | EnergyReadEvent | WallboxReadEvent
     ) -> None:
@@ -72,8 +73,7 @@ class HomeAssistantDiscovery:
             EventBus.unsubscribe(event, self.component_discovery)
 
         if publish:
-            logger.info(
-                f"Home Assistant discovery component: {event.component}")
+            logger.info(f"Home Assistant discovery component: {event.component}")
             device_info = event.component.homeassistant_device_info()
             state_topic = self.state_topic(event.component.mqtt_topic())
             await self.publish_component(event.component, device_info, state_topic)
@@ -93,8 +93,7 @@ class HomeAssistantDiscovery:
             for name, component in {**unit.meters, **unit.batteries}.items():
                 logger.info(f"Home Assistant discovery {unit_key}:{name}")
 
-                device_info = component.homeassistant_device_info_with_name(
-                    name)
+                device_info = component.homeassistant_device_info_with_name(name)
                 state_topic = self.state_topic(
                     component.mqtt_topic(self.settings.modbus.has_followers),
                     name,
@@ -178,8 +177,7 @@ class HomeAssistantDiscovery:
     @EventBus.subscribe(HomeAssistantStatusEvent)
     async def homeassistant_status(self, event: HomeAssistantStatusEvent) -> None:
         if event.input.status == HomeAssistantStatus.ONLINE:
-            logger.info(
-                "Home Assistant status changed to online resend discovery")
+            logger.info("Home Assistant status changed to online resend discovery")
             for topic, entity in self._send_entities.items():
                 await EventBus.emit(
                     MQTTPublishEvent(
@@ -204,14 +202,11 @@ class HomeAssistantDiscovery:
             typed = HomeAssistantType.from_string(prop["ha_typed"])
 
             if typed == HomeAssistantType.BINARY_SENSOR:
-                entity["ha_type"] = HomeAssistantBinarySensorType.from_string(
-                    ha_type)
+                entity["ha_type"] = HomeAssistantBinarySensorType.from_string(ha_type)
             elif typed == HomeAssistantType.NUMBER:
-                entity["ha_type"] = HomeAssistantNumberType.from_string(
-                    ha_type)
+                entity["ha_type"] = HomeAssistantNumberType.from_string(ha_type)
             elif typed == HomeAssistantType.SENSOR:
-                entity["ha_type"] = HomeAssistantSensorType.from_string(
-                    ha_type)
+                entity["ha_type"] = HomeAssistantSensorType.from_string(ha_type)
 
             for field in typed.additional_fields:
                 entity[field] = prop.get(field, None)

--- a/solaredge2mqtt/services/homeassistant/service.py
+++ b/solaredge2mqtt/services/homeassistant/service.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 class HomeAssistantDiscovery:
-    def __init__(self, service_settings: ServiceSettings, event_bus: EventBus) -> None:
+    def __init__(self, service_settings: ServiceSettings) -> None:
         self.settings = service_settings
 
         self._send_entities: dict[str, HomeAssistantEntity] = {}
@@ -43,35 +43,21 @@ class HomeAssistantDiscovery:
 
         self._seen_energy_periods: set[str] = set()
 
-        self.event_bus = event_bus
-        self._subscribe_events()
-
-    def _subscribe_events(self) -> None:
-        self.event_bus.subscribe(
-            [
-                ForecastEvent,
-                EnergyReadEvent,
-                WallboxReadEvent,
-            ],
-            self.component_discovery,
-        )
-
-        self.event_bus.subscribe(PowerflowGeneratedEvent, self.powerflow_discovery)
-
-        self.event_bus.subscribe(ModbusUnitsReadEvent, self.units_discovery)
-
-        self.event_bus.subscribe(
-            HomeAssistantStatusEvent,
-            self.homeassistant_status,
-        )
+        EventBus.register(self)
 
     async def async_init(self) -> None:
-        await self.event_bus.emit(
+        await EventBus.emit(
             HomeAssistantSubscribeEvent(
                 self._status_topic,
             )
         )
 
+    @EventBus.subscribe(
+        [
+            ForecastEvent,
+            EnergyReadEvent,
+            WallboxReadEvent,
+        ])
     async def component_discovery(
         self, event: ForecastEvent | EnergyReadEvent | WallboxReadEvent
     ) -> None:
@@ -83,16 +69,18 @@ class HomeAssistantDiscovery:
             )
             self._seen_energy_periods.add(event.component.mqtt_topic())
         else:
-            self.event_bus.unsubscribe(event, self.component_discovery)
+            EventBus.unsubscribe(event, self.component_discovery)
 
         if publish:
-            logger.info(f"Home Assistant discovery component: {event.component}")
+            logger.info(
+                f"Home Assistant discovery component: {event.component}")
             device_info = event.component.homeassistant_device_info()
             state_topic = self.state_topic(event.component.mqtt_topic())
             await self.publish_component(event.component, device_info, state_topic)
 
+    @EventBus.subscribe(ModbusUnitsReadEvent)
     async def units_discovery(self, event: ModbusUnitsReadEvent) -> None:
-        self.event_bus.unsubscribe(event, self.units_discovery)
+        EventBus.unsubscribe(event, self.units_discovery)
         for unit_key, unit in event.units.items():
             logger.info(f"Home Assistant discovery {unit_key}:inverter")
 
@@ -105,15 +93,17 @@ class HomeAssistantDiscovery:
             for name, component in {**unit.meters, **unit.batteries}.items():
                 logger.info(f"Home Assistant discovery {unit_key}:{name}")
 
-                device_info = component.homeassistant_device_info_with_name(name)
+                device_info = component.homeassistant_device_info_with_name(
+                    name)
                 state_topic = self.state_topic(
                     component.mqtt_topic(self.settings.modbus.has_followers),
                     name,
                 )
                 await self.publish_component(component, device_info, state_topic)
 
+    @EventBus.subscribe(PowerflowGeneratedEvent)
     async def powerflow_discovery(self, event: PowerflowGeneratedEvent) -> None:
-        self.event_bus.unsubscribe(event, self.powerflow_discovery)
+        EventBus.unsubscribe(event, self.powerflow_discovery)
 
         for key, powerflow in event.components.items():
             logger.info(f"Home Assistant discovery {key}:powerflow")
@@ -175,7 +165,7 @@ class HomeAssistantDiscovery:
 
             self._send_entities[topic] = entity
 
-            await self.event_bus.emit(
+            await EventBus.emit(
                 MQTTPublishEvent(
                     topic=topic,
                     payload=entity,
@@ -185,11 +175,13 @@ class HomeAssistantDiscovery:
                 )
             )
 
+    @EventBus.subscribe(HomeAssistantStatusEvent)
     async def homeassistant_status(self, event: HomeAssistantStatusEvent) -> None:
         if event.input.status == HomeAssistantStatus.ONLINE:
-            logger.info("Home Assistant status changed to online resend discovery")
+            logger.info(
+                "Home Assistant status changed to online resend discovery")
             for topic, entity in self._send_entities.items():
-                await self.event_bus.emit(
+                await EventBus.emit(
                     MQTTPublishEvent(
                         topic=topic,
                         payload=entity,
@@ -212,11 +204,14 @@ class HomeAssistantDiscovery:
             typed = HomeAssistantType.from_string(prop["ha_typed"])
 
             if typed == HomeAssistantType.BINARY_SENSOR:
-                entity["ha_type"] = HomeAssistantBinarySensorType.from_string(ha_type)
+                entity["ha_type"] = HomeAssistantBinarySensorType.from_string(
+                    ha_type)
             elif typed == HomeAssistantType.NUMBER:
-                entity["ha_type"] = HomeAssistantNumberType.from_string(ha_type)
+                entity["ha_type"] = HomeAssistantNumberType.from_string(
+                    ha_type)
             elif typed == HomeAssistantType.SENSOR:
-                entity["ha_type"] = HomeAssistantSensorType.from_string(ha_type)
+                entity["ha_type"] = HomeAssistantSensorType.from_string(
+                    ha_type)
 
             for field in typed.additional_fields:
                 entity[field] = prop.get(field, None)

--- a/solaredge2mqtt/services/modbus/__init__.py
+++ b/solaredge2mqtt/services/modbus/__init__.py
@@ -76,9 +76,7 @@ class Modbus:
 
         self._client: AsyncModbusTcpClient | None = None
 
-        self._control: ModbusAdvancedControl = ModbusAdvancedControl(
-            settings
-        )
+        self._control: ModbusAdvancedControl = ModbusAdvancedControl(settings)
 
         EventBus.register(self)
 
@@ -155,8 +153,7 @@ class Modbus:
                     meter.offset,
                 )
             except InvalidRegisterDataException as e:
-                self._log_meter_detection_error(
-                    meter.identifier, inverter_raw, e)
+                self._log_meter_detection_error(meter.identifier, inverter_raw, e)
 
     @staticmethod
     def _should_detect_meter(
@@ -242,8 +239,7 @@ class Modbus:
             else None,
         )
 
-        logger.info(
-            f"Found {key} {info.manufacturer} {info.model} {info.serialnumber}")
+        logger.info(f"Found {key} {info.manufacturer} {info.model} {info.serialnumber}")
         self._device_info[unit_key][key] = info
         return raw_data
 
@@ -278,8 +274,7 @@ class Modbus:
 
                     inverter_data = self._map_inverter(unit_key, inverter_raw)
                     meters_data = self._map_meters(unit_key, meters_raw)
-                    batteries_data = self._map_batteries(
-                        unit_key, batteries_raw)
+                    batteries_data = self._map_batteries(unit_key, batteries_raw)
 
                     units[unit_key] = ModbusUnit(
                         info=inverter_data.info.unit,
@@ -356,8 +351,7 @@ class Modbus:
             address_start = register_or_bundle.address + offset
 
             if address_start in self._block_unreadable:
-                logger.trace(
-                    f"Skip unreadable registers beginning at {address_start}")
+                logger.trace(f"Skip unreadable registers beginning at {address_start}")
                 continue
 
             logger.trace(
@@ -379,8 +373,7 @@ class Modbus:
                     logger.debug(f"Modbus read error: {result}")
                     self._block_register(address_start)
                 else:
-                    data = register_or_bundle.decode_response(
-                        result.registers, data)
+                    data = register_or_bundle.decode_response(result.registers, data)
 
                 if not self._initialized:
                     logger.trace(
@@ -447,8 +440,7 @@ class Modbus:
             )
             logger.debug(meter_data)
             logger.info(
-                LOGGING_DEVICE_INFO +
-                ": {power} W, {consumption} kWh, {delivery} kWh",
+                LOGGING_DEVICE_INFO + ": {power} W, {consumption} kWh, {delivery} kWh",
                 unit_key=meter_data.info.unit_key(":"),
                 device=meter_key,
                 info=meter_data.info,
@@ -477,8 +469,7 @@ class Modbus:
             )
             logger.debug(battery_data)
             logger.info(
-                LOGGING_DEVICE_INFO +
-                ": {status}, {power} W, {state_of_charge} %",
+                LOGGING_DEVICE_INFO + ": {status}, {power} W, {state_of_charge} %",
                 unit_key=battery_data.info.unit_key(":"),
                 device=battery_key,
                 info=battery_data.info,
@@ -498,8 +489,7 @@ class Modbus:
     async def _write_to_modbus(
         self, register: SunSpecRegister, value: SunSpecRawData
     ) -> None:
-        logger.info(
-            f"Writing {value} to register {register.address} ({register.name})")
+        logger.info(f"Writing {value} to register {register.address} ({register.name})")
 
         value_decoded = register.encode_request(value)
         logger.trace(f"Encoded value: {value_decoded}")

--- a/solaredge2mqtt/services/modbus/__init__.py
+++ b/solaredge2mqtt/services/modbus/__init__.py
@@ -58,7 +58,7 @@ LOGGING_DEVICE_INFO = (
 
 
 class Modbus:
-    def __init__(self, settings: ServiceSettings, event_bus: EventBus):
+    def __init__(self, settings: ServiceSettings):
         self.settings = settings.modbus
 
         logger.info(
@@ -69,8 +69,6 @@ class Modbus:
 
         logger.debug(f"Modbus settings: {self.settings}")
 
-        self.event_bus = event_bus
-
         self._block_unreadable: set[int] = set()
 
         self._initialized = False
@@ -79,10 +77,10 @@ class Modbus:
         self._client: AsyncModbusTcpClient | None = None
 
         self._control: ModbusAdvancedControl = ModbusAdvancedControl(
-            settings, event_bus
+            settings
         )
 
-        self._subscribe_events()
+        EventBus.register(self)
 
     @property
     def client(self) -> AsyncModbusTcpClient:
@@ -90,9 +88,6 @@ class Modbus:
             raise RuntimeError("Modbus client not initialized")
 
         return self._client
-
-    def _subscribe_events(self) -> None:
-        self.event_bus.subscribe(ModbusWriteEvent, self._handle_write_event)
 
     async def async_init(self) -> None:
         logger.info("Initializing modbus")
@@ -160,7 +155,8 @@ class Modbus:
                     meter.offset,
                 )
             except InvalidRegisterDataException as e:
-                self._log_meter_detection_error(meter.identifier, inverter_raw, e)
+                self._log_meter_detection_error(
+                    meter.identifier, inverter_raw, e)
 
     @staticmethod
     def _should_detect_meter(
@@ -246,7 +242,8 @@ class Modbus:
             else None,
         )
 
-        logger.info(f"Found {key} {info.manufacturer} {info.model} {info.serialnumber}")
+        logger.info(
+            f"Found {key} {info.manufacturer} {info.model} {info.serialnumber}")
         self._device_info[unit_key][key] = info
         return raw_data
 
@@ -281,7 +278,8 @@ class Modbus:
 
                     inverter_data = self._map_inverter(unit_key, inverter_raw)
                     meters_data = self._map_meters(unit_key, meters_raw)
-                    batteries_data = self._map_batteries(unit_key, batteries_raw)
+                    batteries_data = self._map_batteries(
+                        unit_key, batteries_raw)
 
                     units[unit_key] = ModbusUnit(
                         info=inverter_data.info.unit,
@@ -293,7 +291,7 @@ class Modbus:
         except KeyError as error:
             raise InvalidDataException("Invalid modbus data") from error
 
-        await self.event_bus.emit(ModbusUnitsReadEvent(units))
+        await EventBus.emit(ModbusUnitsReadEvent(units))
 
         return units
 
@@ -358,7 +356,8 @@ class Modbus:
             address_start = register_or_bundle.address + offset
 
             if address_start in self._block_unreadable:
-                logger.trace(f"Skip unreadable registers beginning at {address_start}")
+                logger.trace(
+                    f"Skip unreadable registers beginning at {address_start}")
                 continue
 
             logger.trace(
@@ -380,7 +379,8 @@ class Modbus:
                     logger.debug(f"Modbus read error: {result}")
                     self._block_register(address_start)
                 else:
-                    data = register_or_bundle.decode_response(result.registers, data)
+                    data = register_or_bundle.decode_response(
+                        result.registers, data)
 
                 if not self._initialized:
                     logger.trace(
@@ -447,7 +447,8 @@ class Modbus:
             )
             logger.debug(meter_data)
             logger.info(
-                LOGGING_DEVICE_INFO + ": {power} W, {consumption} kWh, {delivery} kWh",
+                LOGGING_DEVICE_INFO +
+                ": {power} W, {consumption} kWh, {delivery} kWh",
                 unit_key=meter_data.info.unit_key(":"),
                 device=meter_key,
                 info=meter_data.info,
@@ -476,7 +477,8 @@ class Modbus:
             )
             logger.debug(battery_data)
             logger.info(
-                LOGGING_DEVICE_INFO + ": {status}, {power} W, {state_of_charge} %",
+                LOGGING_DEVICE_INFO +
+                ": {status}, {power} W, {state_of_charge} %",
                 unit_key=battery_data.info.unit_key(":"),
                 device=battery_key,
                 info=battery_data.info,
@@ -489,13 +491,15 @@ class Modbus:
 
         return batteries
 
+    @EventBus.subscribe(ModbusWriteEvent)
     async def _handle_write_event(self, event: ModbusWriteEvent):
         await self._write_to_modbus(event.register, event.payload)
 
     async def _write_to_modbus(
         self, register: SunSpecRegister, value: SunSpecRawData
     ) -> None:
-        logger.info(f"Writing {value} to register {register.address} ({register.name})")
+        logger.info(
+            f"Writing {value} to register {register.address} ({register.name})")
 
         value_decoded = register.encode_request(value)
         logger.trace(f"Encoded value: {value_decoded}")

--- a/solaredge2mqtt/services/modbus/control.py
+++ b/solaredge2mqtt/services/modbus/control.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class ModbusAdvancedControl:
-    def __init__(self, service_settings: ServiceSettings, event_bus: EventBus):
+    def __init__(self, service_settings: ServiceSettings):
         self.settings = service_settings.modbus
 
         inverter_topic = (
@@ -31,13 +31,13 @@ class ModbusAdvancedControl:
         )
 
         self.topic_prefix = f"{service_settings.mqtt.topic_prefix}/{inverter_topic}"
-        self.event_bus = event_bus
 
         self._subscribe_events()
 
     def _subscribe_events(self) -> None:
         if self.settings.advanced_power_controls_enabled:
-            self.event_bus.subscribe(MQTTReceivedEvent, self.handle_mqtt_received_event)
+            EventBus.subscribe(MQTTReceivedEvent,
+                               self.handle_mqtt_received_event)
 
     async def async_init(self) -> None:
         await self.handle_advanced_power_control_settings()
@@ -49,7 +49,8 @@ class ModbusAdvancedControl:
         elif self.settings.advanced_power_controls == AdvancedControlsSettings.DISABLE:
             await self.disable_advanced_control_settings()
 
-            logger.warning("Change setting to disabled and restart the service.")
+            logger.warning(
+                "Change setting to disabled and restart the service.")
         else:
             logger.info("Advanced power control is disabled in settings")
 
@@ -62,17 +63,18 @@ class ModbusAdvancedControl:
 
     async def disable_advanced_control_settings(self):
         logger.debug("Disabling advanced power control")
-        await self.event_bus.emit(
-            ModbusWriteEvent(SunSpecPowerControlRegister.REACTIVE_POWER_CONFIG, 0)
+        await EventBus.emit(
+            ModbusWriteEvent(
+                SunSpecPowerControlRegister.REACTIVE_POWER_CONFIG, 0)
         )
 
-        await self.event_bus.emit(
+        await EventBus.emit(
             ModbusWriteEvent(
                 SunSpecPowerControlRegister.ADVANCED_POWER_CONTROL_ENABLE, False
             )
         )
 
-        await self.event_bus.emit(
+        await EventBus.emit(
             ModbusWriteEvent(
                 SunSpecPowerControlRegister.COMMIT_POWER_CONTROL_SETTINGS, 1
             )

--- a/solaredge2mqtt/services/modbus/control.py
+++ b/solaredge2mqtt/services/modbus/control.py
@@ -36,8 +36,7 @@ class ModbusAdvancedControl:
 
     def _subscribe_events(self) -> None:
         if self.settings.advanced_power_controls_enabled:
-            EventBus.subscribe(MQTTReceivedEvent,
-                               self.handle_mqtt_received_event)
+            EventBus.subscribe(MQTTReceivedEvent, self.handle_mqtt_received_event)
 
     async def async_init(self) -> None:
         await self.handle_advanced_power_control_settings()
@@ -49,8 +48,7 @@ class ModbusAdvancedControl:
         elif self.settings.advanced_power_controls == AdvancedControlsSettings.DISABLE:
             await self.disable_advanced_control_settings()
 
-            logger.warning(
-                "Change setting to disabled and restart the service.")
+            logger.warning("Change setting to disabled and restart the service.")
         else:
             logger.info("Advanced power control is disabled in settings")
 
@@ -64,8 +62,7 @@ class ModbusAdvancedControl:
     async def disable_advanced_control_settings(self):
         logger.debug("Disabling advanced power control")
         await EventBus.emit(
-            ModbusWriteEvent(
-                SunSpecPowerControlRegister.REACTIVE_POWER_CONFIG, 0)
+            ModbusWriteEvent(SunSpecPowerControlRegister.REACTIVE_POWER_CONFIG, 0)
         )
 
         await EventBus.emit(

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -91,8 +91,7 @@ class MonitoringSite(HTTPClientAsync):
                 return result
 
         except (ClientResponseError, asyncio.TimeoutError) as error:
-            raise InvalidDataException(
-                "Unable to read logical layout") from error
+            raise InvalidDataException("Unable to read logical layout") from error
 
     def _parse_inverters(self, inverter_objs, reporters_data) -> list[LogicalInverter]:
         inverters = []
@@ -104,16 +103,14 @@ class MonitoringSite(HTTPClientAsync):
                     {
                         "info": info,
                         "energy": (
-                            reporters_data[info["identifier"]
-                                           ]["unscaledEnergy"]
+                            reporters_data[info["identifier"]]["unscaledEnergy"]
                             if info["identifier"] in reporters_data
                             else None
                         ),
                     }
                 )
 
-                self._parse_strings(
-                    inverter, inverter_obj["children"], reporters_data)
+                self._parse_strings(inverter, inverter_obj["children"], reporters_data)
 
                 inverters.append(inverter)
 
@@ -162,8 +159,7 @@ class MonitoringSite(HTTPClientAsync):
         modules = {}
 
         for date_str, reporters_data in playback["reportersData"].items():
-            date = datetime.strptime(
-                date_str, "%a %b %d %H:%M:%S GMT %Y").astimezone()
+            date = datetime.strptime(date_str, "%a %b %d %H:%M:%S GMT %Y").astimezone()
 
             for entries in reporters_data.values():
                 for entry in entries:
@@ -213,8 +209,7 @@ class MonitoringSite(HTTPClientAsync):
 
             return json.loads(response)
         except (ClientResponseError, asyncio.TimeoutError) as error:
-            raise InvalidDataException(
-                "Unable to read logical layout") from error
+            raise InvalidDataException("Unable to read logical layout") from error
 
     async def login(self) -> str:
         try:

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -29,7 +29,6 @@ class MonitoringSite(HTTPClientAsync):
     def __init__(
         self,
         settings: MonitoringSettings,
-        event_bus: EventBus,
         influxdb: InfluxDBAsync | None,
     ) -> None:
         super().__init__("Monitoring Site")
@@ -37,12 +36,9 @@ class MonitoringSite(HTTPClientAsync):
 
         self.influxdb: InfluxDBAsync | None = influxdb
 
-        self.event_bus = event_bus
-        self._subscribe_events()
+        EventBus.register(self)
 
-    def _subscribe_events(self) -> None:
-        self.event_bus.subscribe(Interval15MinTriggerEvent, self.get_data)
-
+    @EventBus.subscribe(Interval15MinTriggerEvent)
     async def get_data(self, event: Interval15MinTriggerEvent | None) -> None:
         energies = await self.get_modules_energy()
         powers = await self.get_modules_power()
@@ -95,7 +91,8 @@ class MonitoringSite(HTTPClientAsync):
                 return result
 
         except (ClientResponseError, asyncio.TimeoutError) as error:
-            raise InvalidDataException("Unable to read logical layout") from error
+            raise InvalidDataException(
+                "Unable to read logical layout") from error
 
     def _parse_inverters(self, inverter_objs, reporters_data) -> list[LogicalInverter]:
         inverters = []
@@ -107,14 +104,16 @@ class MonitoringSite(HTTPClientAsync):
                     {
                         "info": info,
                         "energy": (
-                            reporters_data[info["identifier"]]["unscaledEnergy"]
+                            reporters_data[info["identifier"]
+                                           ]["unscaledEnergy"]
                             if info["identifier"] in reporters_data
                             else None
                         ),
                     }
                 )
 
-                self._parse_strings(inverter, inverter_obj["children"], reporters_data)
+                self._parse_strings(
+                    inverter, inverter_obj["children"], reporters_data)
 
                 inverters.append(inverter)
 
@@ -163,7 +162,8 @@ class MonitoringSite(HTTPClientAsync):
         modules = {}
 
         for date_str, reporters_data in playback["reportersData"].items():
-            date = datetime.strptime(date_str, "%a %b %d %H:%M:%S GMT %Y").astimezone()
+            date = datetime.strptime(
+                date_str, "%a %b %d %H:%M:%S GMT %Y").astimezone()
 
             for entries in reporters_data.values():
                 for entry in entries:
@@ -213,7 +213,8 @@ class MonitoringSite(HTTPClientAsync):
 
             return json.loads(response)
         except (ClientResponseError, asyncio.TimeoutError) as error:
-            raise InvalidDataException("Unable to read logical layout") from error
+            raise InvalidDataException(
+                "Unable to read logical layout") from error
 
     async def login(self) -> str:
         try:
@@ -284,7 +285,7 @@ class MonitoringSite(HTTPClientAsync):
                 count_modules += 1
                 energy_total += module.energy
 
-            await self.event_bus.emit(
+            await EventBus.emit(
                 MQTTPublishEvent(
                     f"monitoring/module/{module.info.serialnumber}",
                     module,
@@ -299,7 +300,7 @@ class MonitoringSite(HTTPClientAsync):
             count_modules=count_modules,
         )
 
-        await self.event_bus.emit(
+        await EventBus.emit(
             MQTTPublishEvent(
                 "monitoring/pv_energy_today",
                 energy_total,

--- a/solaredge2mqtt/services/powerflow/__init__.py
+++ b/solaredge2mqtt/services/powerflow/__init__.py
@@ -23,30 +23,26 @@ class PowerflowService:
     def __init__(
         self,
         settings: ServiceSettings,
-        event_bus: EventBus,
         influxdb: InfluxDBAsync | None = None,
     ):
         self.settings = settings
 
         self.influxdb = influxdb
 
-        self.modbus = Modbus(self.settings, event_bus)
+        self.modbus = Modbus(self.settings)
 
         self.wallbox = (
-            WallboxClient(self.settings.wallbox, event_bus)
+            WallboxClient(self.settings.wallbox)
             if self.settings.wallbox.is_configured
             else None
         )
 
-        self.event_bus = event_bus
-        self._subscribe_events()
-
-    def _subscribe_events(self) -> None:
-        self.event_bus.subscribe(IntervalBaseTriggerEvent, self.calculate_powerflow)
+        EventBus.register(self)
 
     async def async_init(self) -> None:
         await self.modbus.async_init()
 
+    @EventBus.subscribe(IntervalBaseTriggerEvent)
     async def calculate_powerflow(
         self, event: IntervalBaseTriggerEvent | None = None
     ) -> None:
@@ -73,7 +69,8 @@ class PowerflowService:
 
         if Powerflow.is_not_valid_with_last(powerflow):
             logger.debug(powerflow)
-            raise InvalidDataException("Value change not valid, skipping this loop")
+            raise InvalidDataException(
+                "Value change not valid, skipping this loop")
 
         await self.write_to_influxdb(powerflows, batteries)
 
@@ -140,16 +137,17 @@ class PowerflowService:
 
     async def publish_modbus(self, units):
         for key, unit in units.items():
-            await self.event_bus.emit(
+            await EventBus.emit(
                 MQTTPublishEvent(
-                    unit.inverter.mqtt_topic(self.settings.modbus.has_followers),
+                    unit.inverter.mqtt_topic(
+                        self.settings.modbus.has_followers),
                     unit.inverter,
                     self.settings.modbus.retain,
                 )
             )
 
             for key, component in {**unit.meters, **unit.batteries}.items():
-                await self.event_bus.emit(
+                await EventBus.emit(
                     MQTTPublishEvent(
                         f"{component.mqtt_topic(self.settings.modbus.has_followers)}/{key.lower()}",
                         component,
@@ -159,7 +157,7 @@ class PowerflowService:
 
     async def publish_wallbox(self, wallbox_data):
         if wallbox_data is not None:
-            await self.event_bus.emit(
+            await EventBus.emit(
                 MQTTPublishEvent(
                     wallbox_data.mqtt_topic(),
                     wallbox_data,
@@ -170,20 +168,20 @@ class PowerflowService:
     async def publish_powerflow(self, powerflows: dict[str, Powerflow]) -> None:
         if self.settings.modbus.has_followers:
             for pf in powerflows.values():
-                await self.event_bus.emit(
+                await EventBus.emit(
                     MQTTPublishEvent(
                         pf.mqtt_topic(), pf, self.settings.powerflow.retain
                     )
                 )
         else:
             powerflow = powerflows["leader"]
-            await self.event_bus.emit(
+            await EventBus.emit(
                 MQTTPublishEvent(
                     powerflow.mqtt_topic(), powerflow, self.settings.powerflow.retain
                 )
             )
 
-        await self.event_bus.emit(PowerflowGeneratedEvent(powerflows))
+        await EventBus.emit(PowerflowGeneratedEvent(powerflows))
 
     async def write_to_influxdb(
         self,

--- a/solaredge2mqtt/services/powerflow/__init__.py
+++ b/solaredge2mqtt/services/powerflow/__init__.py
@@ -69,8 +69,7 @@ class PowerflowService:
 
         if Powerflow.is_not_valid_with_last(powerflow):
             logger.debug(powerflow)
-            raise InvalidDataException(
-                "Value change not valid, skipping this loop")
+            raise InvalidDataException("Value change not valid, skipping this loop")
 
         await self.write_to_influxdb(powerflows, batteries)
 
@@ -139,8 +138,7 @@ class PowerflowService:
         for key, unit in units.items():
             await EventBus.emit(
                 MQTTPublishEvent(
-                    unit.inverter.mqtt_topic(
-                        self.settings.modbus.has_followers),
+                    unit.inverter.mqtt_topic(self.settings.modbus.has_followers),
                     unit.inverter,
                     self.settings.modbus.retain,
                 )

--- a/solaredge2mqtt/services/wallbox/__init__.py
+++ b/solaredge2mqtt/services/wallbox/__init__.py
@@ -51,10 +51,9 @@ class AuthorizationTokens(BaseModel):
 
 
 class WallboxClient(HTTPClientAsync):
-    def __init__(self, settings: WallboxSettings, event_bus: EventBus):
+    def __init__(self, settings: WallboxSettings):
         super().__init__("Wallbox API")
         self.settings = settings
-        self.event_bus = event_bus
         self.authorization: AuthorizationTokens | None = None
 
         logger.info(
@@ -88,7 +87,7 @@ class WallboxClient(HTTPClientAsync):
                 wallbox=wallbox,
             )
 
-            await self.event_bus.emit(WallboxReadEvent(wallbox))
+            await EventBus.emit(WallboxReadEvent(wallbox))
 
             return wallbox
         except (ClientResponseError, asyncio.TimeoutError) as error:

--- a/solaredge2mqtt/services/weather/__init__.py
+++ b/solaredge2mqtt/services/weather/__init__.py
@@ -22,22 +22,19 @@ TIMEMACHINE_URL = "https://api.openweathermap.org/data/3.0/onecall/timemachine"
 
 
 class WeatherClient(HTTPClientAsync):
-    def __init__(self, settings: ServiceSettings, event_bus: EventBus) -> None:
+    def __init__(self, settings: ServiceSettings) -> None:
         super().__init__("Weather API")
 
         self.location = settings.location
         self.settings = settings.weather
 
-        self.event_bus = event_bus
-        self._subscribe_events()
+        EventBus.register(self)
 
-    def _subscribe_events(self):
-        self.event_bus.subscribe(Interval10MinTriggerEvent, self.loop)
-
+    @EventBus.subscribe(Interval10MinTriggerEvent)
     async def loop(self, event: Interval10MinTriggerEvent | None) -> None:
         weather = await self.get_weather()
-        await self.event_bus.emit(WeatherUpdateEvent(weather))
-        await self.event_bus.emit(
+        await EventBus.emit(WeatherUpdateEvent(weather))
+        await EventBus.emit(
             MQTTPublishEvent(
                 "weather/current",
                 weather.current,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures and configuration for solaredge2mqtt tests."""
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -32,19 +32,43 @@ def pytest_collection_modifyitems(
 
 @pytest.fixture
 def event_bus():
-    """Create an EventBus instance for testing."""
-    return EventBus()
+    """Provide EventBus class access for tests that use classmethods."""
+    return EventBus
+
+
+@pytest.fixture(autouse=True)
+def reset_event_bus_state():
+    """Reset EventBus singleton state to avoid cross-test leakage."""
+    EventBus._listeners = {}
+    EventBus._subscribed_events = {}
+    EventBus._tasks = set()
+    EventBus._critical_error = None
+    yield
+    EventBus._listeners = {}
+    EventBus._subscribed_events = {}
+    EventBus._tasks = set()
+    EventBus._critical_error = None
 
 
 @pytest.fixture
 def mock_event_bus():
-    """Create a mock event bus with mocked emit method."""
-    bus = MagicMock()
-    bus.emit = AsyncMock()
-    bus.subscribe = MagicMock()
-    bus.unsubscribe = MagicMock()
-    bus.unsubscribe_all = MagicMock()
-    return bus
+    """Patch EventBus classmethods and expose a mock handle for assertions."""
+    with (
+        patch("solaredge2mqtt.core.events.EventBus.register") as register,
+        patch("solaredge2mqtt.core.events.EventBus.subscribe") as subscribe,
+        patch("solaredge2mqtt.core.events.EventBus.unsubscribe") as unsubscribe,
+        patch("solaredge2mqtt.core.events.EventBus.unsubscribe_all") as unsubscribe_all,
+        patch(
+            "solaredge2mqtt.core.events.EventBus.emit", new_callable=AsyncMock
+        ) as emit,
+    ):
+        bus = MagicMock()
+        bus.register = register
+        bus.subscribe = subscribe
+        bus.unsubscribe = unsubscribe
+        bus.unsubscribe_all = unsubscribe_all
+        bus.emit = emit
+        yield bus
 
 
 @pytest.fixture

--- a/tests/core/events/test_event_bus.py
+++ b/tests/core/events/test_event_bus.py
@@ -72,7 +72,7 @@ class TestEventBus:
             del event
 
         event_bus.subscribe(TestEvent, listener)
-        listeners = event_bus.subscribed_events
+        listeners = event_bus.subscribed_events()
         assert TestEvent in listeners
 
     def test_subscribe_multiple_events(self, event_bus):
@@ -86,7 +86,7 @@ class TestEventBus:
             """Another test event."""
 
         event_bus.subscribe([TestEvent, AnotherEvent], listener)
-        events = event_bus.subscribed_events
+        events = event_bus.subscribed_events()
         assert TestEvent in events
         assert AnotherEvent in events
 
@@ -99,7 +99,7 @@ class TestEventBus:
 
         event_bus.subscribe(TestEvent, listener)
 
-        events = event_bus.subscribed_events
+        events = event_bus.subscribed_events()
         assert TestEvent in events
 
     def test_unsubscribe(self, event_bus):
@@ -112,7 +112,7 @@ class TestEventBus:
         event_bus.subscribe(TestEvent, listener)
         event_bus.unsubscribe(TestEvent, listener)
 
-        events = event_bus.subscribed_events
+        events = event_bus.subscribed_events()
         assert TestEvent not in events
 
     @pytest.mark.asyncio
@@ -148,7 +148,7 @@ class TestEventBus:
         event_bus.unsubscribe(TestEvent, other_listener)
 
         # Original listener should still be subscribed
-        events = event_bus.subscribed_events
+        events = event_bus.subscribed_events()
         assert TestEvent in events
 
     def test_unsubscribe_with_no_registered_event(self, event_bus):
@@ -158,7 +158,7 @@ class TestEventBus:
             del event
 
         event_bus.unsubscribe(TestEvent, listener)
-        assert TestEvent not in event_bus.subscribed_events
+        assert TestEvent not in event_bus.subscribed_events()
 
     def test_unsubscribe_all(self, event_bus):
         """Test unsubscribing all listeners for an event."""
@@ -175,7 +175,7 @@ class TestEventBus:
         event_bus.subscribe(TestEvent, listener2)
         event_bus.unsubscribe_all(TestEvent)
 
-        events = event_bus.subscribed_events
+        events = event_bus.subscribed_events()
         assert TestEvent not in events
 
     @pytest.mark.asyncio
@@ -300,24 +300,24 @@ class TestEventBus:
 
     @pytest.mark.asyncio
     async def test_emit_raises_stored_critical_error(self):
-        bus = EventBus()
+        EventBus._critical_error = None
 
         async def failing():
             raise MqttError("boom")
 
         task = asyncio.create_task(failing())
         await asyncio.gather(task, return_exceptions=True)
-        bus._tasks.add(task)
-        bus._handle_task_done(task)
+        EventBus._tasks.add(task)
+        EventBus._handle_task_done(task)
 
         with pytest.raises(MqttError):
-            await bus.emit(TestEvent())
+            await EventBus.emit(TestEvent())
 
-        assert bus._critical_error is None
+        assert EventBus._critical_error is None
 
     @pytest.mark.asyncio
     async def test_handle_task_done_logs_second_critical_error(self, monkeypatch):
-        bus = EventBus()
+        EventBus._critical_error = None
         logger_spy = LoggerSpy()
         monkeypatch.setattr("solaredge2mqtt.core.events.logger", logger_spy)
 
@@ -326,15 +326,15 @@ class TestEventBus:
 
         first = asyncio.create_task(failing(MqttError("first")))
         await asyncio.gather(first, return_exceptions=True)
-        bus._tasks.add(first)
-        bus._handle_task_done(first)
+        EventBus._tasks.add(first)
+        EventBus._handle_task_done(first)
 
         second = asyncio.create_task(failing(MqttError("second")))
         await asyncio.gather(second, return_exceptions=True)
-        bus._tasks.add(second)
-        bus._handle_task_done(second)
+        EventBus._tasks.add(second)
+        EventBus._handle_task_done(second)
 
-        assert bus._critical_error is not None
+        assert EventBus._critical_error is not None
         assert logger_spy.warnings
 
     @pytest.mark.asyncio
@@ -383,7 +383,7 @@ class TestEventBus:
     def test_unsubscribe_all_for_non_subscribed_event(self, event_bus):
         """Test unsubscribe_all is a no-op for unknown event."""
         event_bus.unsubscribe_all(TestEvent)
-        assert TestEvent not in event_bus.subscribed_events
+        assert TestEvent not in event_bus.subscribed_events()
 
     @pytest.mark.asyncio
     async def test_notify_listeners_raises_mqtt_error(self, event_bus):
@@ -453,12 +453,11 @@ class TestEventBus:
     @pytest.mark.asyncio
     async def test_cancel_tasks_clears_critical_error(self):
         """Test cancel_tasks resets stored critical error."""
-        bus = EventBus()
-        bus._critical_error = MqttError("old")
+        EventBus._critical_error = MqttError("old")
 
-        await bus.cancel_tasks()
+        await EventBus.cancel_tasks()
 
-        assert bus._critical_error is None
+        assert EventBus._critical_error is None
 
     @pytest.mark.asyncio
     async def test_cancel_tasks_cancels_pending_tasks(self):

--- a/tests/core/influxdb/test_client.py
+++ b/tests/core/influxdb/test_client.py
@@ -56,26 +56,23 @@ def mock_influxdb_client():
 class TestInfluxDBAsyncInit:
     """Tests for InfluxDBAsync initialization."""
 
-    def test_influxdb_async_init_without_event_bus(
+    def test_influxdb_async_init(
         self, influxdb_settings, price_settings, mock_influxdb_client
     ):
-        """Test InfluxDBAsync initialization without event bus."""
+        """Test InfluxDBAsync initialization."""
         influxdb = InfluxDBAsync(influxdb_settings, price_settings)
 
         assert influxdb.settings == influxdb_settings
         assert influxdb.prices == price_settings
-        assert influxdb.event_bus is None
         assert influxdb.client_async is None
 
-    def test_influxdb_async_init_with_event_bus(
+    def test_influxdb_async_registers_to_event_bus(
         self, influxdb_settings, price_settings, mock_event_bus, mock_influxdb_client
     ):
-        """Test InfluxDBAsync initialization with event bus."""
-        influxdb = InfluxDBAsync(influxdb_settings, price_settings, mock_event_bus)
+        """Test InfluxDBAsync registers itself on EventBus."""
+        InfluxDBAsync(influxdb_settings, price_settings)
 
-        assert influxdb.event_bus is mock_event_bus
-        # Verify it subscribed to the 10min trigger event
-        mock_event_bus.subscribe.assert_called()
+        mock_event_bus.register.assert_called_once()
 
     def test_influxdb_async_bucket_name(
         self, influxdb_settings, price_settings, mock_influxdb_client
@@ -401,7 +398,7 @@ class TestInfluxDBAsyncLoop:
         mock_delete_api = MagicMock()
         mock_sync.delete_api.return_value = mock_delete_api
 
-        influxdb = InfluxDBAsync(influxdb_settings, price_settings, mock_event_bus)
+        influxdb = InfluxDBAsync(influxdb_settings, price_settings)
         influxdb.client_async = mock_async
 
         # Cache the aggregate query
@@ -419,29 +416,6 @@ class TestInfluxDBAsyncLoop:
         mock_event_bus.emit.assert_called_once()
         call_args = mock_event_bus.emit.call_args
         assert isinstance(call_args[0][0], InfluxDBAggregatedEvent)
-
-    @pytest.mark.asyncio
-    async def test_loop_without_event_bus_skips_emit(
-        self, influxdb_settings, price_settings, mock_influxdb_client
-    ):
-        """loop should not emit aggregation event when no event bus exists."""
-        mock_sync, mock_async = mock_influxdb_client
-
-        mock_query_api = MagicMock()
-        mock_query_api.query = AsyncMock(return_value=[])
-        mock_async.query_api = MagicMock(return_value=mock_query_api)
-
-        mock_delete_api = MagicMock()
-        mock_sync.delete_api.return_value = mock_delete_api
-
-        influxdb = InfluxDBAsync(influxdb_settings, price_settings)
-        influxdb.client_async = mock_async
-        influxdb.flux_cache["aggregate"] = "aggregate query"
-
-        await influxdb.loop(MagicMock())
-
-        mock_query_api.query.assert_called_once()
-        mock_delete_api.delete.assert_called()
 
 
 class TestInfluxDBAsyncClose:

--- a/tests/core/mqtt/test_client.py
+++ b/tests/core/mqtt/test_client.py
@@ -54,44 +54,22 @@ def mock_aiomqtt_client():
         yield
 
 
-@pytest.fixture
-def event_bus():
-    """Create an EventBus instance for testing."""
-    from solaredge2mqtt.core.events import EventBus
-
-    return EventBus()
-
-
-@pytest.fixture
-def mock_event_bus():
-    """Create a mock event bus with mocked emit method."""
-    from unittest.mock import AsyncMock, MagicMock
-
-    bus = MagicMock()
-    bus.emit = AsyncMock()
-    bus.subscribe = MagicMock()
-    bus.unsubscribe = MagicMock()
-    bus.unsubscribe_all = MagicMock()
-    return bus
-
-
 class TestMQTTClientInit:
     """Tests for MQTTClient initialization."""
 
-    def test_mqtt_client_init(self, mqtt_settings, event_bus, mock_aiomqtt_client):
+    def test_mqtt_client_init(self, mqtt_settings, mock_aiomqtt_client):
         """Test MQTTClient initialization."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
 
         assert client.broker == "localhost"
         assert client.port == 1883
         assert client.topic_prefix == "test"
-        assert client.event_bus is event_bus
 
     def test_mqtt_client_subscribes_to_events(
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Test MQTTClient subscribes to MQTT events."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
 
         # Verify event subscriptions
         mock_event_bus.subscribe.assert_any_call(
@@ -106,7 +84,7 @@ class TestMQTTClientInit:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test __aenter__ marks client as connected."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
 
         with patch(
             "solaredge2mqtt.core.mqtt.Client.__aenter__",
@@ -123,7 +101,7 @@ class TestMQTTClientInit:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test __aexit__ marks client as disconnected."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._is_connected = True
 
         with patch(
@@ -144,7 +122,7 @@ class TestMQTTClientSubscribeTopic:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test subscribing to a new topic."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client.subscribe = AsyncMock()
 
         event = SampleSubscribeEvent("test/topic")
@@ -160,7 +138,7 @@ class TestMQTTClientSubscribeTopic:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test subscribing to an already subscribed topic does nothing."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client.subscribe = AsyncMock()
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
@@ -179,7 +157,7 @@ class TestMQTTClientHandleMessage:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Test handling a valid message with dict payload."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
         # Create mock message
@@ -203,7 +181,7 @@ class TestMQTTClientHandleMessage:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Test handling a valid message with string payload that becomes JSON."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
         # The handler tries to parse as JSON then as dict/scalar
@@ -227,7 +205,7 @@ class TestMQTTClientHandleMessage:
         mock_aiomqtt_client,
     ):
         """Test handling Home Assistant online/offline scalar payload."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["homeassistant/status"] = HomeAssistantStatusEvent
 
         mock_message = MagicMock()
@@ -248,7 +226,7 @@ class TestMQTTClientHandleMessage:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Test handling message for unexpected topic."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
 
         mock_message = MagicMock()
         mock_message.topic = MagicMock()
@@ -265,7 +243,7 @@ class TestMQTTClientHandleMessage:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Test handling message with invalid JSON."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
         mock_message = MagicMock()
@@ -286,7 +264,7 @@ class TestMQTTClientPublish:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test publishing online status."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client.publish_to = AsyncMock()
 
         await client.publish_status_online()
@@ -298,7 +276,7 @@ class TestMQTTClientPublish:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test publishing offline status."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client.publish_to = AsyncMock()
 
         await client.publish_status_offline()
@@ -308,7 +286,7 @@ class TestMQTTClientPublish:
     @pytest.mark.asyncio
     async def test_event_listener(self, mqtt_settings, event_bus, mock_aiomqtt_client):
         """Test event listener calls publish_to."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client.publish_to = AsyncMock()
 
         event = MQTTPublishEvent(
@@ -335,7 +313,7 @@ class TestMQTTClientPublish:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test publish_to with string payload."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._is_connected = True
         client.publish = AsyncMock()
 
@@ -353,7 +331,7 @@ class TestMQTTClientPublish:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test publish_to with BaseModel payload."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._is_connected = True
         client.publish = AsyncMock()
 
@@ -372,7 +350,7 @@ class TestMQTTClientPublish:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test publish_to with custom topic prefix."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._is_connected = True
         client.publish = AsyncMock()
 
@@ -387,7 +365,7 @@ class TestMQTTClientPublish:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test publish_to when not connected does nothing."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._is_connected = False
         client.publish = AsyncMock()
 
@@ -404,7 +382,7 @@ class TestMQTTClientListen:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test listen returns immediately with no subscriptions."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics = {}
 
         # Should return immediately without blocking
@@ -415,7 +393,7 @@ class TestMQTTClientListen:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Skip messages received on topics that are not subscribed."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics = {"test/topic": SampleInputEvent}
 
         msg = MagicMock()
@@ -440,7 +418,7 @@ class TestMQTTClientListen:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Skip messages that exceed maximum payload size."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics = {"test/topic": SampleInputEvent}
 
         msg = MagicMock()
@@ -465,7 +443,7 @@ class TestMQTTClientListen:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Drop messages when processing queue is full."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics = {"test/topic": SampleInputEvent}
         client._received_message_queue = asyncio.Queue(maxsize=1)
 
@@ -499,7 +477,7 @@ class TestMQTTClientProcessQueue:
         self, mqtt_settings, event_bus, mock_aiomqtt_client
     ):
         """Test process_queue returns immediately with no subscriptions."""
-        client = MQTTClient(mqtt_settings, event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics = {}
 
         # Should return immediately without blocking
@@ -510,7 +488,7 @@ class TestMQTTClientProcessQueue:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Test process_queue handles exceptions in message handling."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
         # Add a message to the queue
@@ -543,7 +521,7 @@ class TestMQTTClientHandleMessageErrors:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Invalid payload type should not emit events."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
         mock_message = MagicMock()
@@ -559,7 +537,7 @@ class TestMQTTClientHandleMessageErrors:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """Validation errors are handled without raising."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
         mock_message = MagicMock()
@@ -575,7 +553,7 @@ class TestMQTTClientHandleMessageErrors:
         self, mqtt_settings, mock_event_bus, mock_aiomqtt_client
     ):
         """JSON null payload should be rejected as invalid input type."""
-        client = MQTTClient(mqtt_settings, mock_event_bus)
+        client = MQTTClient(mqtt_settings)
         client._subscribed_topics["test/topic"] = SampleInputEvent
 
         mock_message = MagicMock()

--- a/tests/core/timer/test_timer.py
+++ b/tests/core/timer/test_timer.py
@@ -44,18 +44,17 @@ def calculate_timestamp_for_interval(base_interval: int, target_interval: int) -
 class TestTimer:
     """Tests for Timer class."""
 
-    def test_timer_initialization(self, event_bus):
-        """Test Timer initializes with event_bus and base_interval."""
-        timer = Timer(event_bus, 5)
+    def test_timer_initialization(self):
+        """Test Timer initializes with base_interval."""
+        timer = Timer(5)
 
-        assert timer.event_bus is event_bus
         assert timer.base_interval == 5
 
     @pytest.mark.asyncio
     async def test_timer_loop_emits_base_event_on_interval(self, mock_event_bus):
         """Test that timer loop emits base event at correct interval."""
         base_interval = 5
-        timer = Timer(mock_event_bus, base_interval)
+        timer = Timer(base_interval)
 
         with patch("solaredge2mqtt.core.timer.datetime") as mock_datetime:
             # Use a timestamp divisible by base_interval
@@ -74,7 +73,7 @@ class TestTimer:
     async def test_timer_loop_emits_1min_event(self, mock_event_bus):
         """Test that timer loop emits 1 min event at correct interval."""
         base_interval = 5
-        timer = Timer(mock_event_bus, base_interval)
+        timer = Timer(base_interval)
 
         with patch("solaredge2mqtt.core.timer.datetime") as mock_datetime:
             timestamp = calculate_timestamp_for_interval(base_interval, 60)
@@ -92,7 +91,7 @@ class TestTimer:
     async def test_timer_loop_emits_5min_event(self, mock_event_bus):
         """Test that timer loop emits 5 min event at correct interval."""
         base_interval = 5
-        timer = Timer(mock_event_bus, base_interval)
+        timer = Timer(base_interval)
 
         with patch("solaredge2mqtt.core.timer.datetime") as mock_datetime:
             timestamp = calculate_timestamp_for_interval(base_interval, 300)
@@ -110,7 +109,7 @@ class TestTimer:
     async def test_timer_loop_emits_10min_event(self, mock_event_bus):
         """Test that timer loop emits 10 min event at correct interval."""
         base_interval = 5
-        timer = Timer(mock_event_bus, base_interval)
+        timer = Timer(base_interval)
 
         with patch("solaredge2mqtt.core.timer.datetime") as mock_datetime:
             timestamp = calculate_timestamp_for_interval(base_interval, 600)
@@ -128,7 +127,7 @@ class TestTimer:
     async def test_timer_loop_emits_15min_event(self, mock_event_bus):
         """Test that timer loop emits 15 min event at correct interval."""
         base_interval = 5
-        timer = Timer(mock_event_bus, base_interval)
+        timer = Timer(base_interval)
 
         with patch("solaredge2mqtt.core.timer.datetime") as mock_datetime:
             # For base_interval=5, timestamp 919 reaches final 900-divisible check
@@ -146,7 +145,7 @@ class TestTimer:
     async def test_timer_loop_does_not_emit_when_not_on_interval(self, mock_event_bus):
         """Test that timer doesn't emit base event when not on interval."""
         base_interval = 5
-        timer = Timer(mock_event_bus, base_interval)
+        timer = Timer(base_interval)
 
         with patch("solaredge2mqtt.core.timer.datetime") as mock_datetime:
             # Use a timestamp NOT divisible by base_interval
@@ -165,7 +164,7 @@ class TestTimer:
     async def test_timer_with_different_base_intervals(self, mock_event_bus):
         """Test timer works with different base intervals."""
         for interval in [1, 5, 10, 15]:
-            timer = Timer(mock_event_bus, interval)
+            timer = Timer(interval)
 
             with patch("solaredge2mqtt.core.timer.datetime") as mock_datetime:
                 # Use a timestamp that is a multiple of the base interval

--- a/tests/services/energy/test_service.py
+++ b/tests/services/energy/test_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from solaredge2mqtt.core.exceptions import InvalidDataException
+from solaredge2mqtt.core.influxdb.events import InfluxDBAggregatedEvent
 from solaredge2mqtt.core.mqtt.events import MQTTPublishEvent
 from solaredge2mqtt.services.energy import EnergyService
 from solaredge2mqtt.services.energy.events import EnergyReadEvent
@@ -32,19 +33,19 @@ class TestEnergyServiceInit:
 
     def test_init(self, mock_energy_settings, mock_event_bus, mock_influxdb):
         """Test EnergyService initialization."""
-        service = EnergyService(mock_energy_settings, mock_event_bus, mock_influxdb)
+        service = EnergyService(mock_energy_settings, mock_influxdb)
 
         assert service.settings is mock_energy_settings
-        assert service.event_bus is mock_event_bus
         assert service.influxdb is mock_influxdb
+        mock_event_bus.register.assert_called_once_with(service)
 
     def test_subscribes_to_events(
         self, mock_energy_settings, mock_event_bus, mock_influxdb
     ):
         """Test EnergyService subscribes to influxdb aggregated event."""
-        EnergyService(mock_energy_settings, mock_event_bus, mock_influxdb)
+        EnergyService(mock_energy_settings, mock_influxdb)
 
-        mock_event_bus.subscribe.assert_called()
+        mock_event_bus.register.assert_called_once()
 
 
 class TestEnergyServiceReadHistoricEnergy:
@@ -57,7 +58,7 @@ class TestEnergyServiceReadHistoricEnergy:
         """Test successful energy reading."""
         from datetime import datetime, timezone
 
-        service = EnergyService(mock_energy_settings, mock_event_bus, mock_influxdb)
+        service = EnergyService(mock_energy_settings, mock_influxdb)
 
         # Mock query result with valid record data
         mock_record = {
@@ -85,7 +86,7 @@ class TestEnergyServiceReadHistoricEnergy:
         # Return data for first period, None for others to test both paths
         mock_influxdb.query_timeunit.return_value = [mock_record]
 
-        await service.read_historic_energy(None)
+        await service.read_historic_energy(InfluxDBAggregatedEvent())
 
         # Should emit events for each period that returned data
         assert mock_event_bus.emit.call_count > 0
@@ -95,7 +96,7 @@ class TestEnergyServiceReadHistoricEnergy:
         self, mock_energy_settings, mock_event_bus, mock_influxdb
     ):
         """Test reading energy with no data for LAST query type."""
-        service = EnergyService(mock_energy_settings, mock_event_bus, mock_influxdb)
+        service = EnergyService(mock_energy_settings, mock_influxdb)
 
         # Return None for all queries
         mock_influxdb.query_timeunit.return_value = None
@@ -103,7 +104,7 @@ class TestEnergyServiceReadHistoricEnergy:
         # Should not raise for LAST query type - just skip
         # But will raise for other query types
         with pytest.raises(InvalidDataException):
-            await service.read_historic_energy(None)
+            await service.read_historic_energy(InfluxDBAggregatedEvent())
 
     @pytest.mark.asyncio
     async def test_read_historic_energy_emits_events(
@@ -112,7 +113,7 @@ class TestEnergyServiceReadHistoricEnergy:
         """Test read_historic_energy emits correct events."""
         from datetime import datetime, timezone
 
-        service = EnergyService(mock_energy_settings, mock_event_bus, mock_influxdb)
+        service = EnergyService(mock_energy_settings, mock_influxdb)
 
         mock_record = {
             "_start": datetime(2024, 1, 1, tzinfo=timezone.utc),
@@ -137,7 +138,7 @@ class TestEnergyServiceReadHistoricEnergy:
         }
         mock_influxdb.query_timeunit.return_value = [mock_record]
 
-        await service.read_historic_energy(None)
+        await service.read_historic_energy(InfluxDBAggregatedEvent())
 
         # Check that EnergyReadEvent and MQTTPublishEvent were emitted
         emit_calls = mock_event_bus.emit.call_args_list

--- a/tests/services/forecast/test_service.py
+++ b/tests/services/forecast/test_service.py
@@ -10,7 +10,6 @@ from pandas import DataFrame
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
 
-from solaredge2mqtt.core.events import EventBus
 from solaredge2mqtt.core.exceptions import InvalidDataException
 from solaredge2mqtt.core.settings.models import LocationSettings
 from solaredge2mqtt.services.forecast.models import ForecasterType
@@ -75,8 +74,7 @@ class MockWeatherData:
 
     def __init__(self, hourly=None):
         if hourly is None:
-            hourly = [MockOpenWeatherMapForecastData(
-                hour=i) for i in range(48)]
+            hourly = [MockOpenWeatherMapForecastData(hour=i) for i in range(48)]
         self.hourly = hourly
 
 
@@ -87,14 +85,12 @@ class TestForecastServiceInit:
         """Test ForecastService initialization."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         assert service.settings == settings
         assert service.location == location
-        assert service.event_bus == event_bus
         assert service.influxdb == influxdb
         assert service.last_weather_forecast is None
         assert service.last_hour_forecast is None
@@ -103,29 +99,24 @@ class TestForecastServiceInit:
         """Test ForecastService creates forecasters for each type."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         assert ForecasterType.ENERGY in service.forecasters
         assert ForecasterType.POWER in service.forecasters
-        assert isinstance(
-            service.forecasters[ForecasterType.ENERGY], Forecaster)
-        assert isinstance(
-            service.forecasters[ForecasterType.POWER], Forecaster)
+        assert isinstance(service.forecasters[ForecasterType.ENERGY], Forecaster)
+        assert isinstance(service.forecasters[ForecasterType.POWER], Forecaster)
 
-    def test_forecast_service_subscribes_events(self):
-        """Test ForecastService subscribes to events."""
+    def test_forecast_service_subscribes_events(self, mock_event_bus):
+        """Test ForecastService registers event handlers."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
-        # Check that subscribe was called for both event types
-        assert event_bus.subscribe.call_count == 2
+        mock_event_bus.register.assert_called_once_with(service)
 
 
 class TestForecastServiceWeatherUpdate:
@@ -136,10 +127,9 @@ class TestForecastServiceWeatherUpdate:
         """Test weather_update stores the weather forecast."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         weather_data = MockWeatherData()
         event = MagicMock(spec=WeatherUpdateEvent)
@@ -154,10 +144,9 @@ class TestForecastServiceWeatherUpdate:
         """Test weather_update initializes last_hour_forecast dict."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         weather_data = MockWeatherData()
         event = MagicMock(spec=WeatherUpdateEvent)
@@ -173,10 +162,9 @@ class TestForecastServiceWeatherUpdate:
         """Test weather_update stores current hour's forecast."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         # Use the current UTC datetime to construct forecast data so the
         # local-hour conversion inside the service matches what we expect.
@@ -206,10 +194,9 @@ class TestForecastServiceWeatherUpdate:
         """Test weather_update removes old hour forecasts."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         # Pre-populate with old hours
         service.last_hour_forecast = {
@@ -229,8 +216,7 @@ class TestForecastServiceWeatherUpdate:
             mock_now.hour = 12
             mock_dt.now.return_value = mock_now
             mock_now.astimezone.return_value = mock_now
-            mock_now.__sub__ = lambda self, x: MagicMock(
-                spec=["hour"], hour=11)
+            mock_now.__sub__ = lambda self, x: MagicMock(spec=["hour"], hour=11)
 
             await service.weather_update(event)
 
@@ -244,10 +230,9 @@ class TestForecastServiceWeatherUpdate:
         """weather_update should trigger training write for previous hour."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
         service.write_new_training_data = AsyncMock()
 
         hourly_data = [MockOpenWeatherMapForecastData(hour=11)]
@@ -267,8 +252,7 @@ class TestForecastServiceWeatherUpdate:
 
             await service.weather_update(event)
 
-        service.write_new_training_data.assert_awaited_once_with(
-            hourly_data[0])
+        service.write_new_training_data.assert_awaited_once_with(hourly_data[0])
 
 
 class TestForecastServiceWriteTrainingData:
@@ -279,7 +263,6 @@ class TestForecastServiceWriteTrainingData:
         """Test write_new_training_data writes to InfluxDB."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
         influxdb.query_first = AsyncMock(
             return_value={
@@ -289,7 +272,7 @@ class TestForecastServiceWriteTrainingData:
         )
         influxdb.write_point = AsyncMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         weather_forecast = MockOpenWeatherMapForecastData(hour=11)
 
@@ -309,11 +292,10 @@ class TestForecastServiceWriteTrainingData:
         """Test write_new_training_data raises when production data missing."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
         influxdb.query_first = AsyncMock(return_value=None)
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         weather_forecast = MockOpenWeatherMapForecastData(hour=11)
 
@@ -327,7 +309,6 @@ class TestForecastServiceWriteTrainingData:
         """Test write_new_training_data triggers training at minute 20."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
         influxdb.query_first = AsyncMock(
             return_value={
@@ -338,7 +319,7 @@ class TestForecastServiceWriteTrainingData:
         influxdb.write_point = AsyncMock()
         influxdb.query_dataframe = AsyncMock(return_value=DataFrame())
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
         service.train = AsyncMock()
 
         weather_forecast = MockOpenWeatherMapForecastData(hour=11)
@@ -363,10 +344,9 @@ class TestForecastServiceForecastLoop:
         """Test forecast_loop raises when no weather forecast available."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         # Mock forecasters as trained
         for forecaster in service.forecasters.values():
@@ -382,12 +362,11 @@ class TestForecastServiceForecastLoop:
         """Test forecast_loop triggers training when models not trained."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
         influxdb.query_dataframe = AsyncMock(return_value=DataFrame())
         influxdb.write_points = AsyncMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         # Create mock train that sets up forecasters as trained
         def mock_train_impl():
@@ -417,27 +396,25 @@ class TestForecastServicePublishForecast:
     """Tests for ForecastService publish_forecast method."""
 
     @pytest.mark.asyncio
-    async def test_publish_forecast_empty_data(self):
+    async def test_publish_forecast_empty_data(self, mock_event_bus):
         """Test publish_forecast does nothing with empty data."""
         settings = ForecastSettings(enable=True, retain=True)
         location = MockLocationSettings()
-        event_bus = AsyncMock(spec=EventBus)
         influxdb = AsyncMock()
         influxdb.query_dataframe = AsyncMock(return_value=DataFrame())
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         await service.publish_forecast()
 
         # No events should be emitted when data is empty
-        event_bus.emit.assert_not_called()
+        mock_event_bus.emit.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_publish_forecast_emits_events(self):
+    async def test_publish_forecast_emits_events(self, mock_event_bus):
         """Test publish_forecast emits MQTT and Forecast events."""
         settings = ForecastSettings(enable=True, retain=True)
         location = MockLocationSettings()
-        event_bus = AsyncMock(spec=EventBus)
         influxdb = AsyncMock()
 
         # Create mock forecast data
@@ -455,19 +432,18 @@ class TestForecastServicePublishForecast:
 
         influxdb.query_dataframe = AsyncMock(return_value=forecast_data)
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         await service.publish_forecast()
 
         # Should emit 2 events (MQTTPublishEvent and ForecastEvent)
-        assert event_bus.emit.call_count == 2
+        assert mock_event_bus.emit.call_count == 2
 
     @pytest.mark.asyncio
     async def test_publish_forecast_raises_on_invalid_time(self):
         """publish_forecast should reject non-datetime time values."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = AsyncMock(spec=EventBus)
         influxdb = AsyncMock()
 
         forecast_data = DataFrame(
@@ -479,7 +455,7 @@ class TestForecastServicePublishForecast:
         )
         influxdb.query_dataframe = AsyncMock(return_value=forecast_data)
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
         with patch.object(
             forecast_data,
             "iterrows",
@@ -504,7 +480,6 @@ class TestForecastServicePublishForecast:
         """publish_forecast should reject non-numeric power values."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = AsyncMock(spec=EventBus)
         influxdb = AsyncMock()
 
         forecast_data = DataFrame(
@@ -516,7 +491,7 @@ class TestForecastServicePublishForecast:
         )
         influxdb.query_dataframe = AsyncMock(return_value=forecast_data)
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
         with pytest.raises(InvalidDataException):
             await service.publish_forecast()
 
@@ -525,7 +500,6 @@ class TestForecastServicePublishForecast:
         """publish_forecast should reject non-numeric energy values."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = AsyncMock(spec=EventBus)
         influxdb = AsyncMock()
 
         forecast_data = DataFrame(
@@ -537,7 +511,7 @@ class TestForecastServicePublishForecast:
         )
         influxdb.query_dataframe = AsyncMock(return_value=forecast_data)
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
         with pytest.raises(InvalidDataException):
             await service.publish_forecast()
 
@@ -637,8 +611,7 @@ class TestForecasterTrain:
                 "weather_main": ["Clear"] * 100,
             }
         )
-        data["time"] = data["time"].astype(
-            pd.DatetimeTZDtype(unit="ns", tz=LOCAL_TZ))
+        data["time"] = data["time"].astype(pd.DatetimeTZDtype(unit="ns", tz=LOCAL_TZ))
 
         forecaster.train(data)
 
@@ -659,8 +632,7 @@ class TestForecasterTrain:
                 "energy": [100.0 + i for i in range(70)],
             }
         )
-        data["time"] = data["time"].astype(
-            pd.DatetimeTZDtype(unit="ns", tz=LOCAL_TZ))
+        data["time"] = data["time"].astype(pd.DatetimeTZDtype(unit="ns", tz=LOCAL_TZ))
 
         prepared_pipeline = MagicMock()
         tuned_pipeline = MagicMock()
@@ -702,8 +674,7 @@ class TestForecasterTrain:
                 "energy": [100.0 + i for i in range(70)],
             }
         )
-        data["time"] = data["time"].astype(
-            pd.DatetimeTZDtype(unit="ns", tz=LOCAL_TZ))
+        data["time"] = data["time"].astype(pd.DatetimeTZDtype(unit="ns", tz=LOCAL_TZ))
 
         prepared_pipeline = MagicMock()
         prepared_pipeline.named_steps = {
@@ -951,11 +922,10 @@ class TestForecastServiceWritePeriodsToInfluxDB:
         """Test _write_periods_to_influxdb creates points."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
         influxdb.write_points = AsyncMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         periods = DataFrame(
             {
@@ -979,10 +949,9 @@ class TestForecastServiceWritePeriodsToInfluxDB:
         """_write_periods_to_influxdb should reject non-datetime values."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
         periods = DataFrame({"time": ["invalid"], "energy": [1.5]})
 
         with pytest.raises(InvalidDataException):
@@ -997,7 +966,6 @@ class TestForecastServiceTrain:
         """Test train queries training data from InfluxDB."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
 
         # Create mock dataframe
@@ -1015,7 +983,7 @@ class TestForecastServiceTrain:
 
         influxdb.query_dataframe = AsyncMock(return_value=mock_df)
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         # Mock the training method to avoid actual ML training
         with patch.object(service, "training"):
@@ -1027,9 +995,8 @@ class TestForecastServiceTrain:
         """training should dispatch data to each forecaster."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = MagicMock()
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         first = MagicMock()
         second = MagicMock()
@@ -1053,7 +1020,6 @@ class TestForecastServiceAddLastHourPvProduction:
         """Test add_last_hour_pv_production adds production data."""
         settings = ForecastSettings(enable=True)
         location = MockLocationSettings()
-        event_bus = MagicMock(spec=EventBus)
         influxdb = AsyncMock()
         influxdb.query_first = AsyncMock(
             return_value={
@@ -1062,7 +1028,7 @@ class TestForecastServiceAddLastHourPvProduction:
             }
         )
 
-        service = ForecastService(settings, location, event_bus, influxdb)
+        service = ForecastService(settings, location, influxdb)
 
         training_data = {"temp": 25.0, "clouds": 20}
 
@@ -1071,5 +1037,4 @@ class TestForecastServiceAddLastHourPvProduction:
         # Power is rounded using Python's built-in round()
         assert result[ForecasterType.POWER.target_column] == round(1234.5)
         # Energy is rounded to 2 decimal places
-        assert result[ForecasterType.ENERGY.target_column] == pytest.approx(
-            1.57)
+        assert result[ForecasterType.ENERGY.target_column] == pytest.approx(1.57)

--- a/tests/services/homeassistant/test_service.py
+++ b/tests/services/homeassistant/test_service.py
@@ -22,6 +22,7 @@ from solaredge2mqtt.services.homeassistant.service import (
 )
 from solaredge2mqtt.services.modbus.events import ModbusUnitsReadEvent
 from solaredge2mqtt.services.powerflow.events import PowerflowGeneratedEvent
+from solaredge2mqtt.services.wallbox.events import WallboxReadEvent
 
 
 @pytest.fixture
@@ -54,17 +55,39 @@ class TestHomeAssistantDiscoveryInit:
 
     def test_init(self, mock_service_settings, mock_event_bus):
         """Test HomeAssistantDiscovery initialization."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         assert discovery.settings is mock_service_settings
-        assert discovery.event_bus is mock_event_bus
+        mock_event_bus.register.assert_called_once_with(discovery)
         assert discovery._status_topic == "homeassistant/status"
 
     def test_subscribes_to_events(self, mock_service_settings, mock_event_bus):
         """Test HomeAssistantDiscovery subscribes to events."""
-        HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        HomeAssistantDiscovery(mock_service_settings)
 
-        assert mock_event_bus.subscribe.call_count >= 4
+        mock_event_bus.register.assert_called_once()
+
+
+class TestHomeAssistantDiscoveryEventSubscriptions:
+    """Tests for explicit HomeAssistantDiscovery event subscription contract."""
+
+    def test_subscribed_event_contract(self):
+        """Class listeners must stay bound to the expected event types."""
+        expected_subscriptions = {
+            "component_discovery": {
+                ForecastEvent,
+                EnergyReadEvent,
+                WallboxReadEvent,
+            },
+            "units_discovery": {ModbusUnitsReadEvent},
+            "powerflow_discovery": {PowerflowGeneratedEvent},
+            "homeassistant_status": {HomeAssistantStatusEvent},
+        }
+
+        for method_name, expected_events in expected_subscriptions.items():
+            method = getattr(HomeAssistantDiscovery, method_name)
+            subscribed_events = set(getattr(method, "_event_subscriptions", []))
+            assert subscribed_events == expected_events
 
 
 class TestHomeAssistantDiscoveryAsyncInit:
@@ -75,7 +98,7 @@ class TestHomeAssistantDiscoveryAsyncInit:
         self, mock_service_settings, mock_event_bus
     ):
         """Test async_init subscribes to HA status topic."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         await discovery.async_init()
 
@@ -91,7 +114,7 @@ class TestHomeAssistantDiscoveryStateTopic:
 
     def test_state_topic_without_name(self, mock_service_settings, mock_event_bus):
         """Test state_topic without name."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         result = discovery.state_topic("powerflow")
 
@@ -99,7 +122,7 @@ class TestHomeAssistantDiscoveryStateTopic:
 
     def test_state_topic_with_name(self, mock_service_settings, mock_event_bus):
         """Test state_topic with name."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         result = discovery.state_topic("modbus/meter", "meter0")
 
@@ -168,7 +191,7 @@ class TestHomeAssistantDiscoveryComponentDiscovery:
         self, mock_service_settings, mock_event_bus
     ):
         """Test component_discovery with forecast event."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
         discovery.publish_component = AsyncMock()
 
         mock_component = MagicMock()
@@ -189,7 +212,7 @@ class TestHomeAssistantDiscoveryComponentDiscovery:
         """Test component_discovery with Energy auto_discovery enabled."""
         from solaredge2mqtt.services.energy.models import HistoricEnergy
 
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
         discovery.publish_component = AsyncMock()
 
         # Create mock component with period info
@@ -214,7 +237,7 @@ class TestHomeAssistantDiscoveryComponentDiscovery:
         """Test component_discovery with EnergyReadEvent already seen."""
         from solaredge2mqtt.services.energy.models import HistoricEnergy
 
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
         discovery.publish_component = AsyncMock()
 
         # Create mock component with period info
@@ -242,7 +265,7 @@ class TestHomeAssistantDiscoveryComponentDiscovery:
         """Test component_discovery with Energy auto_discovery disabled."""
         from solaredge2mqtt.services.energy.models import HistoricEnergy
 
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
         discovery.publish_component = AsyncMock()
 
         # Create mock component with period info
@@ -267,7 +290,7 @@ class TestHomeAssistantDiscoveryUnitsDiscovery:
     @pytest.mark.asyncio
     async def test_units_discovery(self, mock_service_settings, mock_event_bus):
         """Test units_discovery with modbus units."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
         discovery.publish_component = AsyncMock()
 
         # Create mock inverter
@@ -300,7 +323,7 @@ class TestHomeAssistantDiscoveryPowerflowDiscovery:
     @pytest.mark.asyncio
     async def test_powerflow_discovery(self, mock_service_settings, mock_event_bus):
         """Test powerflow_discovery."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
         discovery.publish_component = AsyncMock()
 
         mock_powerflow = MagicMock()
@@ -322,7 +345,7 @@ class TestHomeAssistantDiscoveryStatus:
         self, mock_service_settings, mock_event_bus
     ):
         """Test handling HA status online event."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         # Add some cached entities
         mock_entity = MagicMock()
@@ -344,7 +367,7 @@ class TestHomeAssistantDiscoveryStatus:
         self, mock_service_settings, mock_event_bus
     ):
         """Test ignoring status events from wrong topic."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         mock_input = MagicMock(spec=HomeAssistantStatusInput)
         mock_input.status = HomeAssistantStatus.ONLINE
@@ -361,7 +384,7 @@ class TestHomeAssistantDiscoveryStatus:
         self, mock_service_settings, mock_event_bus
     ):
         """Test no resend when HA status is not ONLINE on status topic."""
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         mock_input = MagicMock(spec=HomeAssistantStatusInput)
         mock_input.status = None
@@ -381,7 +404,7 @@ class TestHomeAssistantDiscoveryPublishComponent:
         """Test publish_component creates and publishes entities."""
         from solaredge2mqtt.services.powerflow.models import Powerflow
 
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         # Create mock component
         mock_component = MagicMock(spec=Powerflow)
@@ -415,7 +438,7 @@ class TestHomeAssistantDiscoveryPublishComponent:
         # Disable grid status check to test filtering
         mock_service_settings.modbus.check_grid_status = False
 
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         # Create mock inverter
         mock_inverter = MagicMock(spec=ModbusInverter)
@@ -456,7 +479,7 @@ class TestHomeAssistantDiscoveryPublishComponent:
         # Disable advanced power controls
         mock_service_settings.modbus.advanced_power_controls_enabled = False
 
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         mock_inverter = MagicMock(spec=ModbusInverter)
         mock_inverter.mqtt_topic.return_value = "modbus/inverter"
@@ -492,7 +515,7 @@ class TestHomeAssistantDiscoveryPublishComponent:
         mock_service_settings.is_prices_configured = True
         mock_service_settings.prices.currency = "USD"
 
-        discovery = HomeAssistantDiscovery(mock_service_settings, mock_event_bus)
+        discovery = HomeAssistantDiscovery(mock_service_settings)
 
         mock_component = MagicMock()
         mock_component.mqtt_topic.return_value = "energy"

--- a/tests/services/modbus/test_control.py
+++ b/tests/services/modbus/test_control.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from solaredge2mqtt.core.events import EventBus
 from solaredge2mqtt.core.mqtt.events import MQTTReceivedEvent
 from solaredge2mqtt.services.modbus.control import ModbusAdvancedControl
 from solaredge2mqtt.services.modbus.settings import AdvancedControlsSettings
@@ -21,44 +20,37 @@ def mock_settings():
     return mock_settings
 
 
-@pytest.fixture
-def event_bus():
-    """Create an event bus."""
-    return EventBus()
-
-
 class TestModbusAdvancedControl:
     """Tests for ModbusAdvancedControl class."""
 
-    def test_init_without_followers(self, mock_settings, event_bus):
+    def test_init_without_followers(self, mock_settings, mock_event_bus):
         """Test initialization without followers."""
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         assert control.settings == mock_settings.modbus
-        assert control.event_bus == event_bus
         assert "modbus" in control.topic_prefix
         assert "inverter" in control.topic_prefix
 
-    def test_init_with_followers(self, mock_settings, event_bus):
+    def test_init_with_followers(self, mock_settings, mock_event_bus):
         """Test initialization with followers."""
         mock_settings.modbus.has_followers = True
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         assert control.settings == mock_settings.modbus
         assert "leader" in control.topic_prefix
 
-    def test_topic_prefix_construction(self, mock_settings, event_bus):
+    def test_topic_prefix_construction(self, mock_settings, mock_event_bus):
         """Test topic prefix is correctly constructed."""
         mock_settings.mqtt.topic_prefix = "my_prefix"
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         assert control.topic_prefix.startswith("my_prefix/")
 
     @pytest.mark.asyncio
-    async def test_async_init_disabled(self, mock_settings, event_bus):
+    async def test_async_init_disabled(self, mock_settings, mock_event_bus):
         """Test async_init with disabled controls."""
         mock_settings.modbus.advanced_power_controls = AdvancedControlsSettings.DISABLED
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         await control.async_init()
 
@@ -66,10 +58,10 @@ class TestModbusAdvancedControl:
         # (test passes if no exceptions are raised)
 
     @pytest.mark.asyncio
-    async def test_async_init_enable(self, mock_settings, event_bus):
+    async def test_async_init_enable(self, mock_settings, mock_event_bus):
         """Test async_init with enabled controls."""
         mock_settings.modbus.advanced_power_controls = AdvancedControlsSettings.ENABLED
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         # Mock the methods to avoid actual operations
         control.enable_advanced_power_control = AsyncMock()
@@ -81,10 +73,10 @@ class TestModbusAdvancedControl:
         control.subscribe_topics.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_async_init_disable(self, mock_settings, event_bus):
+    async def test_async_init_disable(self, mock_settings, mock_event_bus):
         """Test async_init with disable controls."""
         mock_settings.modbus.advanced_power_controls = AdvancedControlsSettings.DISABLE
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         # Mock the method to avoid actual operations
         control.disable_advanced_control_settings = AsyncMock()
@@ -94,52 +86,46 @@ class TestModbusAdvancedControl:
         control.disable_advanced_control_settings.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_enable_advanced_power_control(self, mock_settings, event_bus):
+    async def test_enable_advanced_power_control(self, mock_settings, mock_event_bus):
         """Test enabling advanced power control."""
-        control = ModbusAdvancedControl(mock_settings, event_bus)
-
-        # Mock emit to verify events are emitted
-        control.event_bus.emit = AsyncMock()
+        control = ModbusAdvancedControl(mock_settings)
 
         await control.enable_advanced_power_control()
 
         # Should not emit any events by default (no-op in current implementation)
+        mock_event_bus.emit.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_disable_advanced_control_settings(self, mock_settings, event_bus):
+    async def test_disable_advanced_control_settings(
+        self, mock_settings, mock_event_bus
+    ):
         """Test disabling advanced control settings."""
-        control = ModbusAdvancedControl(mock_settings, event_bus)
-
-        # Mock emit to verify events are emitted
-        control.event_bus.emit = AsyncMock()
+        control = ModbusAdvancedControl(mock_settings)
 
         await control.disable_advanced_control_settings()
 
         # Should emit 3 events
-        assert control.event_bus.emit.call_count == 3
+        assert mock_event_bus.emit.call_count == 3
 
     @pytest.mark.asyncio
-    async def test_subscribe_events_when_enabled(self, mock_settings, event_bus):
+    async def test_subscribe_events_when_enabled(self, mock_settings, mock_event_bus):
         """Test _subscribe_events when controls are enabled."""
         mock_settings.modbus.advanced_power_controls_enabled = True
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        ModbusAdvancedControl(mock_settings)
 
-        # Verify that event subscription was called
-        # (event_bus.subscribe should have been called)
-        assert control.event_bus is not None
+        mock_event_bus.subscribe.assert_called_once()
 
-    def test_subscribe_events_when_disabled(self, mock_settings, event_bus):
+    def test_subscribe_events_when_disabled(self, mock_settings, mock_event_bus):
         """Test _subscribe_events when controls are disabled."""
         mock_settings.modbus.advanced_power_controls_enabled = False
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        ModbusAdvancedControl(mock_settings)
 
-        # Should not raise any errors
-        assert control.event_bus is not None
+        mock_event_bus.subscribe.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_handle_mqtt_received_event(self, mock_settings, event_bus):
+    async def test_handle_mqtt_received_event(self, mock_settings, mock_event_bus):
         """Test handling MQTT received event."""
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         # Create a mock event
         mock_event = MagicMock(spec=MQTTReceivedEvent)
@@ -149,9 +135,9 @@ class TestModbusAdvancedControl:
         await control.handle_mqtt_received_event(mock_event)
 
     @pytest.mark.asyncio
-    async def test_subscribe_topics_with_fields(self, mock_settings, event_bus):
+    async def test_subscribe_topics_with_fields(self, mock_settings, mock_event_bus):
         """subscribe_topics should iterate schema fields and log topic usage."""
-        control = ModbusAdvancedControl(mock_settings, event_bus)
+        control = ModbusAdvancedControl(mock_settings)
 
         with patch(
             "solaredge2mqtt.services.modbus.control.ModbusInverter.parse_schema",

--- a/tests/services/modbus/test_service.py
+++ b/tests/services/modbus/test_service.py
@@ -65,24 +65,24 @@ class TestModbusInit:
 
     def test_modbus_init(self, mock_service_settings, mock_event_bus):
         """Test Modbus initialization."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
 
         assert modbus.settings is mock_service_settings.modbus
-        assert modbus.event_bus is mock_event_bus
         assert modbus._client is None
         assert modbus._initialized is False
+        mock_event_bus.register.assert_called_once_with(modbus)
 
     def test_modbus_subscribes_to_events(self, mock_service_settings, mock_event_bus):
-        """Test Modbus subscribes to write events."""
-        Modbus(mock_service_settings, mock_event_bus)
+        """Test Modbus registers for decorated event handlers."""
+        Modbus(mock_service_settings)
 
-        mock_event_bus.subscribe.assert_called()
+        mock_event_bus.register.assert_called_once()
 
     def test_client_property_raises_when_uninitialized(
         self, mock_service_settings, mock_event_bus
     ):
         """Client property should raise before async_init."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
 
         with pytest.raises(RuntimeError):
             _ = modbus.client
@@ -96,7 +96,7 @@ class TestModbusAsyncInit:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test async_init initializes client and detects devices."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus.detect_devices = AsyncMock()
         modbus.check_readable_registers = AsyncMock()
 
@@ -115,7 +115,7 @@ class TestModbusAsyncInit:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """async_init should warn when unreadable registers were blocked."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus.detect_devices = AsyncMock()
         modbus.check_readable_registers = AsyncMock()
         modbus._block_unreadable = {40000}
@@ -135,7 +135,7 @@ class TestModbusAsyncInit:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """detect_devices should read inverter info and run detectors."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
         modbus.read_device_info = AsyncMock(return_value={"meter0": 1})
         modbus._detect_meters = AsyncMock()
@@ -152,7 +152,7 @@ class TestModbusAsyncInit:
         self, mock_service_settings, mock_event_bus
     ):
         """check_readable_registers should iterate all configured units."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._get_raw_data = AsyncMock(return_value=({}, {}, {}))
 
         with patch("solaredge2mqtt.services.modbus.AsyncModbusTcpClient") as client_cls:
@@ -168,7 +168,7 @@ class TestModbusAsyncInit:
         self, mock_service_settings, mock_event_bus
     ):
         """read_device_info stores ModbusDeviceInfo in internal map."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._device_info = {"leader": {}}
         modbus._read_from_modbus = AsyncMock(return_value={"c_model": "X"})
 
@@ -199,7 +199,7 @@ class TestModbusRawDataCollection:
         mock_service_settings.modbus.check_grid_status = True
         mock_service_settings.modbus.advanced_power_controls_enabled = True
 
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._device_info = {
             "leader": {
                 "inverter": MagicMock(),
@@ -258,7 +258,7 @@ class TestModbusRawDataCollection:
         mock_service_settings.modbus.check_grid_status = False
         mock_service_settings.modbus.advanced_power_controls_enabled = False
 
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._device_info = {"leader": {"inverter": MagicMock()}}
 
         with patch(
@@ -278,7 +278,7 @@ class TestModbusRawDataCollection:
         self, mock_service_settings, mock_event_bus
     ):
         """_block_register should not add blocks after initialization."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._initialized = True
 
         modbus._block_register(40000)
@@ -294,7 +294,7 @@ class TestModbusReadFromModbus:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test successful modbus read."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
 
         # Mock register bundle
@@ -319,7 +319,7 @@ class TestModbusReadFromModbus:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Successful read should also work when service is already initialized."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
         modbus._initialized = True
 
@@ -342,7 +342,7 @@ class TestModbusReadFromModbus:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test modbus read error blocks register."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
         modbus._initialized = False
 
@@ -365,7 +365,7 @@ class TestModbusReadFromModbus:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test modbus exception blocks register."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
         modbus._initialized = False
 
@@ -388,7 +388,7 @@ class TestModbusReadFromModbus:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test modbus read skips blocked registers."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
         modbus._block_unreadable = {40000}
 
@@ -411,7 +411,7 @@ class TestModbusGetData:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test get_data returns units."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
         modbus._initialized = True
 
@@ -456,7 +456,7 @@ class TestModbusGetData:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test get_data raises on KeyError."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
         modbus._initialized = True
         modbus._device_info = {}
@@ -475,7 +475,7 @@ class TestModbusMappers:
         self, mock_service_settings, mock_event_bus, mock_device_info
     ):
         """Test _map_inverter creates ModbusInverter."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._device_info = {"leader": {"inverter": mock_device_info}}
 
         with patch(
@@ -496,7 +496,7 @@ class TestModbusMappers:
 
     def test_map_meters(self, mock_service_settings, mock_event_bus, mock_device_info):
         """Test _map_meters creates ModbusMeter dict."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._device_info = {"leader": {"meter0": mock_device_info}}
 
         with patch("solaredge2mqtt.services.modbus.ModbusMeter") as mock_meter_class:
@@ -515,7 +515,7 @@ class TestModbusMappers:
         self, mock_service_settings, mock_event_bus, mock_device_info
     ):
         """Test _map_batteries creates ModbusBattery dict."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._device_info = {"leader": {"battery0": mock_device_info}}
 
         with patch(
@@ -542,7 +542,7 @@ class TestModbusWriteToModbus:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test successful modbus write."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
 
         mock_register = MagicMock()
@@ -559,7 +559,7 @@ class TestModbusWriteToModbus:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test modbus write handles exception."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._client = mock_modbus_client
 
         mock_register = MagicMock()
@@ -581,7 +581,7 @@ class TestModbusHandleWriteEvent:
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test handling write event."""
-        modbus = Modbus(mock_service_settings, mock_event_bus)
+        modbus = Modbus(mock_service_settings)
         modbus._write_to_modbus = AsyncMock()
 
         mock_register = MagicMock()

--- a/tests/services/modbus/test_unicode_exception_handling.py
+++ b/tests/services/modbus/test_unicode_exception_handling.py
@@ -38,12 +38,6 @@ def mock_service_settings():
 
 
 @pytest.fixture
-def mock_event_bus():
-    """Create mock event bus."""
-    return MagicMock()
-
-
-@pytest.fixture
 def mock_modbus_client():
     """Mock pymodbus client."""
     with patch(
@@ -218,7 +212,7 @@ class TestDetectMetersExceptionHandling:
     ):
         """Test that _detect_meters skips meter on exception."""
         with patch("solaredge2mqtt.services.modbus.AsyncModbusTcpClient"):
-            modbus = Modbus(mock_service_settings, mock_event_bus)
+            modbus = Modbus(mock_service_settings)
 
             unit_key = "leader"
             unit_settings = mock_service_settings.modbus.units[unit_key]
@@ -260,7 +254,7 @@ class TestDetectMetersExceptionHandling:
     ):
         """Test that other meters are still processed after exception."""
         with patch("solaredge2mqtt.services.modbus.AsyncModbusTcpClient"):
-            modbus = Modbus(mock_service_settings, mock_event_bus)
+            modbus = Modbus(mock_service_settings)
 
             unit_key = "leader"
             unit_settings = mock_service_settings.modbus.units[unit_key]
@@ -307,7 +301,7 @@ class TestDetectBatteries:
     async def test_detect_batteries_basic(self, mock_service_settings, mock_event_bus):
         """Test basic battery detection."""
         with patch("solaredge2mqtt.services.modbus.AsyncModbusTcpClient"):
-            modbus = Modbus(mock_service_settings, mock_event_bus)
+            modbus = Modbus(mock_service_settings)
 
             unit_key = "leader"
             unit_settings = mock_service_settings.modbus.units[unit_key]

--- a/tests/services/monitoring/test_service.py
+++ b/tests/services/monitoring/test_service.py
@@ -12,6 +12,7 @@ from solaredge2mqtt.core.exceptions import (
     ConfigurationException,
     InvalidDataException,
 )
+from solaredge2mqtt.core.timer.events import Interval15MinTriggerEvent
 from solaredge2mqtt.services.monitoring import MonitoringSite
 from solaredge2mqtt.services.monitoring.models import LogicalModule
 from solaredge2mqtt.services.monitoring.settings import MonitoringSettings
@@ -47,23 +48,23 @@ class TestMonitoringSiteInit:
 
     def test_init(self, mock_monitoring_settings, mock_event_bus, mock_influxdb):
         """Test MonitoringSite initialization."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         assert site.settings is mock_monitoring_settings
-        assert site.event_bus is mock_event_bus
+        mock_event_bus.register.assert_called_once_with(site)
         assert site.influxdb is mock_influxdb
 
     def test_init_without_influxdb(self, mock_monitoring_settings, mock_event_bus):
         """Test MonitoringSite initialization without InfluxDB."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, None)
+        site = MonitoringSite(mock_monitoring_settings, None)
 
         assert site.influxdb is None
 
     def test_subscribes_to_events(self, mock_monitoring_settings, mock_event_bus):
         """Test MonitoringSite subscribes to 15min interval event."""
-        MonitoringSite(mock_monitoring_settings, mock_event_bus, None)
+        MonitoringSite(mock_monitoring_settings, None)
 
-        mock_event_bus.subscribe.assert_called()
+        mock_event_bus.register.assert_called_once()
 
 
 class TestMonitoringSiteLogin:
@@ -74,7 +75,7 @@ class TestMonitoringSiteLogin:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test successful login."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site._post = AsyncMock(return_value="success")
         site.get_cookie = MagicMock(side_effect=[None, "csrf-token"])
 
@@ -88,7 +89,7 @@ class TestMonitoringSiteLogin:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test login returns existing CSRF token without HTTP request."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site._post = AsyncMock()
         site.get_cookie = MagicMock(return_value="existing-csrf-token")
 
@@ -102,7 +103,7 @@ class TestMonitoringSiteLogin:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test login raises when CSRF token is missing after POST."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site._post = AsyncMock(return_value="success")
         site.get_cookie = MagicMock(side_effect=[None, None])
 
@@ -114,7 +115,7 @@ class TestMonitoringSiteLogin:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test login failure raises ConfigurationException."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         mock_request_info = MagicMock(spec=RequestInfo)
         mock_request_info.real_url = "https://test.com"
@@ -134,7 +135,7 @@ class TestMonitoringSiteLogin:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test login timeout raises ConfigurationException."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site._post = AsyncMock(side_effect=asyncio.TimeoutError())
 
         with pytest.raises(ConfigurationException):
@@ -179,7 +180,7 @@ class TestMonitoringSiteSaveToInfluxDB:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test save_to_influxdb writes points."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         # Create mock module with power data
         mock_info = MagicMock()
@@ -200,7 +201,7 @@ class TestMonitoringSiteSaveToInfluxDB:
         self, mock_monitoring_settings, mock_event_bus
     ):
         """Test save_to_influxdb does nothing when influxdb is None."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, None)
+        site = MonitoringSite(mock_monitoring_settings, None)
 
         # Should not raise
         await site.save_to_influxdb({})
@@ -214,7 +215,7 @@ class TestMonitoringSitePublishMQTT:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test publish_mqtt emits events."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         # Create mock module
         mock_info = MagicMock()
@@ -238,7 +239,7 @@ class TestMonitoringSiteGetData:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test get_data orchestrates data retrieval."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         # Mock the sub-methods
         site.get_modules_energy = AsyncMock(return_value={})
@@ -246,7 +247,7 @@ class TestMonitoringSiteGetData:
         site.save_to_influxdb = AsyncMock()
         site.publish_mqtt = AsyncMock()
 
-        await site.get_data(None)
+        await site.get_data(Interval15MinTriggerEvent())
 
         site.get_modules_energy.assert_called_once()
         site.get_modules_power.assert_called_once()
@@ -262,7 +263,7 @@ class TestMonitoringSiteGetModulesPower:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test get_modules_power raises InvalidDataException on HTTP error."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.login = AsyncMock(return_value="csrf-token")
 
         mock_request_info = MagicMock(spec=RequestInfo)
@@ -282,7 +283,7 @@ class TestMonitoringSiteGetModulesPower:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test get_modules_power raises InvalidDataException on non-string response."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.login = AsyncMock(return_value="csrf-token")
         site._post = AsyncMock(return_value={"unexpected": "dict"})
 
@@ -294,7 +295,7 @@ class TestMonitoringSiteGetModulesPower:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test get_modules_power raises InvalidDataException on timeout."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.login = AsyncMock(return_value="csrf-token")
         site._post = AsyncMock(side_effect=asyncio.TimeoutError())
 
@@ -310,7 +311,7 @@ class TestMonitoringSiteGetLogical:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _get_logical logs in if no CSRF token."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.cookie_exists = MagicMock(return_value=False)
         site.login = AsyncMock()
         site.get_cookie = MagicMock(return_value="test_token")
@@ -326,7 +327,7 @@ class TestMonitoringSiteGetLogical:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _get_logical raises on error."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.cookie_exists = MagicMock(return_value=True)
         site.get_cookie = MagicMock(return_value="test_token")
 
@@ -348,7 +349,7 @@ class TestMonitoringSiteGetLogical:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _get_logical raises on non-dict response payload."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.login = AsyncMock(return_value="test_token")
         site._get = AsyncMock(return_value=["unexpected", "list"])
 
@@ -366,7 +367,7 @@ class TestMonitoringSiteGetPlayback:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _get_playback raises on error."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.cookie_exists = MagicMock(return_value=True)
         site.get_cookie = MagicMock(return_value="test_token")
 
@@ -388,7 +389,7 @@ class TestMonitoringSiteGetPlayback:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _get_playback parses playback JS-like payload into dict."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
         site.login = AsyncMock(return_value="test_token")
         site._post = AsyncMock(return_value="{'reportersData': {}}")
 
@@ -409,7 +410,7 @@ class TestMonitoringSiteParseInverters:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _parse_inverters parses inverter data."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         inverter_objs = [
             {
@@ -436,7 +437,7 @@ class TestMonitoringSiteParseInverters:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _parse_inverters logs unknown type."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         inverter_objs = [
             {
@@ -465,7 +466,7 @@ class TestMonitoringSiteParseStrings:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _parse_strings parses string data."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         inverter = MagicMock()
         inverter.strings = []
@@ -498,7 +499,7 @@ class TestMonitoringSiteParsePanels:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test _parse_panels parses panel data."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         string = MagicMock()
         string.modules = []
@@ -531,7 +532,7 @@ class TestMonitoringSiteGetModulesEnergyFull:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test get_modules_energy with full data parsing."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         logical_response = {
             "logicalTree": {
@@ -590,7 +591,7 @@ class TestMonitoringSiteGetModulesPowerFull:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test get_modules_power with full data parsing."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         playback_response = {
             "reportersData": {
@@ -614,7 +615,7 @@ class TestMonitoringSiteGetModulesPowerFull:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """Test get_modules_power appends date entries for existing module key."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         playback_response = {
             "reportersData": {
@@ -646,7 +647,7 @@ class TestMonitoringSiteExtraBranches:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """save_to_influxdb ignores modules with no power data."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         with_power_info = MagicMock()
         with_power_info.serialnumber = "SN123"
@@ -675,7 +676,7 @@ class TestMonitoringSiteExtraBranches:
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
         """publish_mqtt emits module event even when module.energy is None."""
-        site = MonitoringSite(mock_monitoring_settings, mock_event_bus, mock_influxdb)
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         module_info = MagicMock()
         module_info.serialnumber = "SN123"

--- a/tests/services/powerflow/test_service.py
+++ b/tests/services/powerflow/test_service.py
@@ -9,6 +9,7 @@ from solaredge2mqtt.core.exceptions import (
     InvalidDataException,
 )
 from solaredge2mqtt.core.mqtt.events import MQTTPublishEvent
+from solaredge2mqtt.core.timer.events import IntervalBaseTriggerEvent
 from solaredge2mqtt.services.powerflow import PowerflowService
 from solaredge2mqtt.services.powerflow.models import (
     Powerflow,
@@ -40,14 +41,6 @@ def mock_service_settings():
     settings.location.longitude = 13.405
 
     return settings
-
-
-@pytest.fixture
-def mock_event_bus():
-    """Create mock event bus."""
-    event_bus = MagicMock()
-    event_bus.emit = AsyncMock()
-    return event_bus
 
 
 @pytest.fixture
@@ -116,12 +109,12 @@ class TestPowerflowServiceInit:
     def test_powerflow_service_init(self, mock_service_settings, mock_event_bus):
         """Test PowerflowService initialization."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             assert service.settings is mock_service_settings
-            assert service.event_bus is mock_event_bus
             assert service.influxdb is None
             assert service.wallbox is None
+            mock_event_bus.register.assert_called_once_with(service)
 
     def test_powerflow_service_init_with_wallbox(
         self, mock_service_settings, mock_event_bus
@@ -133,7 +126,7 @@ class TestPowerflowServiceInit:
             patch("solaredge2mqtt.services.powerflow.Modbus"),
             patch("solaredge2mqtt.services.powerflow.WallboxClient"),
         ):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             assert service.wallbox is not None
 
@@ -142,9 +135,7 @@ class TestPowerflowServiceInit:
     ):
         """Test PowerflowService initialization with InfluxDB."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(
-                mock_service_settings, mock_event_bus, mock_influxdb
-            )
+            service = PowerflowService(mock_service_settings, mock_influxdb)
 
             assert service.influxdb is mock_influxdb
 
@@ -159,7 +150,7 @@ class TestPowerflowServiceAsyncInit:
             mock_modbus = AsyncMock()
             mock_modbus_class.return_value = mock_modbus
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
             await service.async_init()
 
             mock_modbus.async_init.assert_called_once()
@@ -194,9 +185,9 @@ class TestPowerflowServiceCalculate:
             mock_powerflow.prepare_point.return_value = MagicMock()
             mock_from_modbus.return_value = mock_powerflow
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
-            await service.calculate_powerflow()
+            await service.calculate_powerflow(IntervalBaseTriggerEvent())
 
             mock_modbus.get_data.assert_called_once()
 
@@ -210,10 +201,10 @@ class TestPowerflowServiceCalculate:
             mock_modbus.get_data.return_value = {"follower": MagicMock()}
             mock_modbus_class.return_value = mock_modbus
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             with pytest.raises(InvalidDataException) as exc_info:
-                await service.calculate_powerflow(None)
+                await service.calculate_powerflow(IntervalBaseTriggerEvent())
 
             assert "Invalid modbus data" in exc_info.value.message
 
@@ -230,10 +221,10 @@ class TestPowerflowServiceCalculate:
             mock_modbus.get_data.return_value = {"leader": mock_modbus_unit}
             mock_modbus_class.return_value = mock_modbus
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             with pytest.raises(InvalidDataException) as exc_info:
-                await service.calculate_powerflow()
+                await service.calculate_powerflow(IntervalBaseTriggerEvent())
 
             assert "Invalid battery data" in exc_info.value.message
 
@@ -256,10 +247,10 @@ class TestPowerflowServiceCalculate:
             mock_powerflow.model_dump_json.return_value = "{}"
             mock_from_modbus.return_value = mock_powerflow
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             with pytest.raises(InvalidDataException) as exc_info:
-                await service.calculate_powerflow()
+                await service.calculate_powerflow(IntervalBaseTriggerEvent())
 
             assert "Invalid powerflow data" in exc_info.value.message
 
@@ -282,10 +273,10 @@ class TestPowerflowServiceCalculate:
             mock_powerflow.model_dump_json.return_value = "{}"
             mock_from_modbus.return_value = mock_powerflow
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             with pytest.raises(InvalidDataException) as exc_info:
-                await service.calculate_powerflow()
+                await service.calculate_powerflow(IntervalBaseTriggerEvent())
 
             assert "Value change not valid" in exc_info.value.message
 
@@ -321,7 +312,7 @@ class TestPowerflowServiceCalculate:
             }
             mock_modbus_class.return_value = mock_modbus
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
             service._check_batteries = MagicMock(return_value={})
             service._read_wallbox_data = AsyncMock(return_value=(0, None))
             service._powerflows_from_data = MagicMock(
@@ -335,7 +326,7 @@ class TestPowerflowServiceCalculate:
             service.publish_wallbox = AsyncMock()
             service.publish_powerflow = AsyncMock()
 
-            await service.calculate_powerflow()
+            await service.calculate_powerflow(IntervalBaseTriggerEvent())
 
             mock_cumulated.assert_called_once()
             cumulated_arg = mock_cumulated.call_args.args[0]
@@ -359,7 +350,7 @@ class TestPowerflowServiceHelpers:
         follower_unit.batteries = {"battery1": follower_battery}
 
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             batteries = service._check_batteries(
                 {"leader": mock_modbus_unit, "follower": follower_unit}
@@ -377,7 +368,7 @@ class TestPowerflowServiceHelpers:
         mock_modbus_unit.batteries["battery0"].is_valid = False
 
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             with pytest.raises(InvalidDataException) as exc_info:
                 service._check_batteries({"leader": mock_modbus_unit})
@@ -390,7 +381,7 @@ class TestPowerflowServiceHelpers:
     ):
         """The helper returns defaults when no wallbox is configured."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             evcharger, wallbox_data = await service._read_wallbox_data()
 
@@ -403,7 +394,7 @@ class TestPowerflowServiceHelpers:
     ):
         """The helper returns wallbox payload and power on success."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
             wallbox_payload = MagicMock()
             wallbox_payload.power = 7400
             wallbox = AsyncMock()
@@ -421,7 +412,7 @@ class TestPowerflowServiceHelpers:
     ):
         """The helper keeps defaults when wallbox config is invalid."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
             wallbox = AsyncMock()
             wallbox.get_data.side_effect = ConfigurationException(
                 "wallbox", "not configured"
@@ -439,7 +430,7 @@ class TestPowerflowServiceHelpers:
     ):
         """The helper keeps defaults when wallbox payload is invalid."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
             wallbox = AsyncMock()
             wallbox.get_data.side_effect = InvalidDataException("invalid")
             service.wallbox = wallbox
@@ -466,7 +457,7 @@ class TestPowerflowServiceHelpers:
             follower_powerflow.model_dump_json.return_value = "{}"
             mock_from_modbus.side_effect = [leader_powerflow, follower_powerflow]
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             powerflows = service._powerflows_from_data(
                 {"leader": mock_modbus_unit, "follower": follower_unit}, 7400
@@ -490,9 +481,7 @@ class TestPowerflowServiceWriteInfluxDB:
     ):
         """Test write_to_influxdb writes points."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(
-                mock_service_settings, mock_event_bus, mock_influxdb
-            )
+            service = PowerflowService(mock_service_settings, mock_influxdb)
 
             # Create mock powerflow
             mock_powerflow = MagicMock()
@@ -512,7 +501,7 @@ class TestPowerflowServiceWriteInfluxDB:
     async def test_write_to_influxdb_none(self, mock_service_settings, mock_event_bus):
         """Test write_to_influxdb does nothing when influxdb is None."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             # Should not raise
             await service.write_to_influxdb({}, {})
@@ -527,7 +516,7 @@ class TestPowerflowServicePublish:
     ):
         """Test publish_modbus emits events."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             await service.publish_modbus({"leader": mock_modbus_unit})
 
@@ -540,7 +529,7 @@ class TestPowerflowServicePublish:
     ):
         """Test publish_wallbox with wallbox data."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             mock_wallbox_data = MagicMock()
             mock_wallbox_data.mqtt_topic.return_value = "wallbox"
@@ -555,7 +544,7 @@ class TestPowerflowServicePublish:
     async def test_publish_wallbox_none(self, mock_service_settings, mock_event_bus):
         """Test publish_wallbox with None data."""
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             await service.publish_wallbox(None)
 
@@ -569,7 +558,7 @@ class TestPowerflowServicePublish:
         mock_service_settings.modbus.has_followers = False
 
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             mock_powerflow = MagicMock()
             mock_powerflow.mqtt_topic.return_value = "powerflow"
@@ -587,7 +576,7 @@ class TestPowerflowServicePublish:
         mock_service_settings.modbus.has_followers = True
 
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             mock_powerflow1 = MagicMock()
             mock_powerflow1.mqtt_topic.return_value = "powerflow/leader"
@@ -622,7 +611,7 @@ class TestPowerflowServiceClose:
             mock_wallbox = AsyncMock()
             mock_wallbox_class.return_value = mock_wallbox
 
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             await service.close()
 
@@ -634,7 +623,7 @@ class TestPowerflowServiceClose:
         mock_service_settings.is_wallbox_configured = False
 
         with patch("solaredge2mqtt.services.powerflow.Modbus"):
-            service = PowerflowService(mock_service_settings, mock_event_bus, None)
+            service = PowerflowService(mock_service_settings, None)
 
             # Should not raise
             await service.close()

--- a/tests/services/wallbox/test_client.py
+++ b/tests/services/wallbox/test_client.py
@@ -42,10 +42,9 @@ class TestWallboxClientInit:
 
     def test_wallbox_client_init(self, wallbox_settings, mock_event_bus):
         """Test WallboxClient initialization."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
 
         assert client.settings is wallbox_settings
-        assert client.event_bus is mock_event_bus
         assert client.authorization is None
 
 
@@ -65,7 +64,7 @@ class TestWallboxClientLogin:
             "refreshToken": "test_refresh_token_eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.signature",  # noqa: E501
         }
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
 
         # Mock get_exp_claim
         with patch.object(
@@ -82,7 +81,7 @@ class TestWallboxClientLogin:
         _, mock_post = mock_http_client
         mock_post.return_value = None
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
 
         with pytest.raises(ConfigurationException) as exc_info:
             await client.login()
@@ -97,7 +96,7 @@ class TestWallboxClientLogin:
         _, mock_post = mock_http_client
         mock_post.side_effect = asyncio.TimeoutError()
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
 
         with pytest.raises(ConfigurationException) as exc_info:
             await client.login()
@@ -111,7 +110,7 @@ class TestWallboxClientGetAccess:
     @pytest.mark.asyncio
     async def test_get_access_no_authorization(self, wallbox_settings, mock_event_bus):
         """Test _get_access calls login when no authorization."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.login = AsyncMock()
         client.authorization = None
 
@@ -124,7 +123,7 @@ class TestWallboxClientGetAccess:
         self, wallbox_settings, mock_event_bus
     ):
         """Test _get_access calls login when access token is missing."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.login = AsyncMock()
 
         mock_auth = MagicMock()
@@ -138,7 +137,7 @@ class TestWallboxClientGetAccess:
     @pytest.mark.asyncio
     async def test_get_access_token_expired(self, wallbox_settings, mock_event_bus):
         """Test _get_access calls login when access token expired."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.login = AsyncMock()
 
         # Create mock authorization with expired tokens
@@ -154,7 +153,7 @@ class TestWallboxClientGetAccess:
     @pytest.mark.asyncio
     async def test_get_access_refresh_token(self, wallbox_settings, mock_event_bus):
         """Test _get_access refreshes token when access expired but refresh valid."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client._refresh_token = AsyncMock()
         client.login = AsyncMock()
 
@@ -172,7 +171,7 @@ class TestWallboxClientGetAccess:
     @pytest.mark.asyncio
     async def test_get_access_token_valid(self, wallbox_settings, mock_event_bus):
         """Test _get_access does nothing when token is valid."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.login = AsyncMock()
         client._refresh_token = AsyncMock()
 
@@ -199,7 +198,7 @@ class TestWallboxClientRefreshToken:
         _, mock_post = mock_http_client
         mock_post.return_value = {"accessToken": "new_access_token"}
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.authorization = MagicMock()
         client.authorization.access_token = "old_access_token"
         client.authorization.refresh_token = "old_refresh_token"
@@ -220,7 +219,7 @@ class TestWallboxClientRefreshToken:
             {"accessToken": "new_access_token_2"},
         ]
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.authorization = MagicMock()
         client.authorization.access_token = "old_access_token"
         client.authorization.refresh_token = "old_refresh_token"
@@ -236,7 +235,7 @@ class TestWallboxClientRefreshToken:
         self, wallbox_settings, mock_event_bus
     ):
         """Test _refresh_token raises when there is no prior authorization."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.authorization = None
 
         with pytest.raises(InvalidDataException) as exc_info:
@@ -249,7 +248,7 @@ class TestWallboxClientRefreshToken:
         self, wallbox_settings, mock_event_bus
     ):
         """Test _refresh_token raises when refresh token is missing."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.authorization = MagicMock()
         client.authorization.refresh_token = None
 
@@ -266,7 +265,7 @@ class TestWallboxClientRefreshToken:
         _, mock_post = mock_http_client
         mock_post.return_value = None
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.authorization = MagicMock()
         client.authorization.refresh_token = "old_refresh_token"
 
@@ -283,7 +282,7 @@ class TestWallboxClientRefreshToken:
         _, mock_post = mock_http_client
         mock_post.return_value = {"refreshToken": "unexpected_refresh_token"}
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client.authorization = MagicMock()
         client.authorization.refresh_token = "old_refresh_token"
 
@@ -310,7 +309,7 @@ class TestWallboxClientGetData:
             "connectedVehicle": True,
         }
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client._get_access = AsyncMock()
         client.authorization = MagicMock()
         client.authorization.access_token = "test_token"
@@ -334,7 +333,7 @@ class TestWallboxClientGetData:
         mock_get, _ = mock_http_client
         mock_get.return_value = None
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client._get_access = AsyncMock()
         client.authorization = MagicMock()
         client.authorization.access_token = "test_token"
@@ -347,7 +346,7 @@ class TestWallboxClientGetData:
         self, wallbox_settings, mock_event_bus
     ):
         """Test get_data raises when _get_access leaves authorization unset."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client._get_access = AsyncMock()
         client.authorization = None
 
@@ -361,7 +360,7 @@ class TestWallboxClientGetData:
         self, wallbox_settings, mock_event_bus
     ):
         """Test get_data raises when authorization has no access token."""
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client._get_access = AsyncMock()
         client.authorization = MagicMock()
         client.authorization.access_token = None
@@ -379,7 +378,7 @@ class TestWallboxClientGetData:
         mock_get, _ = mock_http_client
         mock_get.side_effect = asyncio.TimeoutError()
 
-        client = WallboxClient(wallbox_settings, mock_event_bus)
+        client = WallboxClient(wallbox_settings)
         client._get_access = AsyncMock()
         client.authorization = MagicMock()
         client.authorization.access_token = "test_token"

--- a/tests/services/weather/test_client.py
+++ b/tests/services/weather/test_client.py
@@ -8,6 +8,7 @@ from aiohttp import ClientResponseError, RequestInfo
 
 from solaredge2mqtt.core.exceptions import ConfigurationException, InvalidDataException
 from solaredge2mqtt.core.mqtt.events import MQTTPublishEvent
+from solaredge2mqtt.core.timer.events import Interval10MinTriggerEvent
 from solaredge2mqtt.services.weather import WeatherClient
 from solaredge2mqtt.services.weather.events import WeatherUpdateEvent
 
@@ -69,19 +70,19 @@ class TestWeatherClientInit:
 
     def test_weather_client_init(self, mock_service_settings, mock_event_bus):
         """Test WeatherClient initialization."""
-        client = WeatherClient(mock_service_settings, mock_event_bus)
+        client = WeatherClient(mock_service_settings)
 
         assert client.location is mock_service_settings.location
         assert client.settings is mock_service_settings.weather
-        assert client.event_bus is mock_event_bus
+        mock_event_bus.register.assert_called_once_with(client)
 
     def test_weather_client_subscribes_to_events(
         self, mock_service_settings, mock_event_bus
     ):
         """Test WeatherClient subscribes to 10min interval event."""
-        WeatherClient(mock_service_settings, mock_event_bus)
+        WeatherClient(mock_service_settings)
 
-        mock_event_bus.subscribe.assert_called()
+        mock_event_bus.register.assert_called_once()
 
 
 class TestWeatherClientGetWeather:
@@ -92,7 +93,7 @@ class TestWeatherClientGetWeather:
         self, mock_service_settings, mock_event_bus, mock_weather_response
     ):
         """Test successful weather retrieval."""
-        client = WeatherClient(mock_service_settings, mock_event_bus)
+        client = WeatherClient(mock_service_settings)
         client._get = AsyncMock(return_value=mock_weather_response)
 
         result = await client.get_weather()
@@ -106,7 +107,7 @@ class TestWeatherClientGetWeather:
         self, mock_service_settings, mock_event_bus
     ):
         """Test get_weather raises when response is None."""
-        client = WeatherClient(mock_service_settings, mock_event_bus)
+        client = WeatherClient(mock_service_settings)
         client._get = AsyncMock(return_value=None)
 
         with pytest.raises(InvalidDataException) as exc_info:
@@ -117,7 +118,7 @@ class TestWeatherClientGetWeather:
     @pytest.mark.asyncio
     async def test_get_weather_401_error(self, mock_service_settings, mock_event_bus):
         """Test get_weather handles 401 error."""
-        client = WeatherClient(mock_service_settings, mock_event_bus)
+        client = WeatherClient(mock_service_settings)
 
         mock_request_info = MagicMock(spec=RequestInfo)
         mock_request_info.real_url = "https://test.com"
@@ -139,7 +140,7 @@ class TestWeatherClientGetWeather:
         self, mock_service_settings, mock_event_bus
     ):
         """Test get_weather handles other HTTP errors."""
-        client = WeatherClient(mock_service_settings, mock_event_bus)
+        client = WeatherClient(mock_service_settings)
 
         mock_request_info = MagicMock(spec=RequestInfo)
         mock_request_info.real_url = "https://test.com"
@@ -159,7 +160,7 @@ class TestWeatherClientGetWeather:
     @pytest.mark.asyncio
     async def test_get_weather_timeout(self, mock_service_settings, mock_event_bus):
         """Test get_weather handles timeout."""
-        client = WeatherClient(mock_service_settings, mock_event_bus)
+        client = WeatherClient(mock_service_settings)
         client._get = AsyncMock(side_effect=asyncio.TimeoutError())
 
         with pytest.raises(InvalidDataException) as exc_info:
@@ -174,7 +175,7 @@ class TestWeatherClientGetWeather:
         mock_settings.location = None
         mock_settings.weather = MagicMock()
 
-        client = WeatherClient(mock_settings, mock_event_bus)
+        client = WeatherClient(mock_settings)
 
         with pytest.raises(ConfigurationException) as exc_info:
             await client.get_weather()
@@ -190,10 +191,10 @@ class TestWeatherClientLoop:
         self, mock_service_settings, mock_event_bus, mock_weather_response
     ):
         """Test loop publishes weather data."""
-        client = WeatherClient(mock_service_settings, mock_event_bus)
+        client = WeatherClient(mock_service_settings)
         client._get = AsyncMock(return_value=mock_weather_response)
 
-        await client.loop(None)
+        await client.loop(Interval10MinTriggerEvent())
 
         # Should emit WeatherUpdateEvent and MQTTPublishEvent
         assert mock_event_bus.emit.call_count == 2

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18,8 +18,6 @@ def _build_service() -> Service:
     service.loops = set()
     service._run_task = None
     service.mqtt = None
-    service.event_bus = MagicMock()
-    service.event_bus.cancel_tasks = AsyncMock()
     service.influxdb = None
     service.powerflow = cast(Any, None)
     service.monitoring = None
@@ -143,13 +141,11 @@ class TestServiceInitialization:
             homeassistant_enabled=True,
         )
 
-        event_bus = MagicMock()
         influx = MagicMock()
 
         with (
             patch("solaredge2mqtt.service.service_settings", return_value=settings),
             patch("solaredge2mqtt.service.initialize_logging") as init_logging,
-            patch("solaredge2mqtt.service.EventBus", return_value=event_bus),
             patch("solaredge2mqtt.service.Timer") as timer_cls,
             patch(
                 "solaredge2mqtt.service.InfluxDBAsync", return_value=influx
@@ -165,18 +161,16 @@ class TestServiceInitialization:
             service = Service("config")
 
         init_logging.assert_called_once_with("INFO")
-        timer_cls.assert_called_once_with(event_bus, settings.interval)
-        influx_cls.assert_called_once_with(
-            settings.influxdb, settings.prices, event_bus
-        )
-        energy_cls.assert_called_once_with(settings.energy, event_bus, influx)
-        powerflow_cls.assert_called_once_with(settings, event_bus, influx)
-        monitoring_cls.assert_called_once_with(settings.monitoring, event_bus, influx)
-        weather_cls.assert_called_once_with(settings, event_bus)
+        timer_cls.assert_called_once_with(settings.interval)
+        influx_cls.assert_called_once_with(settings.influxdb, settings.prices)
+        energy_cls.assert_called_once_with(settings.energy, influx)
+        powerflow_cls.assert_called_once_with(settings, influx)
+        monitoring_cls.assert_called_once_with(settings.monitoring, influx)
+        weather_cls.assert_called_once_with(settings)
         forecast_cls.assert_called_once_with(
-            settings.forecast, settings.location, event_bus, influx
+            settings.forecast, settings.location, influx
         )
-        homeassistant_cls.assert_called_once_with(settings, event_bus)
+        homeassistant_cls.assert_called_once_with(settings)
         assert service.forecast is forecast_cls.return_value
 
     def test_init_logs_warning_when_forecast_unavailable_but_enabled(self):
@@ -192,7 +186,6 @@ class TestServiceInitialization:
         with (
             patch("solaredge2mqtt.service.service_settings", return_value=settings),
             patch("solaredge2mqtt.service.initialize_logging"),
-            patch("solaredge2mqtt.service.EventBus", return_value=MagicMock()),
             patch("solaredge2mqtt.service.Timer"),
             patch("solaredge2mqtt.service.PowerflowService"),
             patch("solaredge2mqtt.service.FORECAST_AVAILABLE", False),
@@ -223,7 +216,6 @@ class TestServiceInitialization:
         with (
             patch("solaredge2mqtt.service.service_settings", return_value=settings),
             patch("solaredge2mqtt.service.initialize_logging"),
-            patch("solaredge2mqtt.service.EventBus", return_value=MagicMock()),
             patch("solaredge2mqtt.service.Timer"),
             patch("solaredge2mqtt.service.PowerflowService"),
             patch("solaredge2mqtt.service.FORECAST_AVAILABLE", False),
@@ -603,13 +595,14 @@ class TestServiceShutdown:
         """Finalize should stop loops, set offline status, and cancel event tasks."""
         service = _build_service()
         service._stop_loops = AsyncMock()
-        cancel_tasks_mock = AsyncMock()
-        service.event_bus.cancel_tasks = cancel_tasks_mock
         mqtt = MagicMock()
         mqtt.publish_status_offline = AsyncMock()
         service.mqtt = mqtt
 
-        await service.finalize()
+        with patch(
+            "solaredge2mqtt.service.EventBus.cancel_tasks", new=AsyncMock()
+        ) as cancel_tasks_mock:
+            await service.finalize()
 
         service._stop_loops.assert_awaited_once()
         mqtt.publish_status_offline.assert_awaited_once()
@@ -621,14 +614,17 @@ class TestServiceShutdown:
         """Finalize should continue cleanup if offline status publish fails."""
         service = _build_service()
         service._stop_loops = AsyncMock()
-        cancel_tasks_mock = AsyncMock()
-        service.event_bus.cancel_tasks = cancel_tasks_mock
         service.mqtt = MagicMock()
         service.mqtt.publish_status_offline = AsyncMock(
             side_effect=Exception("unavailable")
         )
 
-        with patch("solaredge2mqtt.service.MqttError", Exception):
+        with (
+            patch("solaredge2mqtt.service.MqttError", Exception),
+            patch(
+                "solaredge2mqtt.service.EventBus.cancel_tasks", new=AsyncMock()
+            ) as cancel_tasks_mock,
+        ):
             await service.finalize()
 
         cancel_tasks_mock.assert_awaited_once()
@@ -639,11 +635,12 @@ class TestServiceShutdown:
         """Finalize should cancel event tasks even when mqtt is absent."""
         service = _build_service()
         service._stop_loops = AsyncMock()
-        cancel_tasks_mock = AsyncMock()
-        service.event_bus.cancel_tasks = cancel_tasks_mock
         service.mqtt = None
 
-        await service.finalize()
+        with patch(
+            "solaredge2mqtt.service.EventBus.cancel_tasks", new=AsyncMock()
+        ) as cancel_tasks_mock:
+            await service.finalize()
 
         service._stop_loops.assert_awaited_once()
         cancel_tasks_mock.assert_awaited_once()


### PR DESCRIPTION
This pull request refactors the event handling system to make the `EventBus` a fully class-based singleton, removing the need to pass `event_bus` instances around. Event subscription, emission, and listener registration are now managed via class methods and decorators, resulting in a cleaner and more maintainable codebase. Several services and components are updated to use the new pattern, and constructor signatures are simplified accordingly.

**Core Event System Refactor:**

* Refactored `EventBus` to use class variables and class methods exclusively, making it a singleton and removing the need for instance creation or passing. All event subscription, unsubscription, emission, and listener management are now handled at the class level. Added support for method decorators and automatic listener registration via `EventBus.register`. [[1]](diffhunk://#diff-56bb8c677f1db2689655637b38957a1eeeece174d32ab3385f09eec136a4eae7L4-R178) [[2]](diffhunk://#diff-56bb8c677f1db2689655637b38957a1eeeece174d32ab3385f09eec136a4eae7R188-R193) [[3]](diffhunk://#diff-56bb8c677f1db2689655637b38957a1eeeece174d32ab3385f09eec136a4eae7L142-R212) [[4]](diffhunk://#diff-56bb8c677f1db2689655637b38957a1eeeece174d32ab3385f09eec136a4eae7L159-R223) [[5]](diffhunk://#diff-56bb8c677f1db2689655637b38957a1eeeece174d32ab3385f09eec136a4eae7L170-R242)

**Service and Component Updates:**

* Updated `InfluxDBAsync`, `MQTTClient`, `Timer`, and other services to remove the `event_bus` parameter from their constructors. These components now rely on the class-based `EventBus` and use `EventBus.register(self)` or decorator-based subscriptions for event handling. [[1]](diffhunk://#diff-f9ddb2d7e1226afbdb08756c0f1089286f7bb636777a17e9d4fdaa2c2cbeae51L36-R47) [[2]](diffhunk://#diff-fe719d1253e43574f2b40f91cddf7e669b9c811a2226525f003196f2acb22139L21-R21) [[3]](diffhunk://#diff-98104ecd9ad3825800ef337876aaf11df077e79eaddbfecc78d672055a82329aL14-R41)
* Updated event emission and subscription calls throughout the codebase to use the new class-based `EventBus` API. [[1]](diffhunk://#diff-f9ddb2d7e1226afbdb08756c0f1089286f7bb636777a17e9d4fdaa2c2cbeae51R81) [[2]](diffhunk://#diff-f9ddb2d7e1226afbdb08756c0f1089286f7bb636777a17e9d4fdaa2c2cbeae51L105-R100) [[3]](diffhunk://#diff-fe719d1253e43574f2b40f91cddf7e669b9c811a2226525f003196f2acb22139L67-R70) [[4]](diffhunk://#diff-fe719d1253e43574f2b40f91cddf7e669b9c811a2226525f003196f2acb22139L129-R128) [[5]](diffhunk://#diff-98104ecd9ad3825800ef337876aaf11df077e79eaddbfecc78d672055a82329aL14-R41)

**Application Wiring and Initialization:**

* Simplified object construction in `service.py` by removing all `event_bus` arguments from service constructors, reflecting the new singleton event bus design. [[1]](diffhunk://#diff-401aadfe7e032c946fba569e42060283b4e4c290eab5467e6ce673ddd02a8f0fL52-R52) [[2]](diffhunk://#diff-401aadfe7e032c946fba569e42060283b4e4c290eab5467e6ce673ddd02a8f0fL62-R81) [[3]](diffhunk://#diff-401aadfe7e032c946fba569e42060283b4e4c290eab5467e6ce673ddd02a8f0fL93) [[4]](diffhunk://#diff-401aadfe7e032c946fba569e42060283b4e4c290eab5467e6ce673ddd02a8f0fL103-R99)

**Development Environment:**

* Added a new `.devcontainer/worktree/devcontainer-lock.json` file specifying container features for development, such as Python, Node, Java, and linting tools.