### PR TITLE
Add BetweenIntervalTriggerEvent and handle intermediate triggers

### DIFF
--- a/solaredge2mqtt/core/status/__init__.py
+++ b/solaredge2mqtt/core/status/__init__.py
@@ -2,11 +2,9 @@ from solaredge2mqtt.core.events import EventBus
 from solaredge2mqtt.core.logging import logger
 from solaredge2mqtt.core.mqtt.events import MQTTPublishEvent
 from solaredge2mqtt.core.status.events import (
+    ResendStatusEvent,
     ServiceOfflineEvent,
     ServiceOnlineEvent,
-)
-from solaredge2mqtt.core.timer.events import (
-    BetweenIntervalTriggerEvent,
 )
 
 
@@ -82,8 +80,8 @@ class ServiceStatusController:
 
         self._reset_debounce(service_name)
 
-    @EventBus.subscribe(BetweenIntervalTriggerEvent)
-    async def handle_intermediate_trigger(self, event: BetweenIntervalTriggerEvent):
+    @EventBus.subscribe(ResendStatusEvent)
+    async def handle_intermediate_trigger(self, event: ResendStatusEvent):
         logger.info("Resend status")
         for service_name, is_online in self._status.items():
             await self._emit(service_name, is_online)

--- a/solaredge2mqtt/core/status/__init__.py
+++ b/solaredge2mqtt/core/status/__init__.py
@@ -5,6 +5,9 @@ from solaredge2mqtt.core.status.events import (
     ServiceOfflineEvent,
     ServiceOnlineEvent,
 )
+from solaredge2mqtt.core.timer.events import (
+    BetweenIntervalTriggerEvent,
+)
 
 
 class ServiceStatusController:
@@ -78,6 +81,12 @@ class ServiceStatusController:
                 return
 
         self._reset_debounce(service_name)
+
+    @EventBus.subscribe(BetweenIntervalTriggerEvent)
+    async def handle_intermediate_trigger(self, event: BetweenIntervalTriggerEvent):
+        logger.info("Resend status")
+        for service_name, is_online in self._status.items():
+            await self._publish_service_status(service_name, is_online)
 
     async def _publish_service_status(self, service_name: str, is_online: bool):
         self._status[service_name] = is_online

--- a/solaredge2mqtt/core/status/__init__.py
+++ b/solaredge2mqtt/core/status/__init__.py
@@ -86,11 +86,14 @@ class ServiceStatusController:
     async def handle_intermediate_trigger(self, event: BetweenIntervalTriggerEvent):
         logger.info("Resend status")
         for service_name, is_online in self._status.items():
-            await self._publish_service_status(service_name, is_online)
+            await self._emit(service_name, is_online)
 
     async def _publish_service_status(self, service_name: str, is_online: bool):
         self._status[service_name] = is_online
         self._reset_debounce(service_name)
