### PR TITLE
Add maximum and available energy fields to ModbusBattery model

### DIFF
--- a/solaredge2mqtt/core/settings/loader.py
+++ b/solaredge2mqtt/core/settings/loader.py
@@ -69,8 +69,7 @@ class ConfigurationLoader:
             )
 
         if path.exists(secrets_file):
-            SecretLoader.secrets = ConfigurationLoader._load_yaml_file(
-                secrets_file)
+            SecretLoader.secrets = ConfigurationLoader._load_yaml_file(secrets_file)
             logger.info(f"Loaded secrets from {secrets_file}")
 
         config_data = ConfigurationLoader._load_yaml_file(
@@ -79,8 +78,7 @@ class ConfigurationLoader:
         logger.info(f"Loaded configuration from {config_file}")
 
         if override_data:
-            config_data = ConfigurationLoader._deep_merge(
-                config_data, override_data)
+            config_data = ConfigurationLoader._deep_merge(config_data, override_data)
 
         return ServiceSettings(**config_data)
 
@@ -208,8 +206,7 @@ class ConfigurationLoader:
                 and isinstance(result[key], dict)
                 and isinstance(value, dict)
             ):
-                result[key] = ConfigurationLoader._deep_merge(
-                    result[key], value)
+                result[key] = ConfigurationLoader._deep_merge(result[key], value)
             else:
                 result[key] = value
         return result

--- a/solaredge2mqtt/services/homeassistant/models.py
+++ b/solaredge2mqtt/services/homeassistant/models.py
@@ -214,7 +214,13 @@ class HomeAssistantSensorType(HomeAssistantEntityBaseType):
     BATTERY = "battery", "battery", "measurement", "%"
     CURRENT_A = "current_a", "current", "measurement", "A"
     ENERGY_KWH = "energy_kwh", "energy", "total_increasing", "kWh"
-    ENERGY_WH = "energy_wh", "energy", "total_increasing", "Wh"
+    ENERGY_WH = (
+        "energy_wh",
+        "energy",
+        "total_increasing",
+        "Wh",
+    )
+    ENERGY_MEASUREMENT_WH = "energy_measurement_wh", "energy", "measurement", "Wh"
     FREQUENCY_HZ = "frequency_hz", "frequency", "measurement", "Hz"
     MONETARY = "monetary", "monetary", "total", None
     MONETARY_BALANCE = "monetary_balance", "monetary", None, None

--- a/solaredge2mqtt/services/modbus/models/battery.py
+++ b/solaredge2mqtt/services/modbus/models/battery.py
@@ -24,8 +24,12 @@ class ModbusBattery(ModbusComponent):
     power: float = Field(**HASensor.POWER_W.field("power"))
     state_of_charge: float = Field(**HASensor.BATTERY.field("state of charge"))
     state_of_health: float = Field(**HASensor.BATTERY.field("state of health"))
-    maximum_energy: int = Field(**HASensor.ENERGY_WH.field("maximum_energy"))
-    available_energy: float = Field(**HASensor.ENERGY_WH.field("available_energy"))
+    maximum_energy: int = Field(
+        **HASensor.ENERGY_MEASUREMENT_WH.field("maximum_energy")
+    )
+    available_energy: float = Field(
+        **HASensor.ENERGY_MEASUREMENT_WH.field("available_energy")
+    )
 
     @classmethod
     def extract_sunspec_payload(cls, payload: SunSpecPayload) -> dict[str, Any]:

--- a/solaredge2mqtt/services/modbus/models/battery.py
+++ b/solaredge2mqtt/services/modbus/models/battery.py
@@ -24,6 +24,8 @@ class ModbusBattery(ModbusComponent):
     power: float = Field(**HASensor.POWER_W.field("power"))
     state_of_charge: float = Field(**HASensor.BATTERY.field("state of charge"))
     state_of_health: float = Field(**HASensor.BATTERY.field("state of health"))
+    maximum_energy: int = Field(**HASensor.ENERGY_WH.field("maximum_energy"))
+    available_energy: float = Field(**HASensor.ENERGY_WH.field("available_energy"))
 
     @classmethod
     def extract_sunspec_payload(cls, payload: SunSpecPayload) -> dict[str, Any]:
@@ -34,6 +36,8 @@ class ModbusBattery(ModbusComponent):
             "power": round(float(payload["instantaneous_power"]), 2),
             "state_of_charge": round(float(payload["soe"]), 2),
             "state_of_health": round(float(payload["soh"]), 2),
+            "maximum_energy": round(float(payload["maximum_energy"])),
+            "available_energy": round(float(payload["available_energy"]), 2),
         }
 
         if values["status"] in BATTERY_STATUS_MAP:

--- a/solaredge2mqtt/services/modbus/sunspec/battery.py
+++ b/solaredge2mqtt/services/modbus/sunspec/battery.py
@@ -66,8 +66,8 @@ class SunSpecBatteryRegister(SunSpecRegister):
         SunSpecValueType.UINT64,
     )
 
-    MAXIMUM_ENERGY = "maximum_energy", 57726, SunSpecValueType.FLOAT32
-    AVAILABLE_ENERGY = "available_energy", 57728, SunSpecValueType.FLOAT32
+    MAXIMUM_ENERGY = "maximum_energy", 57726, SunSpecValueType.FLOAT32, True
+    AVAILABLE_ENERGY = "available_energy", 57728, SunSpecValueType.FLOAT32, True
 
     SOH = "soh", 57730, SunSpecValueType.FLOAT32, True
     SOE = "soe", 57732, SunSpecValueType.FLOAT32, True

--- a/tests/services/modbus/test_battery.py
+++ b/tests/services/modbus/test_battery.py
@@ -37,6 +37,8 @@ def make_battery_data(
     power: float = 264.0,
     soe: float = 75.5,
     soh: float = 98.2,
+    maximum_energy: int = 9200,
+    available_energy: float = 6900.0,
 ) -> dict:
     """Create battery data for testing."""
     return {
@@ -46,6 +48,8 @@ def make_battery_data(
         "instantaneous_power": power,
         "soe": soe,
         "soh": soh,
+        "maximum_energy": maximum_energy,
+        "available_energy": available_energy,
     }
 
 
@@ -81,6 +85,8 @@ class TestModbusBattery:
             power=264.999,
             soe=75.555,
             soh=98.224,
+            maximum_energy=9200,
+            available_energy=6900.0,
         )
 
         battery = ModbusBattery.from_sunspec(info, data)

--- a/tests/services/modbus/test_unit.py
+++ b/tests/services/modbus/test_unit.py
@@ -120,6 +120,8 @@ class TestModbusUnit:
             power=480.0,
             state_of_charge=80.0,
             state_of_health=100.0,
+            maximum_energy=9200,
+            available_energy=6900.0,
         )
 
         unit = ModbusUnit(info=None, inverter=inverter, batteries={"battery1": battery})
@@ -152,6 +154,8 @@ class TestModbusUnit:
             power=480.0,
             state_of_charge=80.0,
             state_of_health=100.0,
+            maximum_energy=9200,
+            available_energy=6800,
         )
 
         unit = ModbusUnit(

--- a/tests/services/powerflow/test_models_extended.py
+++ b/tests/services/powerflow/test_models_extended.py
@@ -1360,6 +1360,8 @@ class TestPowerflowFromModbus:
                 "instantaneous_power": 4998,
                 "soe": 50.0,
                 "soh": 100.0,
+                "maximum_energy": 9200,
+                "available_energy": 6800,
             },
         )
 
@@ -1464,6 +1466,8 @@ class TestPowerflowFromModbus:
                 "instantaneous_power": 2000,
                 "soe": 50.0,
                 "soh": 100.0,
+                "maximum_energy": 9200,
+                "available_energy": 4600,
             },
         )
 
@@ -1568,6 +1572,8 @@ class TestPowerflowFromModbus:
                 "instantaneous_power": -1000,
                 "soe": 50.0,
                 "soh": 100.0,
+                "maximum_energy": 9200,
+                "available_energy": 4600,
             },
         )
 
@@ -1754,6 +1760,8 @@ class TestPowerflowFromModbus:
                 "instantaneous_power": 3000,
                 "soe": 50.0,
                 "soh": 100.0,
+                "maximum_energy": 9200,
+                "available_energy": 4600,
             },
         )
 


### PR DESCRIPTION
This pull request introduces two new battery energy attributes to the `ModbusBattery` model and makes minor formatting improvements to the configuration loader for better readability. The most significant changes are outlined below.

### Modbus Battery Model Enhancements
* Added `maximum_energy` and `available_energy` fields to the `ModbusBattery` model in `battery.py`, allowing the system to track and expose these additional battery metrics.
* Updated the `extract_sunspec_payload` method to extract and round the new `maximum_energy` and `available_energy` values from the SunSpec payload.

### Configuration Loader Formatting Improvements
* Refactored line breaks in method calls within `loader.py` for improved code readability, without changing functionality. [[1]](diffhunk://#diff-31481225c4c315fb2e44505812482f00625a1df08c050459444ced0f7cead019L72-R72) [[2]](diffhunk://#diff-31481225c4c315fb2e44505812482f00625a1df08c050459444ced0f7cead019L82-R81) [[3]](diffhunk://#diff-31481225c4c315fb2e44505812482f00625a1df08c050459444ced0f7cead019L211-R209)