### PR TITLE
Multiple seperate inverters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ env.bak/
 venv.bak/
 
 # Configuration files (use .example templates)
-config/**/*
+config/**/*.yml
 config
 
 # Spyder project settings

--- a/README.md
+++ b/README.md
@@ -204,13 +204,15 @@ SolarEdge inverters support a cascading setup, where one inverter acts as the le
 - For the leader inverter, use the basic Modbus settings described above.
 - For each follower inverter, add them to the configuration as shown below.
 
+#### Cascaded inverters (shared Modbus connection)
+
+When followers are wired in a RS485 cascade behind the leader, they share the leader's TCP connection. Only set `unit` (the Modbus device address on the bus) and optionally meter/battery flags:
+
 ```yaml
 modbus:
-  # Leader configuration
   host: 192.168.1.100
   port: 1502
   
-  # Follower inverters
   follower:
     - unit: 2
       meter: [false, false, false]
@@ -220,6 +222,38 @@ modbus:
       battery: [true, false]
 ```
 
+#### Physically separate inverters (individual TCP connections)
+
+When each inverter has its own network connection (e.g. each has its own IP address), specify `host` and optionally `port` per follower. Each follower with its own `host` opens a dedicated TCP connection; those without fall back to the leader's connection:
+
+```yaml
+modbus:
+  # Leader
+  host: 192.168.1.100
+  port: 1502
+
+  follower:
+    # Follower on the same host (cascaded, shares leader connection)
+    - unit: 2
+      meter: [false, false, false]
+      battery: [false, false]
+
+    # Follower with its own IP and default port (1502 inherited from leader)
+    - unit: 1
+      host: 192.168.1.101
+      meter: [true, false, false]
+      battery: [true, false]
+
+    # Follower with its own IP and a custom port
+    - unit: 1
+      host: 192.168.1.102
+      port: 502
+      meter: [false, false, false]
+      battery: [true, true]
+```
+
+When a follower omits `port`, the leader's port is used. When a follower omits `host`, the leader's host and connection are reused.
+
 You can configure up to 11 inverters in total: one leader and up to 10 followers. Each configured inverter will report:
 
 - individual power flow data
@@ -227,7 +261,7 @@ You can configure up to 11 inverters in total: one leader and up to 10 followers
 - cumulative energy and power flow data
 - cumulative production forecasts (if forecasting is enabled)
 
-This setup allows for comprehensive multi-inverter support in systems with cascaded SolarEdge installations.
+This setup allows for comprehensive multi-inverter support in systems with cascaded or physically separate SolarEdge installations.
 
 ### MQTT configuration
 

--- a/solaredge2mqtt/config/configuration.yml.example
+++ b/solaredge2mqtt/config/configuration.yml.example
@@ -40,11 +40,23 @@ modbus:
   # Advanced power controls (enabled, disabled, or disable)
   advanced_power_controls: disabled
   
-  # Follower inverters (for cascading setups)
+  # Follower inverters
+  # Cascaded (shared RS485 bus — all units use the leader's TCP connection):
   # follower:
-  #   - unit: 2
+  #   - unit: 2                          # Modbus device address on the bus
   #     meter: [false, false, false]
   #     battery: [false, false]
+  #   - unit: 3
+  #     meter: [true, false, false]
+  #     battery: [true, false]
+  #
+  # Physically separate inverters (each with its own IP/port):
+  # follower:
+  #   - unit: 1
+  #     host: 192.168.1.101              # Own IP; omit to share the leader's connection
+  #     # port: 1502                     # Own port; omit to inherit the leader's port
+  #     meter: [true, false, false]
+  #     battery: [true, false]
 
 # MQTT configuration (required)
 mqtt:

--- a/solaredge2mqtt/services/forecast/service.py
+++ b/solaredge2mqtt/services/forecast/service.py
@@ -328,7 +328,9 @@ class Forecaster:
 
         logger.info(f"Training execution time: {execution_time:.2f} seconds")
 
-    def _prepare_model_pipeline(self, x_vector_columns: list[str]) -> Pipeline:
+    def _prepare_model_pipeline(
+        self, x_vector_columns: list[str], n_repeats: int = 10
+    ) -> Pipeline:
         base_estimator = HistGradientBoostingRegressor(
             random_state=42,
             categorical_features="from_dtype",
@@ -340,7 +342,7 @@ class Forecaster:
                 ("preprocessor", self._prepare_preprocessor(x_vector_columns)),
                 (
                     "feature_selector",
-                    PFISelector(estimator=clone(base_estimator)),
+                    PFISelector(estimator=clone(base_estimator), n_repeats=n_repeats),
                 ),
                 ("model", clone(base_estimator)),
             ],
@@ -471,10 +473,11 @@ class PFISelector(BaseEstimator, TransformerMixin):
 
         threshold_value = percentile(self.feature_importances_, 75)
 
-        important_indices = cast(
-            list[bool],
-            (self.feature_importances_ > threshold_value).tolist(),
-        )
+        selected = self.feature_importances_ > threshold_value
+        if not selected.any():
+            selected = self.feature_importances_ >= threshold_value
+
+        important_indices = cast(list[bool], selected.tolist())
         self.important_indices_ = important_indices
         self.important_features_ = [
             col

--- a/solaredge2mqtt/services/modbus/__init__.py
+++ b/solaredge2mqtt/services/modbus/__init__.py
@@ -391,7 +391,13 @@ class Modbus:
         effective_client = client if client is not None else self._clients[unit_key]
         data: dict[str, Any] = {}
 
-        for register_or_bundle in registers_or_bundles:
+        bundles = (
+            registers_or_bundles.request_bundles()
+            if isinstance(registers_or_bundles, type)
+            else registers_or_bundles
+        )
+
+        for register_or_bundle in bundles:
             address_start = register_or_bundle.address + offset
 
             if address_start in self._block_unreadable:
@@ -536,9 +542,13 @@ class Modbus:
         value: SunSpecRawData,
         unit_key: str = "leader",
     ) -> None:
-        unit_settings = self.settings.units[unit_key]
-        client = self._clients[unit_key]
-
+        try:
+            unit_settings = self.settings.units[unit_key]
+            client = self._clients[unit_key]
+        except KeyError as error:
+            raise InvalidDataException(
+                f"Unknown modbus unit_key: {unit_key}"
+            ) from error
         logger.info(
             f"Writing {value} to register {register.address} ({register.name})"
             f" on unit {unit_key}"

--- a/solaredge2mqtt/services/modbus/__init__.py
+++ b/solaredge2mqtt/services/modbus/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.exceptions import ModbusException
@@ -79,29 +79,43 @@ class Modbus:
         self._initialized = False
         self._device_info: dict[str, dict[str, ModbusDeviceInfo]] = {}
 
-        self._client: AsyncModbusTcpClient | None = None
+        self._clients: dict[str, AsyncModbusTcpClient] = {}
 
         self._control: ModbusAdvancedControl = ModbusAdvancedControl(settings)
 
         EventBus.register(self)
 
-    @property
-    def client(self) -> AsyncModbusTcpClient:
-        if self._client is None:
-            raise RuntimeError("Modbus client not initialized")
-
-        return self._client
+    def _build_client(
+        self, host: str, port: int, retries: int = 0
+    ) -> AsyncModbusTcpClient:
+        return AsyncModbusTcpClient(
+            host=host,
+            port=port,
+            timeout=self.settings.timeout,
+            retries=retries,
+        )
 
     async def async_init(self) -> None:
         try:
             logger.info("Initializing modbus")
 
-            self._client = AsyncModbusTcpClient(
-                host=self.settings.host,
-                port=self.settings.port,
-                timeout=self.settings.timeout,
-                retries=0,
-            )
+            leader_client = self._build_client(self.settings.host, self.settings.port)
+            self._clients["leader"] = leader_client
+
+            for i, follower in enumerate(self.settings.follower):
+                unit_key = f"follower{i}"
+                if follower.host:
+                    host = follower.host
+                    port = follower.port or self.settings.port
+                    logger.info(
+                        "Unit {unit_key} uses dedicated connection: {host}:{port}",
+                        unit_key=unit_key,
+                        host=host,
+                        port=port,
+                    )
+                    self._clients[unit_key] = self._build_client(host, port)
+                else:
+                    self._clients[unit_key] = leader_client
 
             await self.detect_devices()
 
@@ -125,13 +139,13 @@ class Modbus:
             await EventBus.emit(ModbusOfflineEvent())
             raise
 
-    async def detect_devices(self):
-        async with self.client:
-            for unit_key, unit_settings in self.settings.units.items():
-                logger.info(f"Detecting devices for unit: {unit_key}")
+    async def detect_devices(self) -> None:
+        for unit_key, unit_settings in self.settings.units.items():
+            logger.info(f"Detecting devices for unit: {unit_key}")
 
-                self._device_info[unit_key] = {}
+            self._device_info[unit_key] = {}
 
+            async with self._clients[unit_key]:
                 inverter_raw = await self.read_device_info(
                     SunSpecInverterInfoRegister,
                     unit_key,
@@ -149,7 +163,7 @@ class Modbus:
         unit_key: str,
         unit_settings: ModbusUnitSettings,
         inverter_raw: SunSpecPayload,
-    ):
+    ) -> None:
         """Detect and read meter device information."""
         for meter in SunSpecMeterOffset:
             if not self._should_detect_meter(unit_settings, meter, inverter_raw):
@@ -183,7 +197,7 @@ class Modbus:
     @staticmethod
     def _log_meter_detection_error(
         meter_id: str, inverter_raw: SunSpecPayload, error: Exception
-    ):
+    ) -> None:
         """Log detailed information when meter detection fails."""
         logger.error(
             f"Skipping {meter_id} due to invalid register data in device info",
@@ -202,7 +216,6 @@ class Modbus:
             f"This likely indicates a communication issue with "
             f"{meter_id} or that it is reporting uninitialized data"
         )
-        # Extract meter index from identifier (e.g., "meter0" -> 0)
         meter_idx = meter_id.replace("meter", "")
         logger.info(
             f"If no meter is installed at this position, you can "
@@ -215,7 +228,7 @@ class Modbus:
         unit_key: str,
         unit_settings: ModbusUnitSettings,
         inverter_raw: SunSpecPayload,
-    ):
+    ) -> None:
         """Detect and read battery device information."""
         for battery in SunSpecBatteryOffset:
             if (
@@ -239,7 +252,9 @@ class Modbus:
         unit_settings: ModbusUnitSettings,
         offset: int = 0,
     ) -> SunSpecPayload:
-        raw_data = await self._read_from_modbus(registers, unit_settings.unit, offset)
+        raw_data = await self._read_from_modbus(
+            registers, unit_key, unit_settings.unit, offset
+        )
 
         info = ModbusDeviceInfo.from_sunspec(
             raw_data,
@@ -254,20 +269,16 @@ class Modbus:
         self._device_info[unit_key][key] = info
         return raw_data
 
-    async def check_readable_registers(self):
-        self._client = AsyncModbusTcpClient(
-            host=self.settings.host,
-            port=self.settings.port,
-            timeout=self.settings.timeout,
-            retries=1,
-        )
-
-        async with self._client:
-            for unit_key, unit_settings in self.settings.units.items():
-                logger.info(
-                    f"Checking modbus registers from unit: {unit_key}",
-                )
-                await self._get_raw_data(unit_key, unit_settings.unit)
+    async def check_readable_registers(self) -> None:
+        for unit_key, unit_settings in self.settings.units.items():
+            logger.info(
+                f"Checking modbus registers from unit: {unit_key}",
+            )
+            host = self.settings.unit_host(unit_key)
+            port = self.settings.unit_port(unit_key)
+            client = self._build_client(host, port, retries=1)
+            async with client:
+                await self._get_raw_data(unit_key, unit_settings.unit, client=client)
 
     async def get_data(
         self,
@@ -275,8 +286,8 @@ class Modbus:
         units: dict[str, ModbusUnit] = {}
 
         try:
-            async with self.client:
-                for unit_key, unit_settings in self.settings.units.items():
+            for unit_key, unit_settings in self.settings.units.items():
+                async with self._clients[unit_key]:
                     (
                         inverter_raw,
                         meters_raw,
@@ -308,24 +319,33 @@ class Modbus:
         return units
 
     async def _get_raw_data(
-        self, unit_key: str, unit: int
+        self,
+        unit_key: str,
+        unit: int,
+        client: AsyncModbusTcpClient | None = None,
     ) -> tuple[SunSpecPayload, dict[str, SunSpecPayload], dict[str, SunSpecPayload]]:
         inverter_raw = await self._read_from_modbus(
             SunSpecInverterRegister.request_bundles(),
+            unit_key,
             unit,
+            client=client,
         )
 
         if self.settings.check_grid_status:
             grid_status_raw = await self._read_from_modbus(
                 SunSpecGridStatusRegister.request_bundles(),
+                unit_key,
                 unit,
+                client=client,
             )
             inverter_raw = {**inverter_raw, **grid_status_raw}
 
         if self.settings.advanced_power_controls_enabled:
             advanced_power_control_raw = await self._read_from_modbus(
                 SunSpecPowerControlRegister.request_bundles(),
+                unit_key,
                 unit,
+                client=client,
             )
             inverter_raw = {
                 **inverter_raw,
@@ -341,16 +361,20 @@ class Modbus:
             if meter.identifier in self._device_info[unit_key]:
                 meters_raw[meter.identifier] = await self._read_from_modbus(
                     SunSpecMeterRegister.request_bundles(),
+                    unit_key,
                     unit,
                     offset=meter.offset,
+                    client=client,
                 )
 
         for battery in SunSpecBatteryOffset:
             if battery.identifier in self._device_info[unit_key]:
                 batteries_raw[battery.identifier] = await self._read_from_modbus(
                     SunSpecBatteryRegister.request_bundles(),
+                    unit_key,
                     unit,
                     offset=battery.offset,
+                    client=client,
                 )
 
         return inverter_raw, meters_raw, batteries_raw
@@ -359,10 +383,13 @@ class Modbus:
         self,
         registers_or_bundles: type[SunSpecRegister]
         | list[SunSpecRequestRegisterBundle],
+        unit_key: str,
         unit: int,
         offset: int = 0,
+        client: AsyncModbusTcpClient | None = None,
     ) -> SunSpecPayload:
-        data = {}
+        effective_client = client if client is not None else self._clients[unit_key]
+        data: dict[str, Any] = {}
 
         for register_or_bundle in registers_or_bundles:
             address_start = register_or_bundle.address + offset
@@ -379,7 +406,7 @@ class Modbus:
             )
 
             try:
-                result = await self.client.read_holding_registers(
+                result = await effective_client.read_holding_registers(
                     device_id=unit,
                     address=address_start,
                     count=register_or_bundle.length,
@@ -500,23 +527,32 @@ class Modbus:
         return batteries
 
     @EventBus.subscribe(ModbusWriteEvent)
-    async def _handle_write_event(self, event: ModbusWriteEvent):
-        await self._write_to_modbus(event.register, event.payload)
+    async def _handle_write_event(self, event: ModbusWriteEvent) -> None:
+        await self._write_to_modbus(event.register, event.payload, event.unit_key)
 
     async def _write_to_modbus(
-        self, register: SunSpecRegister, value: SunSpecRawData
+        self,
+        register: SunSpecRegister,
+        value: SunSpecRawData,
+        unit_key: str = "leader",
     ) -> None:
-        logger.info(f"Writing {value} to register {register.address} ({register.name})")
+        unit_settings = self.settings.units[unit_key]
+        client = self._clients[unit_key]
+
+        logger.info(
+            f"Writing {value} to register {register.address} ({register.name})"
+            f" on unit {unit_key}"
+        )
 
         value_decoded = register.encode_request(value)
         logger.trace(f"Encoded value: {value_decoded}")
 
         try:
-            async with self.client:
-                await self.client.write_registers(
+            async with client:
+                await client.write_registers(
                     register.address,
                     value_decoded,
-                    device_id=self.settings.unit,
+                    device_id=unit_settings.unit,
                 )
 
         except ModbusException as error:

--- a/solaredge2mqtt/services/modbus/events.py
+++ b/solaredge2mqtt/services/modbus/events.py
@@ -24,9 +24,15 @@ class ModbusUnitsReadEvent(BaseEvent):
 class ModbusWriteEvent(BaseEvent):
     AWAIT = True
 
-    def __init__(self, register: SunSpecRegister, payload: SunSpecRawData):
+    def __init__(
+        self,
+        register: SunSpecRegister,
+        payload: SunSpecRawData,
+        unit_key: str = "leader",
+    ):
         self._register = register
         self._payload = payload
+        self._unit_key = unit_key
 
     @property
     def register(self) -> SunSpecRegister:
@@ -35,6 +41,10 @@ class ModbusWriteEvent(BaseEvent):
     @property
     def payload(self) -> SunSpecRawData:
         return self._payload
+
+    @property
+    def unit_key(self) -> str:
+        return self._unit_key
 
 
 class ModbusOnlineEvent(ServiceOnlineEvent):

--- a/solaredge2mqtt/services/modbus/settings.py
+++ b/solaredge2mqtt/services/modbus/settings.py
@@ -75,6 +75,11 @@ class ModbusUnitSettings(BaseModel):
         return values
 
 
+class ModbusFollowerSettings(ModbusUnitSettings):
+    host: str | None = Field(default=None)
+    port: int | None = Field(default=None)
+
+
 class ModbusSettings(ModbusUnitSettings):
     host: str
     port: int = Field(default=1502)
@@ -86,7 +91,7 @@ class ModbusSettings(ModbusUnitSettings):
         default=AdvancedControlsSettings.DISABLED
     )
 
-    follower: list[ModbusUnitSettings] = Field(default_factory=list)
+    follower: list[ModbusFollowerSettings] = Field(default_factory=list)
 
     retain: bool = Field(default=False)
 
@@ -128,3 +133,15 @@ class ModbusSettings(ModbusUnitSettings):
     @property
     def has_followers(self) -> bool:
         return len(self.follower) > 0
+
+    def unit_host(self, unit_key: str) -> str:
+        if unit_key == "leader":
+            return self.host
+        idx = int(unit_key.removeprefix("follower"))
+        return self.follower[idx].host or self.host
+
+    def unit_port(self, unit_key: str) -> int:
+        if unit_key == "leader":
+            return self.port
+        idx = int(unit_key.removeprefix("follower"))
+        return self.follower[idx].port or self.port

--- a/solaredge2mqtt/services/modbus/settings.py
+++ b/solaredge2mqtt/services/modbus/settings.py
@@ -137,11 +137,19 @@ class ModbusSettings(ModbusUnitSettings):
     def unit_host(self, unit_key: str) -> str:
         if unit_key == "leader":
             return self.host
-        idx = int(unit_key.removeprefix("follower"))
-        return self.follower[idx].host or self.host
+
+        unit = self.units.get(unit_key)
+        if unit is None or not isinstance(unit, ModbusFollowerSettings):
+            raise ValueError(f"Unknown modbus unit_key: {unit_key}")
+
+        return unit.host or self.host
 
     def unit_port(self, unit_key: str) -> int:
         if unit_key == "leader":
             return self.port
-        idx = int(unit_key.removeprefix("follower"))
-        return self.follower[idx].port or self.port
+
+        unit = self.units.get(unit_key)
+        if unit is None or not isinstance(unit, ModbusFollowerSettings):
+            raise ValueError(f"Unknown modbus unit_key: {unit_key}")
+
+        return unit.port or self.port

--- a/tests/services/forecast/test_service_hyperparameter.py
+++ b/tests/services/forecast/test_service_hyperparameter.py
@@ -53,7 +53,9 @@ class TestForecasterHyperparameterTuning:
 
         y_vector = cast(Series, data["energy"])
         x_data = data.drop(columns=["energy"])
-        pipeline = forecaster._prepare_model_pipeline(x_data.columns.to_list())
+        pipeline = forecaster._prepare_model_pipeline(
+            x_data.columns.to_list(), n_repeats=2
+        )
 
         # This will do actual hyperparameter tuning (slow but tests the method)
         result = forecaster._hyperparametertuning(x_data, y_vector, pipeline)

--- a/tests/services/modbus/test_events.py
+++ b/tests/services/modbus/test_events.py
@@ -61,3 +61,19 @@ class TestModbusWriteEvent:
         event = ModbusWriteEvent(register, True)
 
         assert event.payload is True
+
+    def test_event_unit_key_defaults_to_leader(self):
+        """Test unit_key defaults to leader when not specified."""
+        register = SunSpecPowerControlRegister.ACTIVE_POWER_LIMIT
+
+        event = ModbusWriteEvent(register, 100)
+
+        assert event.unit_key == "leader"
+
+    def test_event_unit_key_custom(self):
+        """Test unit_key can be set to a follower."""
+        register = SunSpecPowerControlRegister.ACTIVE_POWER_LIMIT
+
+        event = ModbusWriteEvent(register, 100, unit_key="follower0")
+
+        assert event.unit_key == "follower0"

--- a/tests/services/modbus/test_service.py
+++ b/tests/services/modbus/test_service.py
@@ -29,6 +29,8 @@ def mock_service_settings():
     # Create unit settings
     mock_unit_settings = MagicMock()
     mock_unit_settings.unit = 1
+    mock_unit_settings.host = None
+    mock_unit_settings.port = None
     mock_unit_settings.role = "leader"
     mock_unit_settings.meter = [True, False, False]
     mock_unit_settings.battery = [True, False]
@@ -69,7 +71,7 @@ class TestModbusInit:
         modbus = Modbus(mock_service_settings)
 
         assert modbus.settings is mock_service_settings.modbus
-        assert modbus._client is None
+        assert modbus._clients == {}
         assert modbus._initialized is False
         mock_event_bus.register.assert_called_once_with(modbus)
 
@@ -79,15 +81,6 @@ class TestModbusInit:
 
         mock_event_bus.register.assert_called_once()
 
-    def test_client_property_raises_when_uninitialized(
-        self, mock_service_settings, mock_event_bus
-    ):
-        """Client property should raise before async_init."""
-        modbus = Modbus(mock_service_settings)
-
-        with pytest.raises(RuntimeError):
-            _ = modbus.client
-
 
 class TestModbusAsyncInit:
     """Tests for Modbus async_init."""
@@ -96,7 +89,7 @@ class TestModbusAsyncInit:
     async def test_async_init(
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
-        """Test async_init initializes client and detects devices."""
+        """Test async_init initializes clients and detects devices."""
         modbus = Modbus(mock_service_settings)
         modbus.detect_devices = AsyncMock()
         modbus.check_readable_registers = AsyncMock()
@@ -106,7 +99,7 @@ class TestModbusAsyncInit:
         ):
             await modbus.async_init()
 
-        assert modbus._client is not None
+        assert "leader" in modbus._clients
         modbus.detect_devices.assert_called_once()
         modbus.check_readable_registers.assert_called_once()
         assert modbus._initialized is True
@@ -137,7 +130,7 @@ class TestModbusAsyncInit:
     ):
         """detect_devices should read inverter info and run detectors."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus.read_device_info = AsyncMock(return_value={"meter0": 1})
         modbus._detect_meters = AsyncMock()
         modbus._detect_batteries = AsyncMock()
@@ -154,7 +147,7 @@ class TestModbusAsyncInit:
     ):
         """get_data should set offline and re-raise on exception."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus._device_info = {"leader": {"inverter": MagicMock()}}
         modbus._get_raw_data = AsyncMock(
             side_effect=InvalidDataException("Invalid data")
@@ -169,7 +162,7 @@ class TestModbusAsyncInit:
     ):
         """async_init should set offline state and re-raise on exception."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus.detect_devices = AsyncMock(
             side_effect=InvalidDataException("Invalid data")
         )
@@ -183,7 +176,7 @@ class TestModbusAsyncInit:
     ):
         """detect_devices should set offline state and re-raise on exception."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus.read_device_info = AsyncMock(
             side_effect=InvalidDataException("Invalid data")
         )
@@ -205,7 +198,10 @@ class TestModbusAsyncInit:
 
             await modbus.check_readable_registers()
 
-        modbus._get_raw_data.assert_called_once_with("leader", 1)
+        modbus._get_raw_data.assert_called_once()
+        call_args = modbus._get_raw_data.call_args
+        assert call_args[0][0] == "leader"
+        assert call_args[0][1] == 1
 
     @pytest.mark.asyncio
     async def test_read_device_info_stores_discovered_device(
@@ -217,6 +213,7 @@ class TestModbusAsyncInit:
         modbus._read_from_modbus = AsyncMock(return_value={"c_model": "X"})
 
         mock_info = MagicMock()
+        modbus._clients = {"leader": AsyncMock()}
         with patch(
             "solaredge2mqtt.services.modbus.ModbusDeviceInfo.from_sunspec",
             return_value=mock_info,
@@ -230,6 +227,124 @@ class TestModbusAsyncInit:
 
         assert result == {"c_model": "X"}
         assert modbus._device_info["leader"]["inverter"] is mock_info
+
+
+class TestModbusAsyncInitFollowerWithOwnIp:
+    """Tests for async_init with followers that have their own IP."""
+
+    def _make_settings(
+        self,
+        mock_event_bus: object,
+        follower_host: str | None,
+        follower_port: int | None = None,
+    ) -> MagicMock:
+        settings = MagicMock()
+        settings.modbus.host = "192.168.1.10"  # noqa: S1313
+        settings.modbus.port = 1502
+        settings.modbus.timeout = 1
+        settings.modbus.debounce_cycles = 0
+        settings.modbus.has_followers = True
+
+        leader_unit = MagicMock()
+        leader_unit.unit = 1
+        leader_unit.host = None
+        leader_unit.port = None
+
+        follower_unit = MagicMock()
+        follower_unit.unit = 2
+        follower_unit.host = follower_host
+        follower_unit.port = follower_port
+
+        settings.modbus.units = {"leader": leader_unit, "follower0": follower_unit}
+        settings.modbus.follower = [follower_unit]
+        return settings
+
+    @pytest.mark.asyncio
+    async def test_async_init_builds_dedicated_client_for_follower_with_host(
+        self, mock_event_bus
+    ):
+        """async_init builds a separate client for a follower with its own host."""
+        settings = self._make_settings(mock_event_bus, "192.168.1.11")  # noqa: S1313
+
+        modbus = Modbus(settings)
+        modbus.detect_devices = AsyncMock()
+        modbus.check_readable_registers = AsyncMock()
+
+        created_clients: list[tuple[str, int]] = []
+
+        def capture_client(host: str, port: int, **_kwargs: object) -> AsyncMock:
+            created_clients.append((host, port))
+            return AsyncMock()
+
+        with (
+            patch(
+                "solaredge2mqtt.services.modbus.asyncio.sleep", new_callable=AsyncMock
+            ),
+            patch(
+                "solaredge2mqtt.services.modbus.AsyncModbusTcpClient",
+                side_effect=capture_client,
+            ),
+        ):
+            await modbus.async_init()
+
+        assert ("192.168.1.10", 1502) in created_clients  # noqa: S1313
+        assert ("192.168.1.11", 1502) in created_clients  # noqa: S1313
+        assert "leader" in modbus._clients
+        assert "follower0" in modbus._clients
+        assert modbus._clients["leader"] is not modbus._clients["follower0"]
+
+    @pytest.mark.asyncio
+    async def test_async_init_follower_without_host_reuses_leader_client(
+        self, mock_event_bus
+    ):
+        """async_init reuses the leader client for a follower without its own host."""
+        settings = self._make_settings(mock_event_bus, None)
+
+        modbus = Modbus(settings)
+        modbus.detect_devices = AsyncMock()
+        modbus.check_readable_registers = AsyncMock()
+
+        with (
+            patch(
+                "solaredge2mqtt.services.modbus.asyncio.sleep", new_callable=AsyncMock
+            ),
+            patch(
+                "solaredge2mqtt.services.modbus.AsyncModbusTcpClient",
+                return_value=AsyncMock(),
+            ) as client_cls,
+        ):
+            await modbus.async_init()
+
+        assert client_cls.call_count == 1
+        assert modbus._clients["leader"] is modbus._clients["follower0"]
+
+    @pytest.mark.asyncio
+    async def test_async_init_follower_uses_custom_port(self, mock_event_bus):
+        """async_init should use the follower's custom port when specified."""
+        settings = self._make_settings(mock_event_bus, "192.168.1.11", 502)  # noqa: S1313
+
+        modbus = Modbus(settings)
+        modbus.detect_devices = AsyncMock()
+        modbus.check_readable_registers = AsyncMock()
+
+        created_clients: list[tuple[str, int]] = []
+
+        def capture_client(host: str, port: int, **_kwargs: object) -> AsyncMock:
+            created_clients.append((host, port))
+            return AsyncMock()
+
+        with (
+            patch(
+                "solaredge2mqtt.services.modbus.asyncio.sleep", new_callable=AsyncMock
+            ),
+            patch(
+                "solaredge2mqtt.services.modbus.AsyncModbusTcpClient",
+                side_effect=capture_client,
+            ),
+        ):
+            await modbus.async_init()
+
+        assert ("192.168.1.11", 502) in created_clients  # noqa: S1313
 
 
 class TestModbusRawDataCollection:
@@ -339,21 +454,19 @@ class TestModbusReadFromModbus:
     ):
         """Test successful modbus read."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
 
-        # Mock register bundle
         mock_bundle = MagicMock()
         mock_bundle.address = 40000
         mock_bundle.length = 10
         mock_bundle.decode_response.return_value = {"field": "value"}
 
-        # Mock successful read
         mock_result = MagicMock()
         mock_result.isError.return_value = False
         mock_result.registers = [1, 2, 3]
         mock_modbus_client.read_holding_registers.return_value = mock_result
 
-        result = await modbus._read_from_modbus([mock_bundle], 1)
+        result = await modbus._read_from_modbus([mock_bundle], "leader", 1)
 
         assert result == {"field": "value"}
         mock_modbus_client.read_holding_registers.assert_called_once()
@@ -364,7 +477,7 @@ class TestModbusReadFromModbus:
     ):
         """Successful read should also work when service is already initialized."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus._initialized = True
 
         mock_bundle = MagicMock()
@@ -377,7 +490,7 @@ class TestModbusReadFromModbus:
         mock_result.registers = [1, 2]
         mock_modbus_client.read_holding_registers.return_value = mock_result
 
-        result = await modbus._read_from_modbus([mock_bundle], 1)
+        result = await modbus._read_from_modbus([mock_bundle], "leader", 1)
 
         assert result == {"value": 1}
 
@@ -387,20 +500,18 @@ class TestModbusReadFromModbus:
     ):
         """Test modbus read error blocks register."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus._initialized = False
 
-        # Mock register bundle
         mock_bundle = MagicMock()
         mock_bundle.address = 40000
         mock_bundle.length = 10
 
-        # Mock error result
         mock_result = MagicMock()
         mock_result.isError.return_value = True
         mock_modbus_client.read_holding_registers.return_value = mock_result
 
-        await modbus._read_from_modbus([mock_bundle], 1)
+        await modbus._read_from_modbus([mock_bundle], "leader", 1)
 
         assert 40000 in modbus._block_unreadable
 
@@ -410,20 +521,18 @@ class TestModbusReadFromModbus:
     ):
         """Test modbus exception blocks register."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus._initialized = False
 
-        # Mock register bundle
         mock_bundle = MagicMock()
         mock_bundle.address = 40000
         mock_bundle.length = 10
 
-        # Mock exception
         mock_modbus_client.read_holding_registers.side_effect = ModbusException(
             "Test error"
         )
 
-        await modbus._read_from_modbus([mock_bundle], 1)
+        await modbus._read_from_modbus([mock_bundle], "leader", 1)
 
         assert 40000 in modbus._block_unreadable
 
@@ -433,18 +542,42 @@ class TestModbusReadFromModbus:
     ):
         """Test modbus read skips blocked registers."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus._block_unreadable = {40000}
 
-        # Mock register bundle for blocked address
         mock_bundle = MagicMock()
         mock_bundle.address = 40000
         mock_bundle.length = 10
 
-        await modbus._read_from_modbus([mock_bundle], 1)
+        await modbus._read_from_modbus([mock_bundle], "leader", 1)
 
-        # Should not have called read
         mock_modbus_client.read_holding_registers.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_from_modbus_uses_explicit_client_override(
+        self, mock_service_settings, mock_event_bus, mock_modbus_client
+    ):
+        """Explicit client parameter overrides the stored client for the unit."""
+        modbus = Modbus(mock_service_settings)
+        stored_client = AsyncMock()
+        modbus._clients = {"leader": stored_client}
+
+        mock_bundle = MagicMock()
+        mock_bundle.address = 40000
+        mock_bundle.length = 2
+        mock_bundle.decode_response.return_value = {"v": 1}
+
+        mock_result = MagicMock()
+        mock_result.isError.return_value = False
+        mock_result.registers = [1]
+        mock_modbus_client.read_holding_registers.return_value = mock_result
+
+        await modbus._read_from_modbus(
+            [mock_bundle], "leader", 1, client=mock_modbus_client
+        )
+
+        mock_modbus_client.read_holding_registers.assert_called_once()
+        stored_client.read_holding_registers.assert_not_called()
 
 
 class TestModbusGetData:
@@ -456,10 +589,9 @@ class TestModbusGetData:
     ):
         """Test get_data returns units."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus._initialized = True
 
-        # Setup device info
         mock_info = MagicMock()
         mock_unit_info = MagicMock()
         mock_unit_info.unit = 1
@@ -472,15 +604,12 @@ class TestModbusGetData:
             }
         }
 