+        await self._emit(service_name, is_online)
+
+    async def _emit(self, service_name, is_online):
         await EventBus.emit(
             MQTTPublishEvent(
                 f"status/{service_name}",

--- a/solaredge2mqtt/core/status/events.py
+++ b/solaredge2mqtt/core/status/events.py
@@ -3,6 +3,9 @@ from typing import ClassVar
 from solaredge2mqtt.core.events.events import BaseEvent
 
 
+class ResendStatusEvent(BaseEvent): ...  # pragma: no cover
+
+
 class ServiceOnlineEvent(BaseEvent):
     SERVICE_NAME: ClassVar[str]
 

--- a/solaredge2mqtt/core/timer/__init__.py
+++ b/solaredge2mqtt/core/timer/__init__.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from solaredge2mqtt.core.events import EventBus
 from solaredge2mqtt.core.timer.events import (
+    BetweenIntervalTriggerEvent,
     Interval1MinTriggerEvent,
     Interval5MinTriggerEvent,
     Interval10MinTriggerEvent,
@@ -39,3 +40,12 @@ class Timer:
 
         if timestamp % 900 == 0:
             await EventBus.emit(Interval15MinTriggerEvent())
+
+    @EventBus.subscribe(BetweenIntervalTriggerEvent)
+    async def on_between_interval_trigger(
+        self, event: BetweenIntervalTriggerEvent
+    ) -> None:
+        await EventBus.emit(Interval1MinTriggerEvent())
+        await EventBus.emit(Interval5MinTriggerEvent())
+        await EventBus.emit(Interval10MinTriggerEvent())
+        await EventBus.emit(Interval15MinTriggerEvent())

--- a/solaredge2mqtt/core/timer/events.py
+++ b/solaredge2mqtt/core/timer/events.py
@@ -4,6 +4,9 @@ from solaredge2mqtt.core.events.events import BaseEvent
 class IntervalBaseTriggerEvent(BaseEvent): ...  # pragma: no cover
 
 
+class BetweenIntervalTriggerEvent(BaseEvent): ...  # pragma: no cover
+
+
 class Interval1MinTriggerEvent(BaseEvent): ...  # pragma: no cover
 
 

--- a/solaredge2mqtt/services/homeassistant/service.py
+++ b/solaredge2mqtt/services/homeassistant/service.py
@@ -8,6 +8,7 @@ from solaredge2mqtt.core.logging import logger
 from solaredge2mqtt.core.mqtt.events import (
     MQTTPublishEvent,
 )
+from solaredge2mqtt.core.status.events import ResendStatusEvent
 from solaredge2mqtt.core.timer.events import (
     BetweenIntervalTriggerEvent,
 )
@@ -211,6 +212,9 @@ class HomeAssistantDiscovery:
 
             logger.info("Resending long interval triggered data to Home Assistant")
             await EventBus.emit(BetweenIntervalTriggerEvent())
+
+            await asyncio.sleep(resend_delay_seconds)
+            await EventBus.emit(ResendStatusEvent())
 
     @staticmethod
     def property_parser(prop, name: str, path: list[str]) -> dict | None:

--- a/solaredge2mqtt/services/homeassistant/service.py
+++ b/solaredge2mqtt/services/homeassistant/service.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from solaredge2mqtt.core.events import EventBus
 from solaredge2mqtt.core.logging import logger
 from solaredge2mqtt.core.mqtt.events import (
     MQTTPublishEvent,
+)
+from solaredge2mqtt.core.timer.events import (
+    BetweenIntervalTriggerEvent,
 )
 from solaredge2mqtt.services.energy.events import EnergyReadEvent
 from solaredge2mqtt.services.forecast.events import ForecastEvent
@@ -186,6 +190,9 @@ class HomeAssistantDiscovery:
 
     @EventBus.subscribe(HomeAssistantStatusEvent)
     async def homeassistant_status(self, event: HomeAssistantStatusEvent) -> None:
+        expected_topic = f"{self.settings.homeassistant.topic_prefix}/status"
+        if event.topic != expected_topic:
+            return
         if event.input.status == HomeAssistantStatus.ONLINE:
             logger.info("Home Assistant status changed to online resend discovery")
             for topic, entity in self._send_entities.items():
@@ -198,6 +205,11 @@ class HomeAssistantDiscovery:
                         exclude_none=True,
                     )
                 )
+
+            await asyncio.sleep(10)
+
+            logger.info("Resending long interval triggered data to Home Assistant")
+            await EventBus.emit(BetweenIntervalTriggerEvent())
 
     @staticmethod
     def property_parser(prop, name: str, path: list[str]) -> dict | None:

--- a/solaredge2mqtt/services/homeassistant/service.py
+++ b/solaredge2mqtt/services/homeassistant/service.py
@@ -206,7 +206,8 @@ class HomeAssistantDiscovery:
                     )
                 )
 
-            await asyncio.sleep(10)
+            resend_delay_seconds = 10
+            await asyncio.sleep(resend_delay_seconds)
 
             logger.info("Resending long interval triggered data to Home Assistant")
             await EventBus.emit(BetweenIntervalTriggerEvent())

--- a/tests/core/status/test_service_status_controller.py
+++ b/tests/core/status/test_service_status_controller.py
@@ -8,10 +8,10 @@ from solaredge2mqtt.core.events import EventBus
 from solaredge2mqtt.core.mqtt.events import MQTTPublishEvent
 from solaredge2mqtt.core.status import ServiceStatusController
 from solaredge2mqtt.core.status.events import (
+    ResendStatusEvent,
     ServiceOfflineEvent,
     ServiceOnlineEvent,
 )
-from solaredge2mqtt.core.timer.events import BetweenIntervalTriggerEvent
 
 
 class TestServiceStatusControllerInit:
@@ -499,7 +499,7 @@ class TestServiceStatusControllerHandleIntermediateTrigger:
         controller._status = {"modbus": True, "mqtt": False}
 
         with patch.object(EventBus, "emit", new_callable=AsyncMock) as mock_emit:
-            await controller.handle_intermediate_trigger(BetweenIntervalTriggerEvent())
+            await controller.handle_intermediate_trigger(ResendStatusEvent())
 
             emitted_topics = [call.args[0].topic for call in mock_emit.call_args_list]
             assert "status/modbus" in emitted_topics
