### PR TITLE
Refactor worktree path conversion to ensure relative paths for .git a…

### DIFF
--- a/.devcontainer/worktree/fix-worktree.sh
+++ b/.devcontainer/worktree/fix-worktree.sh
@@ -1,39 +1,83 @@
 #!/bin/bash
 
 # Fix git worktree paths for devcontainer usage
-# This script converts absolute paths in .git to relative paths
+# Converts absolute paths to relative paths in both directions:
+#   1. Worktree/.git      → ../.repo/worktrees/<name>
+#   2. .repo/worktrees/<name>/gitdir → ../../../<name>/.git
 
-if [ -f .git ] && [ ! -d .git ]; then
-    # This is a worktree, .git is a file
-    echo "🔧 Detected git worktree, fixing git directory reference..."
-    
-    # Read the current gitdir
-    GITDIR=$(cat .git | sed 's/gitdir: //')
-    
-    # Check if it's an absolute path
-    if [[ "$GITDIR" == /* ]]; then
-        echo "📝 Found absolute path, converting to relative..."
-        
-        # Extract worktree name from gitdir
-        WORKTREE_NAME=$(basename "$GITDIR")
-        
-        # Create relative path pointing to .repo
-        RELATIVE_PATH="../.repo/worktrees/$WORKTREE_NAME"
-        
-        # Update .git file
-        echo "gitdir: $RELATIVE_PATH" > .git
-        
-        echo "✅ Updated .git to use relative path: $RELATIVE_PATH"
-    else
-        echo "✅ Path is already relative, nothing to fix."
-    fi
-else
+set -e
+
+if [ ! -f .git ] || [ -d .git ]; then
     echo "ℹ️  Regular git repository (not a worktree), nothing to fix."
+    exit 0
 fi
 
-# Verify git is working
+echo "🔧 Detected git worktree, fixing git directory references..."
+
+# ── 1. Read current gitdir ────────────────────────────────────────────────────
+
+GITDIR=$(sed 's/gitdir: //' .git)
+WORKTREE_NAME=$(basename "$(pwd)")
+
+echo "   Worktree name : $WORKTREE_NAME"
+echo "   Current gitdir: $GITDIR"
+
+# ── 2. Fix .git file (Worktree → Bare Repo) ──────────────────────────────────
+
+EXPECTED_GITDIR="../.repo/worktrees/$WORKTREE_NAME"
+
+if [ "$GITDIR" != "$EXPECTED_GITDIR" ]; then
+    echo "📝 Fixing .git (absolute → relative)..."
+    echo "gitdir: $EXPECTED_GITDIR" > .git
+    echo "✅ .git updated: $EXPECTED_GITDIR"
+else
+    echo "✅ .git already correct."
+fi
+
+# ── 3. Fix gitdir back-reference (Bare Repo → Worktree) ──────────────────────
+#
+# Relative path is calculated from:
+#   .repo/worktrees/<name>/gitdir
+# to:
+#   <name>/.git
+#
+# Both on host and in devcontainer the directory structure is:
+#   <root>/
+#     .repo/worktrees/<name>/gitdir   (3 levels deep)
+#     <name>/.git
+#
+# So the relative path is always: ../../../<name>/.git
+
+BACK_REF_FILE="../.repo/worktrees/$WORKTREE_NAME/gitdir"
+EXPECTED_BACK_REF="../../../$WORKTREE_NAME/.git"
+
+if [ ! -f "$BACK_REF_FILE" ]; then
+    echo "⚠️  Back-reference file not found: $BACK_REF_FILE"
+    echo "   Make sure the .repo mount is available."
+else
+    CURRENT_BACK_REF=$(cat "$BACK_REF_FILE")
+    echo "   Current back-ref: $CURRENT_BACK_REF"
+
+    if [ "$CURRENT_BACK_REF" != "$EXPECTED_BACK_REF" ]; then
+        echo "📝 Fixing back-reference (absolute → relative)..."
+        echo "$EXPECTED_BACK_REF" > "$BACK_REF_FILE"
+        echo "✅ Back-reference updated: $BACK_REF_FILE → $EXPECTED_BACK_REF"
+    else
+        echo "✅ Back-reference already correct."
+    fi
+fi
+
+# ── 4. Verify ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "🔍 Verifying git..."
+
 if git status > /dev/null 2>&1; then
     echo "✅ Git is working correctly!"
+    git worktree list
 else
-    echo "❌ Warning: Git commands may not work properly. Please check your worktree setup."
+    echo "❌ Git commands not working. Current state:"
+    echo "   .git contents  : $(cat .git)"
+    echo "   back-ref       : $(cat "$BACK_REF_FILE" 2>/dev/null || echo 'not readable')"
+    exit 1
 fi

--- a/scripts/manage-worktrees.sh
+++ b/scripts/manage-worktrees.sh
@@ -191,13 +191,47 @@ skipping upstream configuration"
 
 convert_git_to_relative() {
     local WORKTREE_PATH=$1
+    local WORKTREE_NAME
+    WORKTREE_NAME=$(basename "$WORKTREE_PATH")
     local GIT_FILE="$WORKTREE_PATH/.git"
-    
+
     [ ! -f "$GIT_FILE" ] && return 0
-    
-    info "Converting .git to relative path..."
-    echo "gitdir: ../.repo/worktrees/$(basename "$WORKTREE_PATH")" > "$GIT_FILE"
-    success "Converted .git to relative path"
+
+    # ── 1. Fix Worktree → Bare Repo (.git file) ──────────────────────────────
+    local EXPECTED_GITDIR="../.repo/worktrees/$WORKTREE_NAME"
+    local CURRENT_GITDIR
+    CURRENT_GITDIR=$(sed 's/gitdir: //' "$GIT_FILE")
+
+    if [ "$CURRENT_GITDIR" != "$EXPECTED_GITDIR" ]; then
+        info "Converting .git to relative path..."
+        echo "gitdir: $EXPECTED_GITDIR" > "$GIT_FILE"
+        success "Converted .git → $EXPECTED_GITDIR"
+    else
+        info ".git already uses relative path"
+    fi
+
+    # ── 2. Fix Bare Repo → Worktree (gitdir back-reference) ──────────────────
+    # Relative path from .repo/worktrees/<name>/gitdir to <name>/.git
+    # Both on host and in devcontainer the structure is flat:
+    #   <root>/.repo/worktrees/<name>/gitdir  →  ../../../<name>/.git
+    local BACK_REF_FILE="$REPO_DIR/worktrees/$WORKTREE_NAME/gitdir"
+    local EXPECTED_BACK_REF="../../../$WORKTREE_NAME/.git"
+
+    if [ ! -f "$BACK_REF_FILE" ]; then
+        warning "Back-reference not found: $BACK_REF_FILE"
+        return 0
+    fi
+
+    local CURRENT_BACK_REF
+    CURRENT_BACK_REF=$(cat "$BACK_REF_FILE")
+
+    if [ "$CURRENT_BACK_REF" != "$EXPECTED_BACK_REF" ]; then
+        info "Converting back-reference to relative path..."
+        echo "$EXPECTED_BACK_REF" > "$BACK_REF_FILE"
+        success "Converted back-reference → $EXPECTED_BACK_REF"
+    else
+        info "Back-reference already uses relative path"
+    fi
 }
 
 sanitize_branch_name() {


### PR DESCRIPTION
This pull request enhances and robustly refactors the scripts responsible for fixing and managing Git worktree path references in development containers. The main improvements ensure that both the `.git` file in a worktree and the back-reference in the bare repository always use correct relative paths, improving compatibility and reducing errors in various environments.

**Worktree path correction enhancements:**

* [`.devcontainer/worktree/fix-worktree.sh`](diffhunk://#diff-2a0c16520071fb8cf122274eb400b3a56b4770e83c93a77a0ed74f12f2056b88L4-R82): Refactored to handle both directions of path correction—ensuring `.git` points to the correct relative path in `.repo/worktrees/<name>`, and the bare repo back-reference (`gitdir` file) points back to the worktree’s `.git` using a relative path. Added clear verification and user feedback for each step, and improved error handling.
* [`scripts/manage-worktrees.sh`](diffhunk://#diff-5ef180d4bbc5d6bead6105458dac275be61390a677b0e0548a8a8d0971df6a8dR194-R234): Updated `convert_git_to_relative` to mirror the robust logic from the devcontainer script, checking and correcting both the `.git` file and the back-reference, with improved logging and idempotency.…nd back-references