-        # Mock _get_raw_data
         modbus._get_raw_data = AsyncMock(return_value=({}, {}, {}))
 
-        # Mock mappers - create properly structured mock objects
         with patch("solaredge2mqtt.services.modbus.ModbusUnit") as mock_unit_class:
             mock_unit_instance = MagicMock()
             mock_unit_class.return_value = mock_unit_instance
 
-            # Mock _map_inverter to return a proper mock
             mock_inverter = MagicMock()
             mock_inverter.info = mock_info
             mock_inverter.info.unit = mock_unit_info
@@ -490,7 +619,6 @@ class TestModbusGetData:
 
             await modbus.get_data()
 
-            # Should emit ModbusUnitsReadEvent (plus MQTTPublishEvent from state)
             assert mock_event_bus.emit.call_count >= 1
             emitted_types = [type(c[0][0]) for c in mock_event_bus.emit.call_args_list]
             assert ModbusUnitsReadEvent in emitted_types
@@ -501,11 +629,10 @@ class TestModbusGetData:
     ):
         """Test get_data raises on KeyError."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
         modbus._initialized = True
         modbus._device_info = {}
 
-        # Mock _get_raw_data to raise KeyError
         modbus._get_raw_data = AsyncMock(side_effect=KeyError("missing key"))
 
         with pytest.raises(InvalidDataException):
@@ -585,9 +712,9 @@ class TestModbusWriteToModbus:
     async def test_write_to_modbus_success(
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
-        """Test successful modbus write."""
+        """Test successful modbus write to leader."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
 
         mock_register = MagicMock()
         mock_register.address = 40000