@@ -511,6 +511,6 @@ class TestServiceStatusControllerHandleIntermediateTrigger:
         controller = ServiceStatusController()
 
         with patch.object(EventBus, "emit", new_callable=AsyncMock) as mock_emit:
-            await controller.handle_intermediate_trigger(BetweenIntervalTriggerEvent())
+            await controller.handle_intermediate_trigger(ResendStatusEvent())
 
             mock_emit.assert_not_called()

--- a/tests/core/status/test_service_status_controller.py
+++ b/tests/core/status/test_service_status_controller.py
@@ -11,6 +11,7 @@ from solaredge2mqtt.core.status.events import (
     ServiceOfflineEvent,
     ServiceOnlineEvent,
 )
+from solaredge2mqtt.core.timer.events import BetweenIntervalTriggerEvent
 
 
 class TestServiceStatusControllerInit:
@@ -483,3 +484,33 @@ class TestServiceStatusControllerIntegration:
             # Both should now be offline
             assert controller._status["service1"] is False
             assert controller._status["service2"] is False
+
+
+class TestServiceStatusControllerHandleIntermediateTrigger:
+    """Tests for ServiceStatusController.handle_intermediate_trigger."""
+
+    @pytest.mark.asyncio
+    async def test_handle_intermediate_trigger_publishes_all_service_statuses(self):
+        """
+        Test that BetweenIntervalTriggerEvent republishes
+        all known service statuses.
+        """
+        controller = ServiceStatusController()
+        controller._status = {"modbus": True, "mqtt": False}
+
+        with patch.object(EventBus, "emit", new_callable=AsyncMock) as mock_emit:
+            await controller.handle_intermediate_trigger(BetweenIntervalTriggerEvent())
+
+            emitted_topics = [call.args[0].topic for call in mock_emit.call_args_list]
+            assert "status/modbus" in emitted_topics
+            assert "status/mqtt" in emitted_topics
+
+    @pytest.mark.asyncio
+    async def test_handle_intermediate_trigger_empty_status_emits_nothing(self):
+        """Test that handle_intermediate_trigger with no services emits nothing."""
+        controller = ServiceStatusController()
+
+        with patch.object(EventBus, "emit", new_callable=AsyncMock) as mock_emit:
+            await controller.handle_intermediate_trigger(BetweenIntervalTriggerEvent())
+
+            mock_emit.assert_not_called()

--- a/tests/core/timer/test_timer.py
+++ b/tests/core/timer/test_timer.py
@@ -6,6 +6,7 @@ import pytest
 
 from solaredge2mqtt.core.timer import Timer
 from solaredge2mqtt.core.timer.events import (
+    BetweenIntervalTriggerEvent,
     Interval1MinTriggerEvent,
     Interval5MinTriggerEvent,
     Interval10MinTriggerEvent,
@@ -175,3 +176,40 @@ class TestTimer:
                 await timer.loop()
 
                 assert mock_event_bus.emit.called
+
+
+class TestTimerBetweenIntervalTrigger:
+    """Tests for Timer.on_between_interval_trigger handler."""
+
+    @pytest.mark.asyncio
+    async def test_between_interval_trigger_emits_all_long_intervals(
+        self, mock_event_bus
+    ):
+        """
+        Test that BetweenIntervalTriggerEvent causes
+        all long intervals to be emitted.
+        """
+        timer = Timer(5)
+        event = BetweenIntervalTriggerEvent()
+
+        await timer.on_between_interval_trigger(event)
+
+        emitted_types = [
+            type(call.args[0]) for call in mock_event_bus.emit.call_args_list
+        ]
+        assert Interval1MinTriggerEvent in emitted_types
+        assert Interval5MinTriggerEvent in emitted_types
+        assert Interval10MinTriggerEvent in emitted_types
+        assert Interval15MinTriggerEvent in emitted_types
+
+    @pytest.mark.asyncio
+    async def test_between_interval_trigger_emits_exactly_four_events(
+        self, mock_event_bus
+    ):
+        """Test that exactly the four long-interval events are emitted."""
+        timer = Timer(5)
+        event = BetweenIntervalTriggerEvent()
+
+        await timer.on_between_interval_trigger(event)
+
+        assert mock_event_bus.emit.call_count == 4


### PR DESCRIPTION
- Introduced BetweenIntervalTriggerEvent in timer events.
- Updated ServiceStatusController to handle BetweenIntervalTriggerEvent and publish service statuses.
- Enhanced Timer class to emit long interval events upon receiving BetweenIntervalTriggerEvent.
- Added tests for the new event handling in ServiceStatusController and Timer.

Signed-off-by: Johannes Ott <mail@johannes-ott.net>