@@ -599,12 +726,42 @@ class TestModbusWriteToModbus:
         mock_modbus_client.write_registers.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_write_to_modbus_uses_unit_settings_device_id(
+        self, mock_service_settings, mock_event_bus, mock_modbus_client
+    ):
+        """
+        _write_to_modbus should use the unit's device_id
+        and client for the given unit_key.
+        """
+        follower_client = AsyncMock()
+        follower_unit = MagicMock()
+        follower_unit.unit = 3
+        mock_service_settings.modbus.units = {
+            "leader": mock_service_settings.modbus.units["leader"],
+            "follower0": follower_unit,
+        }
+
+        modbus = Modbus(mock_service_settings)
+        modbus._clients = {"leader": mock_modbus_client, "follower0": follower_client}
+
+        mock_register = MagicMock()
+        mock_register.address = 40000
+        mock_register.name = "test_register"
+        mock_register.encode_request.return_value = [1, 2, 3]
+
+        await modbus._write_to_modbus(mock_register, 100, unit_key="follower0")
+
+        follower_client.write_registers.assert_called_once()
+        mock_modbus_client.write_registers.assert_not_called()
+        assert follower_client.write_registers.call_args.kwargs["device_id"] == 3
+
+    @pytest.mark.asyncio
     async def test_write_to_modbus_exception(
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
         """Test modbus write handles exception."""
         modbus = Modbus(mock_service_settings)
-        modbus._client = mock_modbus_client
+        modbus._clients = {"leader": mock_modbus_client}
 
         mock_register = MagicMock()
         mock_register.address = 40000
@@ -613,7 +770,6 @@ class TestModbusWriteToModbus:
 
         mock_modbus_client.write_registers.side_effect = ModbusException("Write error")
 
-        # Should not raise, just log error
         await modbus._write_to_modbus(mock_register, 100)
 
 
@@ -624,7 +780,7 @@ class TestModbusHandleWriteEvent:
     async def test_handle_write_event(
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
-        """Test handling write event."""
+        """Test handling write event passes register, payload and unit_key."""
         modbus = Modbus(mock_service_settings)
         modbus._write_to_modbus = AsyncMock()
 
@@ -633,4 +789,19 @@ class TestModbusHandleWriteEvent:
 
         await modbus._handle_write_event(event)
 
-        modbus._write_to_modbus.assert_called_once_with(mock_register, 100)
+        modbus._write_to_modbus.assert_called_once_with(mock_register, 100, "leader")
+
+    @pytest.mark.asyncio
+    async def test_handle_write_event_with_follower_unit_key(
+        self, mock_service_settings, mock_event_bus, mock_modbus_client
+    ):
+        """Test handling write event forwards custom unit_key to _write_to_modbus."""
+        modbus = Modbus(mock_service_settings)
+        modbus._write_to_modbus = AsyncMock()
+
+        mock_register = MagicMock()
+        event = ModbusWriteEvent(mock_register, 50, unit_key="follower0")
+
+        await modbus._handle_write_event(event)
+
+        modbus._write_to_modbus.assert_called_once_with(mock_register, 50, "follower0")

--- a/tests/services/modbus/test_service.py
+++ b/tests/services/modbus/test_service.py
@@ -772,6 +772,23 @@ class TestModbusWriteToModbus:
 
         await modbus._write_to_modbus(mock_register, 100)
 
+    @pytest.mark.asyncio
+    async def test_write_to_modbus_unknown_unit_key(
+        self, mock_service_settings, mock_event_bus, mock_modbus_client
+    ):
+        """Test _write_to_modbus raises InvalidDataException for unknown unit_key."""
+        modbus = Modbus(mock_service_settings)
+        modbus._clients = {"leader": mock_modbus_client}
+
+        mock_register = MagicMock()
+        mock_register.address = 40000
+        mock_register.name = "test_register"
+
+        with pytest.raises(InvalidDataException, match="Unknown modbus unit_key"):
+            await modbus._write_to_modbus(mock_register, 100, unit_key="unknown")
+
+        mock_modbus_client.write_registers.assert_not_called()
+
 
 class TestModbusHandleWriteEvent:
     """Tests for Modbus _handle_write_event."""

--- a/tests/services/modbus/test_settings.py
+++ b/tests/services/modbus/test_settings.py
@@ -1,5 +1,7 @@
 """Tests for modbus settings module."""
 
+import pytest
+
 from solaredge2mqtt.services.modbus.models.base import ModbusUnitRole
 from solaredge2mqtt.services.modbus.settings import (
     AdvancedControlsSettings,
@@ -275,6 +277,13 @@ class TestModbusSettings:
 
         assert settings.unit_host("follower0") == "192.168.1.11"  # noqa: S1313
 
+    def test_unit_host_raises_for_unknown_unit_key(self):
+        """unit_host raises ValueError for an unknown unit_key."""
+        settings = ModbusSettings(host="192.168.1.10")  # noqa: S1313
+
+        with pytest.raises(ValueError, match="Unknown modbus unit_key"):
+            settings.unit_host("follower0")
+
     def test_unit_port_returns_leader_port_for_leader(self):
         """unit_port returns the leader's port for unit_key 'leader'."""
         settings = ModbusSettings(host="192.168.1.10", port=502)  # noqa: S1313
@@ -298,3 +307,10 @@ class TestModbusSettings:
         )
 
         assert settings.unit_port("follower0") == 502
+
+    def test_unit_port_raises_for_unknown_unit_key(self):
+        """unit_port raises ValueError for an unknown unit_key."""
+        settings = ModbusSettings(host="192.168.1.10", port=502)  # noqa: S1313
+
+        with pytest.raises(ValueError, match="Unknown modbus unit_key"):
+            settings.unit_port("follower0")

--- a/tests/services/modbus/test_settings.py
+++ b/tests/services/modbus/test_settings.py
@@ -3,6 +3,7 @@
 from solaredge2mqtt.services.modbus.models.base import ModbusUnitRole
 from solaredge2mqtt.services.modbus.settings import (
     AdvancedControlsSettings,
+    ModbusFollowerSettings,
     ModbusSettings,
     ModbusUnitSettings,
 )
@@ -214,3 +215,86 @@ class TestModbusSettings:
 
         assert settings.follower[0].meter == [False, False, False]
         assert settings.follower[0].battery == [False, False]
+
+    def test_modbus_settings_follower_with_own_host(self):
+        """Test that a follower can have its own host and port."""
+        settings = ModbusSettings(
+            host="192.168.1.10",  # noqa: S1313
+            follower=[
+                {"unit": 2, "host": "192.168.1.11", "port": 502},  # pyright: ignore[reportArgumentType]
+            ],
+        )
+
+        assert isinstance(settings.follower[0], ModbusFollowerSettings)
+        assert settings.follower[0].host == "192.168.1.11"  # noqa: S1313
+        assert settings.follower[0].port == 502
+
+    def test_modbus_settings_follower_with_own_host_no_port(self):
+        """Test that a follower can have only its own host without a custom port."""
+        settings = ModbusSettings(
+            host="192.168.1.10",  # noqa: S1313
+            follower=[
+                {"unit": 2, "host": "192.168.1.11"},  # pyright: ignore[reportArgumentType]
+            ],
+        )
+
+        assert settings.follower[0].host == "192.168.1.11"  # noqa: S1313
+        assert settings.follower[0].port is None
+
+    def test_modbus_settings_follower_without_own_host_defaults_to_none(self):
+        """Test that follower host defaults to None when not specified."""
+        settings = ModbusSettings(
+            host="192.168.1.10",  # noqa: S1313
+            follower=[{"unit": 2}],  # pyright: ignore[reportArgumentType]
+        )
+
+        assert settings.follower[0].host is None
+        assert settings.follower[0].port is None
+
+    def test_unit_host_returns_leader_host_for_leader(self):
+        """unit_host returns the leader's host for unit_key 'leader'."""
+        settings = ModbusSettings(host="192.168.1.10")  # noqa: S1313
+
+        assert settings.unit_host("leader") == "192.168.1.10"  # noqa: S1313
+
+    def test_unit_host_falls_back_to_leader_for_follower_without_host(self):
+        """unit_host falls back to leader's host when follower has no own host."""
+        settings = ModbusSettings(
+            host="192.168.1.10",  # noqa: S1313
+            follower=[{"unit": 2}],  # pyright: ignore[reportArgumentType]
+        )
+
+        assert settings.unit_host("follower0") == "192.168.1.10"  # noqa: S1313
+
+    def test_unit_host_returns_follower_host_when_set(self):
+        """unit_host returns the follower's own host when configured."""
+        settings = ModbusSettings(
+            host="192.168.1.10",  # noqa: S1313
+            follower=[{"unit": 2, "host": "192.168.1.11"}],  # pyright: ignore[reportArgumentType]
+        )
+
+        assert settings.unit_host("follower0") == "192.168.1.11"  # noqa: S1313
+
+    def test_unit_port_returns_leader_port_for_leader(self):
+        """unit_port returns the leader's port for unit_key 'leader'."""
+        settings = ModbusSettings(host="192.168.1.10", port=502)  # noqa: S1313
+
+        assert settings.unit_port("leader") == 502
+
+    def test_unit_port_falls_back_to_leader_for_follower_without_port(self):
+        """unit_port falls back to leader's port when follower has no own port."""
+        settings = ModbusSettings(
+            host="192.168.1.10",  # noqa: S1313
+            follower=[{"unit": 2, "host": "192.168.1.11"}],  # pyright: ignore[reportArgumentType]
+        )
+
+        assert settings.unit_port("follower0") == 1502
+
+    def test_unit_port_returns_follower_port_when_set(self):
+        """unit_port returns the follower's own port when configured."""
+        settings = ModbusSettings(
+            host="192.168.1.10",  # noqa: S1313
+            follower=[{"unit": 2, "host": "192.168.1.11", "port": 502}],  # pyright: ignore[reportArgumentType]
+        )
+
+        assert settings.unit_port("follower0") == 502

--- a/tests/services/modbus/test_unicode_exception_handling.py
+++ b/tests/services/modbus/test_unicode_exception_handling.py
@@ -228,7 +228,7 @@ class TestDetectMetersExceptionHandling:
 
             # Mock read_device_info to raise exception for meter0
             async def mock_read_device_info(  # noqa: S7503
-                register_class, uk, identifier, us, offset
+                register_class, uk, identifier, us, offset=0
             ):
                 if identifier == "meter0":
                     raise InvalidRegisterDataException(
@@ -272,7 +272,7 @@ class TestDetectMetersExceptionHandling:
             call_count = 0
 
             async def mock_read_device_info(  # noqa: S7503
-                register_class, uk, identifier, us, offset
+                register_class, uk, identifier, us, offset=0
             ):
                 nonlocal call_count
                 call_count += 1


### PR DESCRIPTION
This pull request adds robust support for SolarEdge multi-inverter setups with both cascaded (shared RS485/TCP) and physically separate (individual TCP) inverters. The codebase is refactored to manage multiple Modbus TCP clients—one per inverter as needed—and the configuration, event, and service logic are updated accordingly. Documentation and configuration examples are expanded to clearly describe both connection types.

**Multi-inverter Modbus connection support:**

* Refactored `solaredge2mqtt/services/modbus/__init__.py` to manage a dictionary of Modbus TCP clients, allowing each inverter (leader or follower) to use either the leader's connection or its own dedicated TCP connection based on configuration. All read/write operations and device detection now correctly select the appropriate client per inverter. [[1]](diffhunk://#diff-9c9fca0d5b3477273377806e9b3db5a8581e0e9433e94cf658d4f5a10980aa90L82-R118) [[2]](diffhunk://#diff-9c9fca0d5b3477273377806e9b3db5a8581e0e9433e94cf658d4f5a10980aa90L242-R257) [[3]](diffhunk://#diff-9c9fca0d5b3477273377806e9b3db5a8581e0e9433e94cf658d4f5a10980aa90R386-R392) [[4]](diffhunk://#diff-9c9fca0d5b3477273377806e9b3db5a8581e0e9433e94cf658d4f5a10980aa90L503-R555)
* Updated the follower configuration model in `solaredge2mqtt/services/modbus/settings.py` to add `host` and `port` fields, so followers can specify their own network connection details; added helper methods to resolve the effective host/port for each unit. [[1]](diffhunk://#diff-0da9e89b83d51fbbe0e54ba600378dbfd6b9c90b7e61a64df4761aed5e885c6fR78-R82) [[2]](diffhunk://#diff-0da9e89b83d51fbbe0e54ba600378dbfd6b9c90b7e61a64df4761aed5e885c6fL89-R94) [[3]](diffhunk://#diff-0da9e89b83d51fbbe0e54ba600378dbfd6b9c90b7e61a64df4761aed5e885c6fR136-R147)

**Event and test enhancements:**

* Modified `ModbusWriteEvent` in `solaredge2mqtt/services/modbus/events.py` to carry a `unit_key` property, ensuring Modbus write events are routed to the correct inverter; added and extended tests for this behavior. [[1]](diffhunk://#diff-7ef4b2083d1a63ea3d5d2a83c572ff22f8436c9eed19ffc9ec9bd13f8fb070f9L27-R35) [[2]](diffhunk://#diff-7ef4b2083d1a63ea3d5d2a83c572ff22f8436c9eed19ffc9ec9bd13f8fb070f9R45-R48) [[3]](diffhunk://#diff-b83e837c9efea9dff5675af891b0a6c001385f8db1220248578a7a9e72694000R64-R79)

**Documentation and configuration examples:**

* Expanded `README.md` and `configuration.yml.example` to clearly document both cascaded and physically separate inverter setups, with detailed YAML examples and explanations of how host/port inheritance works. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R207-L213) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R225-R264) [[3]](diffhunk://#diff-886e457b0effba1ec1f366f4f9f5954d26a11644bcc6bd523d32117a5f1ac64cL43-R59)

**Minor fixes and typing improvements:**

* Various small fixes to type annotations, error logging, and function signatures for clarity and correctness. [[1]](diffhunk://#diff-9c9fca0d5b3477273377806e9b3db5a8581e0e9433e94cf658d4f5a10980aa90L152-R166) [[2]](diffhunk://#diff-9c9fca0d5b3477273377806e9b3db5a8581e0e9433e94cf658d4f5a10980aa90L186-R200) [[3]](diffhunk://#diff-9c9fca0d5b3477273377806e9b3db5a8581e0e9433e94cf658d4f5a10980aa90L205) [[4]](diffhunk://#diff-b490419f436dc070c8c4b50fdcab83f4b9084468a3a5a256049af01a967be6efR32-R33)

These changes make the system much more flexible and reliable for installations with multiple SolarEdge inverters in both shared and separate network configurations.