### PR TITLE
fix: adapt monitoring service to new SolarEdge API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,18 @@
 # Claude Code Instructions
 
-See [AGENTS.md](AGENTS.md) for full project context and conventions.
+See [AGENTS.md](AGENTS.md) for full project context and conventions — read it before
+non-trivial code changes; it is not auto-loaded, this file only points to it.
+
+## Critical rules (violating these is a hard error, not a style nit)
+
+- **No comments in source code** — inline or block. Code must be self-explanatory
+  through naming. Docstrings on tests are fine (required, see below); `#` comments
+  are not, anywhere in `*.py`.
+- All code and docs in **English**.
+- Type hints on all functions; built-in generics (`list[str]`, `dict[str, int]`),
+  not `typing.List`/`typing.Dict`.
+- No wildcard imports; imports at top, grouped stdlib → third-party → local.
+- Most specific exception type possible; avoid bare `Exception`/`BaseException`.
+- `ruff check` and `pyright` must both be clean before considering work done.
+- New code needs tests in `tests/`; minimum coverage 90% (`pytest --cov=solaredge2mqtt`).
+- Never commit secrets; sensitive data stays out of logs.

--- a/monitoring.py
+++ b/monitoring.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+
+from solaredge2mqtt.core.exceptions import ConfigurationException
+from solaredge2mqtt.core.logging import initialize_logging, logger
+from solaredge2mqtt.core.settings import service_settings
+from solaredge2mqtt.services.monitoring import MonitoringSite
+
+
+async def _run(config_dir: str) -> None:
+    settings = service_settings(config_dir)
+    initialize_logging(settings.logging_level)
+
+    if not settings.monitoring.is_configured:
+        logger.error("Monitoring is not configured")
+        return
+
+    monitoring = MonitoringSite(settings.monitoring, None)
+
+    try:
+        modules = await monitoring.get_modules()
+
+        for identifier, module in modules.items():
+            logger.info(
+                "{identifier}: energy={energy} power_slots={power_slots}",
+                identifier=f"{identifier} ({module.info.name})",
+                energy=module.energy,
+                power_slots=len(module.power) if module.power else 0,
+            )
+    finally:
+        await monitoring.close()
+
+
+def run(config_dir: str = "config") -> None:
+    try:
+        asyncio.run(_run(config_dir))
+    except ConfigurationException:
+        logger.error("Configuration error")
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run the SolarEdge2MQTT monitoring service once (single shot)"
+    )
+    parser.add_argument(
+        "--config-dir",
+        type=str,
+        default="config",
+        help="Path to configuration directory (default: config)",
+    )
+    args = parser.parse_args()
+
+    run(config_dir=args.config_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ Issues = "https://github.com/DerOetzi/solaredge2mqtt/issues"
 [project.scripts]
 solaredge2mqtt = "solaredge2mqtt.__main__:main"
 solaredge2mqtt-migrate = "migrate_config:main"
+solaredge2mqtt-monitoring = "monitoring:main"
 
 [project.optional-dependencies]
 dev = [
@@ -77,7 +78,7 @@ include = ["solaredge2mqtt*"]
 exclude = ["tests*"]
 
 [tool.setuptools]
-py-modules = ["migrate_config"]
+py-modules = ["migrate_config", "monitoring"]
 
 [tool.setuptools_scm]
 version_scheme = "post-release"

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -430,16 +430,18 @@ class MonitoringSite(HTTPClientAsync):
     def _decode_optimizers_compact(
         data: dict, day: date
     ) -> dict[str, dict[datetime, float]]:
-        serials = data.get("optimizerSerials", [])
-        slots = data.get("timeSlotsCount", 0)
-        power_values = data.get("compressPowerData", [])
-
-        if not serials or not slots or len(power_values) < 2:
+        if not isinstance(serials, list) or not serials:
             return {}
 
-        # Header layout: [version, payloadStart, (opaqueId, offset)*N, values*N*slots].
-        # offset for optimizer i is always i*slots (verified against optimizerSerials).
+        if not isinstance(slots, int) or slots <= 0 or slots > 24:
+            return {}
+
+        if not isinstance(power_values, list) or len(power_values) < 2:
+            return {}
+
         payload_start = int(power_values[1])
+        if payload_start < 0 or payload_start + len(serials) * slots > len(power_values):
+            return {}
 
         modules: dict[str, dict[datetime, float]] = {}
 
@@ -447,8 +449,10 @@ class MonitoringSite(HTTPClientAsync):
             start = payload_start + index * slots
             values = power_values[start : start + slots]
 
-            modules[serial] = {
-                datetime.combine(day, time(hour=hour)).astimezone(): float(value)
+            modules[str(serial)] = {
+                datetime.combine(day, time(hour=hour, tzinfo=timezone.utc)).astimezone(): float(
+                    value
+                )
                 for hour, value in enumerate(values)
             }
 

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -318,10 +318,10 @@ class MonitoringSite(HTTPClientAsync):
             for optimizer_data in inverter_data.get("optimizers", []):
                 if not isinstance(optimizer_data, dict):
                     continue
-                serial = optimizer_data.get("serial")
+                optimizer_serial = optimizer_data.get("serial")
                 energy = (optimizer_data.get("energy") or {}).get("value")
-                if serial and energy is not None:
-                    optimizers_energy[str(serial)] = float(energy)
+                if optimizer_serial and energy is not None:
+                    optimizers_energy[str(optimizer_serial)] = float(energy)
 
             inverter_energy = inverter_data.get("energy")
 
@@ -437,6 +437,10 @@ class MonitoringSite(HTTPClientAsync):
     def _decode_optimizers_compact(
         data: dict, day: date
     ) -> dict[str, dict[datetime, float]]:
+        serials = data.get("optimizerSerials", [])
+        slots = data.get("timeSlotsCount", 0)
+        power_values = data.get("compressPowerData", [])
+
         if not isinstance(serials, list) or not serials:
             return {}
 
@@ -446,8 +450,11 @@ class MonitoringSite(HTTPClientAsync):
         if not isinstance(power_values, list) or len(power_values) < 2:
             return {}
 
+        # Header layout: [version, payloadStart, (opaqueId, offset)*N, values*N*slots].
+        # offset for optimizer i is always i*slots (verified against optimizerSerials).
         payload_start = int(power_values[1])
-        if payload_start < 0 or payload_start + len(serials) * slots > len(power_values):
+        payload_end = payload_start + len(serials) * slots
+        if payload_start < 0 or payload_end > len(power_values):
             return {}
 
         modules: dict[str, dict[datetime, float]] = {}
@@ -457,9 +464,7 @@ class MonitoringSite(HTTPClientAsync):
             values = power_values[start : start + slots]
 
             modules[str(serial)] = {
-                datetime.combine(day, time(hour=hour, tzinfo=timezone.utc)).astimezone(): float(
-                    value
-                )
+                datetime.combine(day, time(hour=hour)).astimezone(): float(value)
                 for hour, value in enumerate(values)
             }
 

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -192,7 +192,12 @@ class MonitoringSite(HTTPClientAsync):
     async def _load_structure(self) -> None:
         try:
             logical = await self._get_logical()
-            self._cached_structure = logical["siteStructure"]
+            site_structure = logical.get("siteStructure")
+            if not isinstance(site_structure, dict):
+                raise InvalidDataException(
+                    "Unexpected response format when reading logical layout"
+                )
+            self._cached_structure = site_structure
             logger.info("Loaded monitoring site structure")
         except (
             ClientResponseError,

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -305,16 +305,23 @@ class MonitoringSite(HTTPClientAsync):
             if not serial:
                 continue
 
-            strings_energy = {
-                string_data["stringRelativeOrder"]: string_data["energy"]["value"]
-                for string_data in inverter_data.get("strings", [])
-                if string_data.get("energy") and "stringRelativeOrder" in string_data
-            }
-            optimizers_energy = {
-                optimizer_data["serial"]: optimizer_data["energy"]["value"]
-                for optimizer_data in inverter_data.get("optimizers", [])
-                if optimizer_data.get("energy") and optimizer_data.get("serial")
-            }
+            strings_energy: dict[int, float] = {}
+            for string_data in inverter_data.get("strings", []):
+                if not isinstance(string_data, dict):
+                    continue
+                order = string_data.get("stringRelativeOrder")
+                energy = (string_data.get("energy") or {}).get("value")
+                if isinstance(order, int) and energy is not None:
+                    strings_energy[order] = float(energy)
+
+            optimizers_energy: dict[str, float] = {}
+            for optimizer_data in inverter_data.get("optimizers", []):
+                if not isinstance(optimizer_data, dict):
+                    continue
+                serial = optimizer_data.get("serial")
+                energy = (optimizer_data.get("energy") or {}).get("value")
+                if serial and energy is not None:
+                    optimizers_energy[str(serial)] = float(energy)
 
             inverter_energy = inverter_data.get("energy")
 

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -450,8 +450,6 @@ class MonitoringSite(HTTPClientAsync):
         if not isinstance(power_values, list) or len(power_values) < 2:
             return {}
 
-        # Header layout: [version, payloadStart, (opaqueId, offset)*N, values*N*slots].
-        # offset for optimizer i is always i*slots (verified against optimizerSerials).
         payload_start = int(power_values[1])
         payload_end = payload_start + len(serials) * slots
         if payload_start < 0 or payload_end > len(power_values):

--- a/solaredge2mqtt/services/monitoring/__init__.py
+++ b/solaredge2mqtt/services/monitoring/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
-import json
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timezone
 
 from aiohttp import ClientResponseError
 
@@ -31,8 +30,11 @@ from solaredge2mqtt.services.monitoring.models import (
 from solaredge2mqtt.services.monitoring.settings import MonitoringSettings
 
 LOGIN_URL = "https://monitoring.solaredge.com/solaredge-apigw/api/login"
-LOGICAL_URL = "https://monitoring.solaredge.com/solaredge-apigw/api/sites/{site_id}/layout/logical"
-POWER_PUBLIC_URL = "https://monitoring.solaredge.com/solaredge-web/p/playbackData"
+LOGICAL_URL = "https://monitoring.solaredge.com/services/layout/logical/generic/v2/site/{site_id}?include-optimizers=true"
+ENERGY_BY_INVERTER_URL = (
+    "https://monitoring.solaredge.com/services/layout/energy/site/{site_id}/by-inverter"
+)
+OPTIMIZERS_COMPACT_URL = "https://monitoring.solaredge.com/services/layout/playback/site/{site_id}/optimizers-compact"
 DEVICES_URL = "https://monitoring.solaredge.com/services/api/homeautomation/v1.0/sites/{site_id}/devices"
 CHARGING_CONTROL_URL = "https://monitoring.solaredge.com/services/m/api/homeautomation/v1.0/{site_id}/devices/{device_id}/activationState"
 CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded"
@@ -50,11 +52,13 @@ class MonitoringSite(HTTPClientAsync):
         self.influxdb: InfluxDBAsync | None = influxdb
 
         self.found_evchargers: bool = False
+        self._cached_structure: dict | None = None
 
         EventBus.register(self)
 
     async def async_init(self) -> None:
         await self._discover_evchargers()
+        await self._load_structure()
 
     async def _discover_evchargers(self) -> None:
         try:
@@ -167,10 +171,7 @@ class MonitoringSite(HTTPClientAsync):
     @EventBus.subscribe(Interval15MinTriggerEvent)
     async def get_data(self, event: Interval15MinTriggerEvent | None) -> None:
         try:
-            energies = await self.get_modules_energy()
-            powers = await self.get_modules_power()
-
-            modules = self.merge_modules(energies, powers)
+            modules = await self.get_modules()
 
             energy_total = 0
             count_modules = 0
@@ -182,12 +183,45 @@ class MonitoringSite(HTTPClientAsync):
             await EventBus.emit(MonitoringOfflineEvent())
             raise
 
-    async def get_modules_energy(self) -> dict[str, LogicalModule]:
-        logical = await self._get_logical()
+    async def get_modules(self) -> dict[str, LogicalModule]:
+        energies = await self.get_modules_energy()
+        powers = await self.get_modules_power()
 
-        inverters = self._parse_inverters(
-            logical["logicalTree"]["children"], logical["reportersData"]
-        )
+        return self.merge_modules(energies, powers)
+
+    async def _load_structure(self) -> None:
+        try:
+            logical = await self._get_logical()
+            self._cached_structure = logical["siteStructure"]
+            logger.info("Loaded monitoring site structure")
+        except (
+            ClientResponseError,
+            asyncio.TimeoutError,
+            ConfigurationException,
+            InvalidDataException,
+        ) as error:
+            logger.warning(
+                "Unable to load monitoring site structure: {error}", error=error
+            )
+
+    async def get_modules_energy(self) -> dict[str, LogicalModule]:
+        if self._cached_structure is None:
+            await self._load_structure()
+
+        if self._cached_structure is None:
+            raise InvalidDataException("Monitoring site structure is not available")
+
+        site_structure = self._cached_structure
+
+        inverter_serials = [
+            inverter_node["serial"]
+            for inverter_node in self._folder_children(site_structure, "INVERTER")
+            if inverter_node.get("type") == "INVERTER" and inverter_node.get("serial")
+        ]
+
+        energy_by_inverter = await self._get_energy_by_inverter(inverter_serials)
+
+        inverters = self._parse_inverters(site_structure, energy_by_inverter)
 
         modules = {}
 
@@ -225,124 +259,195 @@ class MonitoringSite(HTTPClientAsync):
         except (ClientResponseError, asyncio.TimeoutError) as error:
             raise InvalidDataException("Unable to read logical layout") from error
 
-    def _parse_inverters(self, inverter_objs, reporters_data) -> list[LogicalInverter]:
-        inverters = []
+    async def _get_energy_by_inverter(self, inverter_serials: list[str]) -> dict:
+        if not inverter_serials:
+            return {}
 
-        for inverter_obj in inverter_objs:
-            info = LogicalInfo.map(inverter_obj["data"])
-            if "INVERTER" in info["type"]:
-                inverter = LogicalInverter.model_validate(
-                    {
-                        "info": info,
-                        "energy": (
-                            reporters_data[info["identifier"]]["unscaledEnergy"]
-                            if info["identifier"] in reporters_data
-                            else None
-                        ),
-                    }
+        today = datetime.now().astimezone().date().isoformat()
+
+        try:
+            headers = await self._add_login_headers()
+
+            async with asyncio.timeout(10):
+                result = await self._get(
+                    ENERGY_BY_INVERTER_URL.format(site_id=self.settings.site_id_secret),
+                    params={
+                        "start-date": today,
+                        "end-date": today,
+                        "inverter-serials": ",".join(inverter_serials),
+                        "include-max-temperature": "false",
+                        "include-color": "true",
+                    },
+                    headers=headers,
                 )
 
-                self._parse_strings(inverter, inverter_obj["children"], reporters_data)
+            if not isinstance(result, dict):
+                raise InvalidDataException(
+                    "Unexpected response format when reading energy by inverter"
+                )
 
-                inverters.append(inverter)
+            return self._index_energy_by_inverter(result)
 
-            else:
-                logger.info("Unknown inverter type: {type}", type=info["type"])
+        except (ClientResponseError, asyncio.TimeoutError) as error:
+            raise InvalidDataException("Unable to read energy by inverter") from error
+
+    @staticmethod
+    def _index_energy_by_inverter(data: dict) -> dict:
+        index = {}
+
+        for inverter_data in data.get("inverters", []):
+            serial = inverter_data.get("serial")
+            if not serial:
+                continue
+
+            strings_energy = {
+                string_data["stringRelativeOrder"]: string_data["energy"]["value"]
+                for string_data in inverter_data.get("strings", [])
+                if string_data.get("energy") and "stringRelativeOrder" in string_data
+            }
+            optimizers_energy = {
+                optimizer_data["serial"]: optimizer_data["energy"]["value"]
+                for optimizer_data in inverter_data.get("optimizers", [])
+                if optimizer_data.get("energy") and optimizer_data.get("serial")
+            }
+
+            inverter_energy = inverter_data.get("energy")
+
+            index[serial] = {
+                "energy": inverter_energy["value"] if inverter_energy else None,
+                "strings": strings_energy,
+                "optimizers": optimizers_energy,
+            }
+
+        return index
+
+    @staticmethod
+    def _folder_children(node: dict, folder_name: str) -> list[dict]:
+        for child in node.get("children", []):
+            if child.get("type") == "FOLDER" and child.get("name") == folder_name:
+                return child.get("children", [])
+
+        return []
+
+    def _parse_inverters(
+        self, site_structure: dict, energy_by_inverter: dict
+    ) -> list[LogicalInverter]:
+        inverters = []
+
+        for inverter_node in self._folder_children(site_structure, "INVERTER"):
+            if inverter_node.get("type") != "INVERTER":
+                logger.info(
+                    "Unknown inverter type: {type}", type=inverter_node.get("type")
+                )
+                continue
+
+            info = LogicalInfo.map(inverter_node)
+            inverter_energy = energy_by_inverter.get(inverter_node.get("serial"), {})
+
+            inverter = LogicalInverter.model_validate(
+                {"info": info, "energy": inverter_energy.get("energy")}
+            )
+
+            self._parse_strings(
+                inverter,
+                inverter_node,
+                inverter_energy.get("strings", {}),
+                inverter_energy.get("optimizers", {}),
+            )
+
+            inverters.append(inverter)
 
         return inverters
 
-    def _parse_strings(self, inverter, string_objs, reporters_data):
-        for string_obj in string_objs:
-            info = LogicalInfo.map(string_obj["data"])
-            string = LogicalString.model_validate(
-                {
-                    "info": info,
-                    "energy": (
-                        reporters_data[info["identifier"]]["unscaledEnergy"]
-                        if info["identifier"] in reporters_data
-                        else None
-                    ),
-                },
-            )
+    def _parse_strings(
+        self,
+        inverter,
+        inverter_node: dict,
+        strings_energy: dict,
+        optimizers_energy: dict,
+    ):
+        for string_node in self._folder_children(inverter_node, "STRING"):
+            if string_node.get("type") != "STRING":
+                continue
 
-            self._parse_panels(string, string_obj["children"], reporters_data)
+            info = LogicalInfo.map(string_node)
+            energy = strings_energy.get(string_node.get("order"))
+
+            string = LogicalString.model_validate({"info": info, "energy": energy})
+
+            self._parse_panels(string, string_node, optimizers_energy)
 
             inverter.strings.append(string)
 
-    def _parse_panels(self, string, panel_objs, reporters_data):
-        for panel_obj in panel_objs:
-            info = LogicalInfo.map(panel_obj["data"])
-            panel = LogicalModule.model_validate(
-                {
-                    "info": info,
-                    "energy": (
-                        reporters_data[info["identifier"]]["unscaledEnergy"]
-                        if info["identifier"] in reporters_data
-                        else None
-                    ),
-                },
-            )
+    def _parse_panels(self, string, string_node: dict, optimizers_energy: dict):
+        for optimizer_node in self._folder_children(string_node, "OPTIMIZER"):
+            if optimizer_node.get("type") != "OPTIMIZER":
+                continue
+
+            info = LogicalInfo.map(optimizer_node)
+            energy = optimizers_energy.get(optimizer_node.get("serial"))
+
+            panel = LogicalModule.model_validate({"info": info, "energy": energy})
 
             string.modules.append(panel)
 
     async def get_modules_power(self) -> dict[str, dict[datetime, float]]:
-        playback = await self._get_playback()
+        today = datetime.now().astimezone().date()
 
-        modules = {}
-
-        for date_str, reporters_data in playback["reportersData"].items():
-            date = datetime.strptime(date_str, "%a %b %d %H:%M:%S GMT %Y").astimezone()
-
-            for entries in reporters_data.values():
-                for entry in entries:
-                    key = entry["key"]
-                    if key not in modules:
-                        modules[key] = {}
-
-                    modules[key][date] = float(entry["value"])
-
-        logger.debug(modules)
-
-        return modules
-
-    async def _get_playback(self) -> dict:
         try:
-            headers = await self._add_login_headers(
-                {
-                    "Content-Type": CONTENT_TYPE_FORM_URLENCODED,
-                }
-            )
+            headers = await self._add_login_headers()
 
             async with asyncio.timeout(10):
-                playback_data = await self._post(
-                    POWER_PUBLIC_URL,
-                    data={
-                        "fieldId": self.settings.site_id_secret,
-                        "timeUnit": str(4),
-                        "CSRF": headers.get("X-CSRF-TOKEN", ""),
+                result = await self._get(
+                    OPTIMIZERS_COMPACT_URL.format(site_id=self.settings.site_id_secret),
+                    params={
+                        "resolution": "hours",
+                        "start-date": f"{today.isoformat()}T00:00:00Z",
+                        "end-date": f"{today.isoformat()}T23:59:59Z",
                     },
                     headers=headers,
-                    expect_json=False,
                 )
 
-            if not isinstance(playback_data, str):
+            if not isinstance(result, dict):
                 raise InvalidDataException(
-                    "Unexpected response format when reading playback data"
+                    "Unexpected response format when reading optimizer power data"
                 )
 
-            response = (
-                playback_data.replace("'", '"')
-                .replace("Array", "")
-                .replace("key", '"key"')
-                .replace("value", '"value"')
-                .replace("timeUnit", '"timeUnit"')
-                .replace("fieldData", '"fieldData"')
-                .replace("reportersData", '"reportersData"')
-            )
+            modules = self._decode_optimizers_compact(result, today)
 
-            return json.loads(response)
+            logger.debug(modules)
+
+            return modules
         except (ClientResponseError, asyncio.TimeoutError) as error:
-            raise InvalidDataException("Unable to read logical layout") from error
+            raise InvalidDataException("Unable to read optimizer power data") from error
+
+    @staticmethod
+    def _decode_optimizers_compact(
+        data: dict, day: date
+    ) -> dict[str, dict[datetime, float]]:
+        serials = data.get("optimizerSerials", [])
+        slots = data.get("timeSlotsCount", 0)
+        power_values = data.get("compressPowerData", [])
+
+        if not serials or not slots or len(power_values) < 2:
+            return {}
+
+        # Header layout: [version, payloadStart, (opaqueId, offset)*N, values*N*slots].
+        # offset for optimizer i is always i*slots (verified against optimizerSerials).
+        payload_start = int(power_values[1])
+
+        modules: dict[str, dict[datetime, float]] = {}
+
+        for index, serial in enumerate(serials):
+            start = payload_start + index * slots
+            values = power_values[start : start + slots]
+
+            modules[serial] = {
+                datetime.combine(day, time(hour=hour)).astimezone(): float(value)
+                for hour, value in enumerate(values)
+            }
+
+        return modules
 
     async def _execute_charge_control(self, device_id: int, level: int) -> None:
         if not self.settings.is_configured:

--- a/solaredge2mqtt/services/monitoring/models.py
+++ b/solaredge2mqtt/services/monitoring/models.py
@@ -42,11 +42,18 @@ class LogicalInfo(BaseModel):
         if not isinstance(properties, dict) or "identifier" not in properties:
             raise InvalidDataException("Logical info data is not valid")
 
-        node_type = data["type"]
+        node_type = data.get("type")
+        if not isinstance(node_type, str):
+            raise InvalidDataException("Logical info data is not valid")
+
+        raw_name = data.get("name")
+        if not isinstance(raw_name, str):
+            raise InvalidDataException("Logical info data is not valid")
+
         display_order = data.get("displayOrder")
         prefix = LogicalInfo.DISPLAY_ORDER_PREFIXES.get(node_type)
 
-        name = f"{prefix} {display_order}" if display_order and prefix else data["name"]
+        name = f"{prefix} {display_order}" if display_order and prefix else raw_name
 
         return {
             "identifier": str(properties["identifier"]),

--- a/solaredge2mqtt/services/monitoring/models.py
+++ b/solaredge2mqtt/services/monitoring/models.py
@@ -27,11 +27,6 @@ class LogicalInfo(BaseModel):
     name: str
     type: str
 
-    # SolarEdge's monitoring UI historically named nodes "Inverter 1",
-    # "String 1.2", "Module 1.2.1". The pre-break API sent that formatted
-    # name directly; the current API only sends the bare displayOrder
-    # ("1", "1.2", "1.2.1"), so the prefix has to be reconstructed to keep
-    # names consistent with what is already stored in InfluxDB.
     DISPLAY_ORDER_PREFIXES: ClassVar[dict[str, str]] = {
         "INVERTER": "Inverter",
         "STRING": "String",

--- a/solaredge2mqtt/services/monitoring/models.py
+++ b/solaredge2mqtt/services/monitoring/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import BaseModel, Field, computed_field, field_serializer
 from pydantic.json_schema import SkipJsonSchema
@@ -27,16 +27,37 @@ class LogicalInfo(BaseModel):
     name: str
     type: str
 
+    # SolarEdge's monitoring UI historically named nodes "Inverter 1",
+    # "String 1.2", "Module 1.2.1". The pre-break API sent that formatted
+    # name directly; the current API only sends the bare displayOrder
+    # ("1", "1.2", "1.2.1"), so the prefix has to be reconstructed to keep
+    # names consistent with what is already stored in InfluxDB.
+    DISPLAY_ORDER_PREFIXES: ClassVar[dict[str, str]] = {
+        "INVERTER": "Inverter",
+        "STRING": "String",
+        "OPTIMIZER": "Module",
+    }
+
     @staticmethod
-    def map(data: HTTPResponsePayload) -> dict[str, str]:
+    def map(data: HTTPResponsePayload) -> dict[str, str | None]:
         if not isinstance(data, dict):
             raise InvalidDataException("Logical info data is not valid")
 
+        properties = data.get("properties")
+        if not isinstance(properties, dict) or "identifier" not in properties:
+            raise InvalidDataException("Logical info data is not valid")
+
+        node_type = data["type"]
+        display_order = data.get("displayOrder")
+        prefix = LogicalInfo.DISPLAY_ORDER_PREFIXES.get(node_type)
+
+        name = f"{prefix} {display_order}" if display_order and prefix else data["name"]
+
         return {
-            "identifier": str(data["id"]),
-            "serialnumber": data["serialNumber"],
-            "name": data["name"],
-            "type": data["type"],
+            "identifier": str(properties["identifier"]),
+            "serialnumber": data.get("serial"),
+            "name": name,
+            "type": node_type,
         }
 
 

--- a/tests/services/monitoring/test_models.py
+++ b/tests/services/monitoring/test_models.py
@@ -287,6 +287,16 @@ class TestLogicalInfo:
         with pytest.raises(InvalidDataException):
             LogicalInfo.map({"name": "Test", "type": "INVERTER"})
 
+    def test_logical_info_map_missing_type_raises(self):
+        """Test LogicalInfo.map raises when type is missing."""
+        with pytest.raises(InvalidDataException):
+            LogicalInfo.map({"name": "Test", "properties": {"identifier": "1"}})
+
+    def test_logical_info_map_missing_name_raises(self):
+        """Test LogicalInfo.map raises when name is missing."""
+        with pytest.raises(InvalidDataException):
+            LogicalInfo.map({"type": "INVERTER", "properties": {"identifier": "1"}})
+
 
 class TestLogicalInverter:
     """Tests for LogicalInverter class."""

--- a/tests/services/monitoring/test_models.py
+++ b/tests/services/monitoring/test_models.py
@@ -220,10 +220,11 @@ class TestLogicalInfo:
     def test_logical_info_map_method(self):
         """Test LogicalInfo.map static method."""
         data = {
-            "id": 789,
-            "serialNumber": "SN789",
+            "serial": "SN789",
             "name": "Inverter 1",
+            "displayOrder": "1",
             "type": "INVERTER",
+            "properties": {"identifier": "789"},
         }
 
         result = LogicalInfo.map(data)
@@ -233,24 +234,58 @@ class TestLogicalInfo:
         assert result["name"] == "Inverter 1"
         assert result["type"] == "INVERTER"
 
-    def test_logical_info_map_method_string_id(self):
-        """Test LogicalInfo.map converts numeric id to string."""
+    def test_logical_info_map_method_numeric_identifier(self):
+        """Test LogicalInfo.map converts numeric identifier to string."""
         data = {
-            "id": 12345,
-            "serialNumber": "SN001",
+            "serial": "SN001",
             "name": "Test",
-            "type": "MODULE",
+            "displayOrder": "1.2.1",
+            "type": "OPTIMIZER",
+            "properties": {"identifier": 12345},
         }
 
         result = LogicalInfo.map(data)
 
         assert isinstance(result["identifier"], str)
         assert result["identifier"] == "12345"
+        assert result["name"] == "Module 1.2.1"
+
+    def test_logical_info_map_method_no_serial(self):
+        """Test LogicalInfo.map handles nodes with no top-level serial (e.g. STRING)."""
+        data = {
+            "name": "String 1.2",
+            "displayOrder": "1.2",
+            "type": "STRING",
+            "properties": {"identifier": "7B0756CB_32"},
+        }
+
+        result = LogicalInfo.map(data)
+
+        assert result["identifier"] == "7B0756CB_32"
+        assert result["serialnumber"] is None
+        assert result["name"] == "String 1.2"
+
+    def test_logical_info_map_method_falls_back_to_name_without_display_order(self):
+        """Test LogicalInfo.map falls back to name when displayOrder is missing."""
+        data = {
+            "name": "Inverter 1",
+            "type": "INVERTER",
+            "properties": {"identifier": "789"},
+        }
+
+        result = LogicalInfo.map(data)
+
+        assert result["name"] == "Inverter 1"
 
     def test_logical_info_map_invalid_input_raises(self):
         """Test LogicalInfo.map raises on non-dict data."""
         with pytest.raises(InvalidDataException):
             LogicalInfo.map("invalid")
+
+    def test_logical_info_map_missing_properties_raises(self):
+        """Test LogicalInfo.map raises when properties/identifier is missing."""
+        with pytest.raises(InvalidDataException):
+            LogicalInfo.map({"name": "Test", "type": "INVERTER"})
 
 
 class TestLogicalInverter:

--- a/tests/services/monitoring/test_service.py
+++ b/tests/services/monitoring/test_service.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import datetime, timezone
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ClientResponseError, RequestInfo
@@ -16,10 +16,6 @@ from solaredge2mqtt.core.timer.events import Interval15MinTriggerEvent
 from solaredge2mqtt.services.monitoring import MonitoringSite
 from solaredge2mqtt.services.monitoring.models import LogicalModule
 from solaredge2mqtt.services.monitoring.settings import MonitoringSettings
-
-# Date format used by SolarEdge monitoring API
-MONITORING_DATE_FORMAT = "%a %b %d %H:%M:%S GMT %Y"
-SAMPLE_PLAYBACK_DATE = "Mon Jan 01 12:00:00 GMT 2024"
 
 
 @pytest.fixture
@@ -145,6 +141,30 @@ class TestMonitoringSiteLogin:
 
         with pytest.raises(ConfigurationException):
             await site.login()
+
+
+class TestMonitoringSiteGetModules:
+    """Tests for MonitoringSite.get_modules (pure read, no EventBus/InfluxDB)."""
+
+    @pytest.mark.asyncio
+    async def test_get_modules_merges_energy_and_power_without_side_effects(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """get_modules fetches+merges data and emits nothing on the EventBus."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+
+        mock_module: LogicalModule = cast(LogicalModule, MagicMock(spec=LogicalModule))
+        mock_module.power = None
+        site.get_modules_energy = AsyncMock(return_value={"SN123": mock_module})
+        site.get_modules_power = AsyncMock(
+            return_value={"SN123": {datetime.now(timezone.utc): 100.0}}
+        )
+
+        result = await site.get_modules()
+
+        assert "SN123" in result
+        assert result["SN123"].power is not None
+        mock_event_bus.emit.assert_not_called()
 
 
 class TestMonitoringSiteMergeModules:
@@ -281,54 +301,6 @@ class TestMonitoringSiteGetData:
         )
 
 
-class TestMonitoringSiteGetModulesPower:
-    """Tests for MonitoringSite get_modules_power."""
-
-    @pytest.mark.asyncio
-    async def test_get_modules_power_http_error_raises_invalid_data(
-        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
-    ):
-        """Test get_modules_power raises InvalidDataException on HTTP error."""
-        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
-        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "csrf-token"})
-
-        mock_request_info = MagicMock(spec=RequestInfo)
-        mock_request_info.real_url = "https://test.com"
-        error = ClientResponseError(
-            request_info=mock_request_info,
-            history=(),
-            status=500,
-        )
-        site._post = AsyncMock(side_effect=error)
-
-        with pytest.raises(InvalidDataException):
-            await site.get_modules_power()
-
-    @pytest.mark.asyncio
-    async def test_get_modules_power_non_string_response_raises_invalid_data(
-        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
-    ):
-        """Test get_modules_power raises InvalidDataException on non-string response."""
-        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
-        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "csrf-token"})
-        site._post = AsyncMock(return_value={"unexpected": "dict"})
-
-        with pytest.raises(InvalidDataException):
-            await site.get_modules_power()
-
-    @pytest.mark.asyncio
-    async def test_get_modules_power_timeout_raises_invalid_data(
-        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
-    ):
-        """Test get_modules_power raises InvalidDataException on timeout."""
-        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
-        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "csrf-token"})
-        site._post = AsyncMock(side_effect=asyncio.TimeoutError())
-
-        with pytest.raises(InvalidDataException):
-            await site.get_modules_power()
-
-
 class TestMonitoringSiteGetLogical:
     """Tests for MonitoringSite _get_logical."""
 
@@ -383,48 +355,141 @@ class TestMonitoringSiteGetLogical:
         assert "Unexpected response format" in exc_info.value.message
 
 
-class TestMonitoringSiteGetPlayback:
-    """Tests for MonitoringSite _get_playback."""
+class TestMonitoringSiteGetEnergyByInverter:
+    """Tests for MonitoringSite _get_energy_by_inverter."""
 
     @pytest.mark.asyncio
-    async def test_get_playback_error(
+    async def test_empty_serials_returns_empty_without_request(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test _get_playback raises on error."""
+        """Test _get_energy_by_inverter short-circuits when there are no inverters."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
-        site.cookie_exists = MagicMock(return_value=True)
-        site.get_cookie = MagicMock(return_value="test_token")
+        site._add_login_headers = AsyncMock()
+        site._get = AsyncMock()
+
+        result = await site._get_energy_by_inverter([])
+
+        assert result == {}
+        site._get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_success_indexes_response(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _get_energy_by_inverter parses and indexes a valid response."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "token"})
+        site._get = AsyncMock(
+            return_value={
+                "inverters": [
+                    {
+                        "serial": "INV1",
+                        "energy": {"value": 1000.0, "unit": "watt-hour"},
+                        "strings": [
+                            {
+                                "energy": {"value": 500.0, "unit": "watt-hour"},
+                                "stringRelativeOrder": 2,
+                            }
+                        ],
+                        "optimizers": [
+                            {
+                                "serial": "PAN1-C1",
+                                "energy": {"value": 100.0, "unit": "watt-hour"},
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        result = await site._get_energy_by_inverter(["INV1"])
+
+        assert result["INV1"]["energy"] == pytest.approx(1000.0)
+        assert result["INV1"]["strings"][2] == pytest.approx(500.0)
+        assert result["INV1"]["optimizers"]["PAN1-C1"] == pytest.approx(100.0)
+
+    @pytest.mark.asyncio
+    async def test_error_raises_invalid_data(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _get_energy_by_inverter raises InvalidDataException on HTTP error."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "token"})
 
         mock_request_info = MagicMock(spec=RequestInfo)
         mock_request_info.real_url = "https://test.com"
-
-        error = ClientResponseError(
-            request_info=mock_request_info,
-            history=(),
-            status=500,
+        site._get = AsyncMock(
+            side_effect=ClientResponseError(
+                request_info=mock_request_info, history=(), status=500
+            )
         )
-        site._post = AsyncMock(side_effect=error)
 
         with pytest.raises(InvalidDataException):
-            await site._get_playback()
+            await site._get_energy_by_inverter(["INV1"])
 
     @pytest.mark.asyncio
-    async def test_get_playback_success_parses_response(
+    async def test_non_dict_response_raises_invalid_data(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test _get_playback parses playback JS-like payload into dict."""
+        """Test _get_energy_by_inverter raises on non-dict response payload."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
-        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "test_token"})
-        site._post = AsyncMock(return_value="{'reportersData': {}}")
+        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "token"})
+        site._get = AsyncMock(return_value=["unexpected", "list"])
 
-        with patch("solaredge2mqtt.services.monitoring.json.loads") as loads_mock:
-            loads_mock.return_value = {"reportersData": {}}
-            result = await site._get_playback()
+        with pytest.raises(InvalidDataException):
+            await site._get_energy_by_inverter(["INV1"])
 
-        loads_mock.assert_called_once()
 
-        assert isinstance(result, dict)
-        assert "reportersData" in result
+class TestMonitoringSiteIndexEnergyByInverter:
+    """Tests for MonitoringSite._index_energy_by_inverter."""
+
+    def test_skips_inverter_without_serial(self):
+        result = MonitoringSite._index_energy_by_inverter(
+            {"inverters": [{"energy": {"value": 1.0}}]}
+        )
+        assert result == {}
+
+    def test_missing_energy_value_is_none(self):
+        result = MonitoringSite._index_energy_by_inverter(
+            {"inverters": [{"serial": "INV1"}]}
+        )
+        assert result["INV1"]["energy"] is None
+        assert result["INV1"]["strings"] == {}
+        assert result["INV1"]["optimizers"] == {}
+
+
+class TestMonitoringSiteLoadStructure:
+    """Tests for MonitoringSite._load_structure."""
+
+    @pytest.mark.asyncio
+    async def test_success_caches_structure(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _load_structure caches siteStructure from _get_logical."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._get_logical = AsyncMock(return_value={"siteStructure": {"children": []}})
+
+        await site._load_structure()
+
+        assert site._cached_structure == {"children": []}
+
+    @pytest.mark.asyncio
+    async def test_error_logs_warning_no_raise(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _load_structure swallows errors, leaving cache empty."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._get_logical = AsyncMock(
+            side_effect=InvalidDataException("unable to read")
+        )
+
+        await site._load_structure()
+
+        assert site._cached_structure is None
+
+
+def make_folder(name: str, children: list[dict]) -> dict:
+    return {"type": "FOLDER", "name": name, "children": children}
 
 
 class TestMonitoringSiteParseInverters:
@@ -433,54 +498,122 @@ class TestMonitoringSiteParseInverters:
     def test_parse_inverters(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test _parse_inverters parses inverter data."""
+        """Test _parse_inverters parses inverter data nested under a FOLDER."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
-        inverter_objs = [
-            {
-                "data": {
-                    "id": 1,
-                    "name": "Inverter 1",
-                    "serialNumber": "SN123",
-                    "key": "INV1",
-                    "type": "INVERTER",
-                },
-                "children": [],
-            }
-        ]
-        reporters_data = {
-            "1": {"unscaledEnergy": 1000},
+        site_structure = {
+            "children": [
+                make_folder(
+                    "INVERTER",
+                    [
+                        {
+                            "name": "Inverter 1",
+                            "serial": "SN123",
+                            "type": "INVERTER",
+                            "properties": {"identifier": "1"},
+                            "children": [],
+                        }
+                    ],
+                )
+            ]
         }
 
-        result = site._parse_inverters(inverter_objs, reporters_data)
+        result = site._parse_inverters(site_structure, {})
 
         assert len(result) == 1
         assert result[0].info.serialnumber == "SN123"
 
+    def test_parse_inverters_with_energy(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _parse_inverters attaches energy from the energy-by-inverter index."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+
+        site_structure = {
+            "children": [
+                make_folder(
+                    "INVERTER",
+                    [
+                        {
+                            "name": "Inverter 1",
+                            "serial": "SN123",
+                            "type": "INVERTER",
+                            "properties": {"identifier": "1"},
+                            "children": [],
+                        }
+                    ],
+                )
+            ]
+        }
+        energy_by_inverter = {
+            "SN123": {"energy": 1234.5, "strings": {}, "optimizers": {}}
+        }
+
+        result = site._parse_inverters(site_structure, energy_by_inverter)
+
+        assert result[0].energy == pytest.approx(1234.5)
+
     def test_parse_inverters_unknown_type(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test _parse_inverters logs unknown type."""
+        """Test _parse_inverters logs and skips unknown type nodes."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
-        inverter_objs = [
-            {
-                "data": {
-                    "id": 2,
-                    "name": "Unknown Device",
-                    "serialNumber": "SN456",
-                    "key": "UNK1",
-                    "type": "UNKNOWN_TYPE",
-                },
-                "children": [],
-            }
-        ]
-        reporters_data = {}
+        site_structure = {
+            "children": [
+                make_folder(
+                    "INVERTER",
+                    [
+                        {
+                            "name": "Unknown Device",
+                            "serial": "SN456",
+                            "type": "UNKNOWN_TYPE",
+                            "properties": {"identifier": "2"},
+                            "children": [],
+                        }
+                    ],
+                )
+            ]
+        }
 
-        result = site._parse_inverters(inverter_objs, reporters_data)
+        result = site._parse_inverters(site_structure, {})
 
         # Should skip unknown types
         assert len(result) == 0
+
+    def test_parse_inverters_no_inverter_folder(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _parse_inverters returns empty list when no INVERTER folder exists."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+
+        result = site._parse_inverters({"children": []}, {})
+
+        assert result == []
+
+
+class TestMonitoringSiteFolderChildren:
+    """Tests for MonitoringSite._folder_children."""
+
+    def test_skips_non_matching_siblings_before_match(self):
+        """A non-matching sibling before the target FOLDER is skipped, not returned."""
+        node = {
+            "children": [
+                make_folder("BATTERY", [{"type": "BATTERY"}]),
+                make_folder("INVERTER", [{"type": "INVERTER", "serial": "SN1"}]),
+            ]
+        }
+
+        result = MonitoringSite._folder_children(node, "INVERTER")
+
+        assert result == [{"type": "INVERTER", "serial": "SN1"}]
+
+    def test_no_matching_folder_returns_empty(self):
+        node = {"children": [make_folder("BATTERY", [{"type": "BATTERY"}])]}
+
+        result = MonitoringSite._folder_children(node, "INVERTER")
+
+        assert result == []
 
 
 class TestMonitoringSiteParseStrings:
@@ -489,31 +622,91 @@ class TestMonitoringSiteParseStrings:
     def test_parse_strings(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test _parse_strings parses string data."""
+        """Test _parse_strings parses string data nested under a FOLDER."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         inverter = MagicMock()
         inverter.strings = []
 
-        string_objs = [
-            {
-                "data": {
-                    "id": 10,
-                    "name": "String 1",
-                    "serialNumber": "STR1",
-                    "key": "STR1",
-                    "type": "STRING",
-                },
-                "children": [],
-            }
-        ]
-        reporters_data = {
-            "10": {"unscaledEnergy": 500},
+        inverter_node = {
+            "children": [
+                make_folder(
+                    "STRING",
+                    [
+                        {
+                            "name": "String 1",
+                            "type": "STRING",
+                            "properties": {"identifier": "SN123_10"},
+                            "children": [],
+                        }
+                    ],
+                )
+            ]
         }
 
-        site._parse_strings(inverter, string_objs, reporters_data)
+        site._parse_strings(inverter, inverter_node, {}, {})
 
         assert len(inverter.strings) == 1
+
+    def test_parse_strings_with_energy(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _parse_strings attaches energy matched by stringRelativeOrder."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+
+        inverter = MagicMock()
+        inverter.strings = []
+
+        inverter_node = {
+            "children": [
+                make_folder(
+                    "STRING",
+                    [
+                        {
+                            "name": "String 1",
+                            "type": "STRING",
+                            "order": 2,
+                            "properties": {"identifier": "SN123_10"},
+                            "children": [],
+                        }
+                    ],
+                )
+            ]
+        }
+
+        site._parse_strings(inverter, inverter_node, {2: 555.0}, {})
+
+        assert inverter.strings[0].energy == pytest.approx(555.0)
+
+    def test_parse_strings_skips_non_string_type(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _parse_strings skips nodes inside the STRING folder with a
+        mismatched type."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+
+        inverter = MagicMock()
+        inverter.strings = []
+
+        inverter_node = {
+            "children": [
+                make_folder(
+                    "STRING",
+                    [
+                        {
+                            "name": "Unexpected",
+                            "type": "UNKNOWN_TYPE",
+                            "properties": {"identifier": "X"},
+                            "children": [],
+                        }
+                    ],
+                )
+            ]
+        }
+
+        site._parse_strings(inverter, inverter_node, {}, {})
+
+        assert inverter.strings == []
 
 
 class TestMonitoringSiteParsePanels:
@@ -522,30 +715,89 @@ class TestMonitoringSiteParsePanels:
     def test_parse_panels(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test _parse_panels parses panel data."""
+        """Test _parse_panels parses optimizer data nested under a FOLDER."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
         string = MagicMock()
         string.modules = []
 
-        panel_objs = [
-            {
-                "data": {
-                    "id": 100,
-                    "name": "Panel 1",
-                    "serialNumber": "PAN1",
-                    "key": "PAN1",
-                    "type": "PANEL",
-                },
-            }
-        ]
-        reporters_data = {
-            "100": {"unscaledEnergy": 100},
+        string_node = {
+            "children": [
+                make_folder(
+                    "OPTIMIZER",
+                    [
+                        {
+                            "name": "Optimizer 1",
+                            "serial": "PAN1-C1",
+                            "type": "OPTIMIZER",
+                            "properties": {"identifier": "PAN1"},
+                        }
+                    ],
+                )
+            ]
         }
 
-        site._parse_panels(string, panel_objs, reporters_data)
+        site._parse_panels(string, string_node, {})
 
         assert len(string.modules) == 1
+
+    def test_parse_panels_with_energy(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _parse_panels attaches energy matched by optimizer serial."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+
+        string = MagicMock()
+        string.modules = []
+
+        string_node = {
+            "children": [
+                make_folder(
+                    "OPTIMIZER",
+                    [
+                        {
+                            "name": "Optimizer 1",
+                            "serial": "PAN1-C1",
+                            "type": "OPTIMIZER",
+                            "properties": {"identifier": "PAN1"},
+                        }
+                    ],
+                )
+            ]
+        }
+
+        site._parse_panels(string, string_node, {"PAN1-C1": 42.0})
+
+        assert string.modules[0].energy == pytest.approx(42.0)
+
+    def test_parse_panels_skips_non_optimizer_type(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _parse_panels skips nodes inside the OPTIMIZER folder with a
+        mismatched type."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+
+        string = MagicMock()
+        string.modules = []
+
+        string_node = {
+            "children": [
+                make_folder(
+                    "OPTIMIZER",
+                    [
+                        {
+                            "name": "Unexpected",
+                            "type": "UNKNOWN_TYPE",
+                            "properties": {"identifier": "X"},
+                        }
+                    ],
+                )
+            ]
+        }
+
+        site._parse_panels(string, string_node, {})
+
+        assert string.modules == []
 
 
 class TestMonitoringSiteGetModulesEnergyFull:
@@ -558,53 +810,105 @@ class TestMonitoringSiteGetModulesEnergyFull:
         """Test get_modules_energy with full data parsing."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
-        logical_response = {
-            "logicalTree": {
-                "children": [
-                    {
-                        "data": {
-                            "id": 1,
+        site._cached_structure = {
+            "children": [
+                make_folder(
+                    "INVERTER",
+                    [
+                        {
                             "name": "Inverter 1",
-                            "serialNumber": "INV1",
-                            "key": "INV1",
+                            "serial": "INV1",
                             "type": "INVERTER",
-                        },
-                        "children": [
-                            {
-                                "data": {
-                                    "id": 10,
-                                    "name": "String 1",
-                                    "serialNumber": "STR1",
-                                    "key": "STR1",
-                                    "type": "STRING",
-                                },
-                                "children": [
-                                    {
-                                        "data": {
-                                            "id": 100,
-                                            "name": "Panel 1",
-                                            "serialNumber": "PAN1",
-                                            "key": "PAN1",
-                                            "type": "PANEL",
-                                        },
-                                    }
-                                ],
-                            }
-                        ],
-                    }
-                ]
-            },
-            "reportersData": {
-                "1": {"unscaledEnergy": 1000},
-                "10": {"unscaledEnergy": 500},
-                "100": {"unscaledEnergy": 100},
-            },
+                            "properties": {"identifier": "1"},
+                            "children": [
+                                make_folder(
+                                    "STRING",
+                                    [
+                                        {
+                                            "name": "String 1",
+                                            "type": "STRING",
+                                            "properties": {"identifier": "10"},
+                                            "children": [
+                                                make_folder(
+                                                    "OPTIMIZER",
+                                                    [
+                                                        {
+                                                            "name": "Panel 1",
+                                                            "serial": "PAN1-C1",
+                                                            "type": "OPTIMIZER",
+                                                            "properties": {
+                                                                "identifier": "100"
+                                                            },
+                                                        }
+                                                    ],
+                                                )
+                                            ],
+                                        }
+                                    ],
+                                )
+                            ],
+                        }
+                    ],
+                )
+            ]
         }
-        site._get_logical = AsyncMock(return_value=logical_response)
+        site._get_energy_by_inverter = AsyncMock(
+            return_value={
+                "INV1": {
+                    "energy": 1000.0,
+                    "strings": {},
+                    "optimizers": {"PAN1-C1": 100.0},
+                }
+            }
+        )
 
         result = await site.get_modules_energy()
 
         assert "100" in result
+        assert result["100"].energy == pytest.approx(100.0)
+        site._get_energy_by_inverter.assert_called_once_with(["INV1"])
+
+    @pytest.mark.asyncio
+    async def test_get_modules_energy_lazy_loads_structure_when_uncached(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test get_modules_energy lazily loads the structure if not cached yet."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        assert site._cached_structure is None
+
+        site._get_logical = AsyncMock(return_value={"siteStructure": {"children": []}})
+        site._get_energy_by_inverter = AsyncMock(return_value={})
+
+        result = await site.get_modules_energy()
+
+        site._get_logical.assert_called_once()
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_modules_energy_reuses_cached_structure(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test get_modules_energy does not refetch structure once cached."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._cached_structure = {"children": []}
+
+        site._get_logical = AsyncMock()
+        site._get_energy_by_inverter = AsyncMock(return_value={})
+
+        await site.get_modules_energy()
+
+        site._get_logical.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_modules_energy_raises_when_structure_unavailable(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test get_modules_energy raises if structure stays uncached after load."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._load_structure = AsyncMock()
+
+        with pytest.raises(InvalidDataException):
+            await site.get_modules_energy()
 
 
 class TestMonitoringSiteGetModulesPowerFull:
@@ -614,53 +918,103 @@ class TestMonitoringSiteGetModulesPowerFull:
     async def test_get_modules_power_full(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test get_modules_power with full data parsing."""
+        """Test get_modules_power decodes optimizers-compact into per-module power."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
-
-        playback_response = {
-            "reportersData": {
-                SAMPLE_PLAYBACK_DATE: {
-                    "group1": [
-                        {"key": "PAN1", "value": "100.5"},
-                        {"key": "PAN2", "value": "95.3"},
-                    ]
-                }
+        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "token"})
+        site._get = AsyncMock(
+            return_value={
+                "timeSlotsCount": 2,
+                "optimizerSerials": ["PAN1", "PAN2"],
+                "compressPowerData": [2.0, 6.0, 0, 0, 0, 0, 100.5, 101.0, 95.3, 96.0],
             }
-        }
-        site._get_playback = AsyncMock(return_value=playback_response)
+        )
 
         result = await site.get_modules_power()
 
         assert "PAN1" in result
         assert "PAN2" in result
+        assert list(result["PAN1"].values()) == [100.5, 101.0]
+        assert list(result["PAN2"].values()) == [95.3, 96.0]
 
     @pytest.mark.asyncio
-    async def test_get_modules_power_merges_same_module_over_multiple_timestamps(
+    async def test_get_modules_power_http_error_raises_invalid_data(
         self, mock_monitoring_settings, mock_event_bus, mock_influxdb
     ):
-        """Test get_modules_power appends date entries for existing module key."""
+        """Test get_modules_power raises InvalidDataException on HTTP error."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "token"})
 
-        playback_response = {
-            "reportersData": {
-                SAMPLE_PLAYBACK_DATE: {
-                    "group1": [
-                        {"key": "PAN1", "value": "100.5"},
-                    ]
-                },
-                "Mon Jan 01 12:15:00 GMT 2024": {
-                    "group1": [
-                        {"key": "PAN1", "value": "101.0"},
-                    ]
-                },
-            }
+        mock_request_info = MagicMock(spec=RequestInfo)
+        mock_request_info.real_url = "https://test.com"
+        site._get = AsyncMock(
+            side_effect=ClientResponseError(
+                request_info=mock_request_info, history=(), status=500
+            )
+        )
+
+        with pytest.raises(InvalidDataException):
+            await site.get_modules_power()
+
+    @pytest.mark.asyncio
+    async def test_get_modules_power_non_dict_response_raises_invalid_data(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test get_modules_power raises InvalidDataException on non-dict response."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "token"})
+        site._get = AsyncMock(return_value=["unexpected", "list"])
+
+        with pytest.raises(InvalidDataException):
+            await site.get_modules_power()
+
+    @pytest.mark.asyncio
+    async def test_get_modules_power_timeout_raises_invalid_data(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test get_modules_power raises InvalidDataException on timeout."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._add_login_headers = AsyncMock(return_value={"X-CSRF-TOKEN": "token"})
+        site._get = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        with pytest.raises(InvalidDataException):
+            await site.get_modules_power()
+
+
+class TestMonitoringSiteDecodeOptimizersCompact:
+    """Tests for MonitoringSite._decode_optimizers_compact."""
+
+    def test_decodes_per_optimizer_hourly_power(self):
+        today = datetime.now().astimezone().date()
+        data = {
+            "timeSlotsCount": 2,
+            "optimizerSerials": ["PAN1", "PAN2"],
+            "compressPowerData": [2.0, 6.0, 0, 0, 0, 0, 100.5, 101.0, 95.3, 96.0],
         }
-        site._get_playback = AsyncMock(return_value=playback_response)
 
-        result = await site.get_modules_power()
+        result = MonitoringSite._decode_optimizers_compact(data, today)
 
-        assert "PAN1" in result
-        assert len(result["PAN1"]) == 2
+        assert list(result["PAN1"].values()) == [100.5, 101.0]
+        assert list(result["PAN2"].values()) == [95.3, 96.0]
+
+    def test_empty_serials_returns_empty(self):
+        today = datetime.now().astimezone().date()
+        result = MonitoringSite._decode_optimizers_compact(
+            {"timeSlotsCount": 24, "optimizerSerials": [], "compressPowerData": []},
+            today,
+        )
+        assert result == {}
+
+    def test_missing_time_slots_returns_empty(self):
+        today = datetime.now().astimezone().date()
+        result = MonitoringSite._decode_optimizers_compact(
+            {
+                "timeSlotsCount": 0,
+                "optimizerSerials": ["PAN1"],
+                "compressPowerData": [2.0, 4.0, 0, 0],
+            },
+            today,
+        )
+        assert result == {}
 
 
 class TestMonitoringSiteExtraBranches:
@@ -745,10 +1099,22 @@ class TestMonitoringSiteAsyncInit:
     ):
         site = MonitoringSite(mock_monitoring_settings, None)
         site._discover_evchargers = AsyncMock()
+        site._load_structure = AsyncMock()
 
         await site.async_init()
 
         site._discover_evchargers.assert_called_once()
+
+    async def test_async_init_loads_structure(
+        self, mock_monitoring_settings, mock_event_bus
+    ):
+        site = MonitoringSite(mock_monitoring_settings, None)
+        site._discover_evchargers = AsyncMock()
+        site._load_structure = AsyncMock()
+
+        await site.async_init()
+
+        site._load_structure.assert_called_once()
 
 
 class TestMonitoringSiteDiscoverEVChargers:

--- a/tests/services/monitoring/test_service.py
+++ b/tests/services/monitoring/test_service.py
@@ -172,7 +172,6 @@ class TestMonitoringSiteMergeModules:
 
     def test_merge_modules(self):
         """Test merge_modules combines energy and power data."""
-        # Create mock module
         mock_module: LogicalModule = cast(LogicalModule, MagicMock(spec=LogicalModule))
         mock_module.power = None
 
@@ -207,7 +206,6 @@ class TestMonitoringSiteSaveToInfluxDB:
         """Test save_to_influxdb writes points."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
-        # Create mock module with power data
         mock_info = MagicMock()
         mock_info.serialnumber = "SN123"
         mock_info.name = "Module 1"
@@ -228,7 +226,6 @@ class TestMonitoringSiteSaveToInfluxDB:
         """Test save_to_influxdb does nothing when influxdb is None."""
         site = MonitoringSite(mock_monitoring_settings, None)
 
-        # Should not raise
         await site.save_to_influxdb({})
 
 
@@ -242,7 +239,6 @@ class TestMonitoringSitePublishMQTT:
         """Test publish_mqtt emits events."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
-        # Create mock module
         mock_info = MagicMock()
         mock_info.serialnumber = "SN123"
 
@@ -252,7 +248,6 @@ class TestMonitoringSitePublishMQTT:
 
         await site.publish_mqtt({"SN123": mock_module}, 0, 0)
 
-        # Should emit events for module and total
         assert mock_event_bus.emit.call_count == 2
 
 
@@ -266,7 +261,6 @@ class TestMonitoringSiteGetData:
         """Test get_data orchestrates data retrieval."""
         site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
 
-        # Mock the sub-methods
         site.get_modules_energy = AsyncMock(return_value={})
         site.get_modules_power = AsyncMock(return_value={})
         site.save_to_influxdb = AsyncMock()
@@ -294,7 +288,6 @@ class TestMonitoringSiteGetData:
         with pytest.raises(InvalidDataException):
             await site.get_data(Interval15MinTriggerEvent())
 
-        # Check that MonitoringOfflineEvent was emitted
         emit_calls = mock_event_bus.emit.call_args_list
         assert any(
             isinstance(call[0][0], MonitoringOfflineEvent) for call in emit_calls
@@ -650,7 +643,6 @@ class TestMonitoringSiteParseInverters:
 
         result = site._parse_inverters(site_structure, {})
 
-        # Should skip unknown types
         assert len(result) == 0
 
     def test_parse_inverters_no_inverter_folder(
@@ -1107,8 +1099,6 @@ class TestMonitoringSiteDecodeOptimizersCompact:
             {
                 "timeSlotsCount": 24,
                 "optimizerSerials": ["PAN1", "PAN2"],
-                # header claims payloadStart=4, but only 2 values follow instead
-                # of 2 optimizers * 24 slots = 48.
                 "compressPowerData": [2.0, 4.0, 0, 0, 100.5, 95.3],
             },
             today,
@@ -1163,13 +1153,8 @@ class TestMonitoringSiteExtraBranches:
 
         await site.publish_mqtt({"SN123": module}, 0, 0)
 
-        # One module publish + one total publish
         assert mock_event_bus.emit.call_count == 2
 
-
-# ---------------------------------------------------------------------------
-# Shared EV charger test data
-# ---------------------------------------------------------------------------
 
 SAMPLE_EV_CHARGER_DEVICE = {
     "manufacturer": "Keba AG",

--- a/tests/services/monitoring/test_service.py
+++ b/tests/services/monitoring/test_service.py
@@ -457,6 +457,66 @@ class TestMonitoringSiteIndexEnergyByInverter:
         assert result["INV1"]["strings"] == {}
         assert result["INV1"]["optimizers"] == {}
 
+    def test_skips_non_dict_string_entry(self):
+        result = MonitoringSite._index_energy_by_inverter(
+            {"inverters": [{"serial": "INV1", "strings": ["not-a-dict"]}]}
+        )
+        assert result["INV1"]["strings"] == {}
+
+    def test_skips_string_entry_with_non_int_order(self):
+        result = MonitoringSite._index_energy_by_inverter(
+            {
+                "inverters": [
+                    {
+                        "serial": "INV1",
+                        "strings": [
+                            {
+                                "stringRelativeOrder": "not-an-int",
+                                "energy": {"value": 1.0},
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        assert result["INV1"]["strings"] == {}
+
+    def test_skips_non_dict_optimizer_entry(self):
+        result = MonitoringSite._index_energy_by_inverter(
+            {"inverters": [{"serial": "INV1", "optimizers": ["not-a-dict"]}]}
+        )
+        assert result["INV1"]["optimizers"] == {}
+
+    def test_skips_optimizer_entry_without_serial(self):
+        result = MonitoringSite._index_energy_by_inverter(
+            {
+                "inverters": [
+                    {
+                        "serial": "INV1",
+                        "optimizers": [{"energy": {"value": 1.0}}],
+                    }
+                ]
+            }
+        )
+        assert result["INV1"]["optimizers"] == {}
+
+    def test_correctly_keys_by_inverter_serial_not_optimizer_serial(self):
+        """Regression: inverter serial must not be shadowed by optimizer serial."""
+        result = MonitoringSite._index_energy_by_inverter(
+            {
+                "inverters": [
+                    {
+                        "serial": "INV1",
+                        "energy": {"value": 1000.0},
+                        "optimizers": [{"serial": "PAN1", "energy": {"value": 100.0}}],
+                    }
+                ]
+            }
+        )
+        assert "INV1" in result
+        assert result["INV1"]["energy"] == pytest.approx(1000.0)
+        assert result["INV1"]["optimizers"]["PAN1"] == pytest.approx(100.0)
+
 
 class TestMonitoringSiteLoadStructure:
     """Tests for MonitoringSite._load_structure."""
@@ -482,6 +542,18 @@ class TestMonitoringSiteLoadStructure:
         site._get_logical = AsyncMock(
             side_effect=InvalidDataException("unable to read")
         )
+
+        await site._load_structure()
+
+        assert site._cached_structure is None
+
+    @pytest.mark.asyncio
+    async def test_missing_site_structure_key_logs_warning_no_raise(
+        self, mock_monitoring_settings, mock_event_bus, mock_influxdb
+    ):
+        """Test _load_structure treats a missing/non-dict siteStructure as an error."""
+        site = MonitoringSite(mock_monitoring_settings, mock_influxdb)
+        site._get_logical = AsyncMock(return_value={"unexpected": "shape"})
 
         await site._load_structure()
 
@@ -1011,6 +1083,33 @@ class TestMonitoringSiteDecodeOptimizersCompact:
                 "timeSlotsCount": 0,
                 "optimizerSerials": ["PAN1"],
                 "compressPowerData": [2.0, 4.0, 0, 0],
+            },
+            today,
+        )
+        assert result == {}
+
+    def test_power_values_too_short_returns_empty(self):
+        today = datetime.now().astimezone().date()
+        result = MonitoringSite._decode_optimizers_compact(
+            {
+                "timeSlotsCount": 2,
+                "optimizerSerials": ["PAN1"],
+                "compressPowerData": [2.0],
+            },
+            today,
+        )
+        assert result == {}
+
+    def test_truncated_payload_returns_empty(self):
+        """payloadStart + N*slots exceeding the array length means corrupt data."""
+        today = datetime.now().astimezone().date()
+        result = MonitoringSite._decode_optimizers_compact(
+            {
+                "timeSlotsCount": 24,
+                "optimizerSerials": ["PAN1", "PAN2"],
+                # header claims payloadStart=4, but only 2 values follow instead
+                # of 2 optimizers * 24 slots = 48.
+                "compressPowerData": [2.0, 4.0, 0, 0, 100.5, 95.3],
             },
             today,
         )

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,171 @@
+"""Tests for monitoring.py top-level single-shot script."""
+
+import runpy
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from solaredge2mqtt.core.exceptions import ConfigurationException
+
+WORKSPACE_ROOT = Path(__file__).parent.parent
+
+
+@pytest.fixture
+def mock_settings():
+    settings = MagicMock()
+    settings.monitoring.is_configured = True
+    return settings
+
+
+class TestMonitoringRun:
+    """Tests for monitoring.run() error handling."""
+
+    def test_run_invokes_run_coroutine_with_config_dir(self):
+        import monitoring
+
+        with patch("monitoring._run", new=AsyncMock()) as mock_run_coro:
+            monitoring.run(config_dir="custom")
+
+        mock_run_coro.assert_called_once_with("custom")
+
+    def test_run_swallows_configuration_exception(self):
+        import monitoring
+
+        with (
+            patch(
+                "monitoring._run",
+                new=AsyncMock(side_effect=ConfigurationException("x", "y")),
+            ),
+            patch("monitoring.logger") as mock_logger,
+        ):
+            monitoring.run()
+
+        mock_logger.error.assert_called_once()
+
+    def test_run_swallows_keyboard_interrupt(self):
+        import monitoring
+
+        with (
+            patch("monitoring._run", new=AsyncMock(side_effect=KeyboardInterrupt())),
+            patch("monitoring.logger") as mock_logger,
+        ):
+            monitoring.run()
+
+        mock_logger.info.assert_called_once()
+
+
+class TestMonitoringMain:
+    """Tests for monitoring.main() argument parsing."""
+
+    def test_main_with_default_config_dir(self):
+        import monitoring
+
+        with patch("monitoring.run") as mock_run:
+            with patch.object(sys, "argv", ["monitoring.py"]):
+                monitoring.main()
+
+            mock_run.assert_called_once_with(config_dir="config")
+
+    def test_main_with_custom_config_dir(self):
+        import monitoring
+
+        with patch("monitoring.run") as mock_run:
+            with patch.object(
+                sys, "argv", ["monitoring.py", "--config-dir", "/custom/config"]
+            ):
+                monitoring.main()
+
+            mock_run.assert_called_once_with(config_dir="/custom/config")
+
+    def test_main_guard_executes_module(self):
+        """Executing script as __main__ should invoke main() guard path.
+
+        runpy re-executes the file in a fresh namespace, so patches must
+        target the source modules monitoring.py imports from (not the
+        already-imported `monitoring` module) to actually take effect.
+        """
+        mock_settings = MagicMock()
+        mock_settings.logging_level.level = "INFO"
+        mock_settings.monitoring.is_configured = False
+
+        with (
+            patch(
+                "solaredge2mqtt.core.settings.service_settings",
+                return_value=mock_settings,
+            ),
+            patch.object(sys, "argv", ["monitoring.py"]),
+        ):
+            runpy.run_path(str(WORKSPACE_ROOT / "monitoring.py"), run_name="__main__")
+
+
+class TestMonitoringRunInternal:
+    """Tests for monitoring._run() orchestration logic."""
+
+    @pytest.mark.asyncio
+    async def test_not_configured_logs_error_and_returns(self, mock_settings):
+        import monitoring
+
+        mock_settings.monitoring.is_configured = False
+
+        with (
+            patch("monitoring.service_settings", return_value=mock_settings),
+            patch("monitoring.initialize_logging"),
+            patch("monitoring.logger") as mock_logger,
+            patch("monitoring.MonitoringSite") as mock_site_cls,
+        ):
+            await monitoring._run("config")
+
+        mock_logger.error.assert_called_once()
+        mock_site_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_configured_fetches_and_logs_modules(self, mock_settings):
+        import monitoring
+
+        mock_module_with_power = MagicMock()
+        mock_module_with_power.energy = 123.0
+        mock_module_with_power.power = {"a": 1.0, "b": 2.0}
+
+        mock_module_without_power = MagicMock()
+        mock_module_without_power.energy = None
+        mock_module_without_power.power = None
+
+        mock_site = MagicMock()
+        mock_site.get_modules = AsyncMock(
+            return_value={
+                "PAN1": mock_module_with_power,
+                "PAN2": mock_module_without_power,
+            }
+        )
+        mock_site.close = AsyncMock()
+
+        with (
+            patch("monitoring.service_settings", return_value=mock_settings),
+            patch("monitoring.initialize_logging"),
+            patch("monitoring.MonitoringSite", return_value=mock_site) as mock_site_cls,
+        ):
+            await monitoring._run("config")
+
+        mock_site_cls.assert_called_once_with(mock_settings.monitoring, None)
+        mock_site.get_modules.assert_called_once()
+        mock_site.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_closes_site_even_when_get_modules_raises(self, mock_settings):
+        import monitoring
+
+        mock_site = MagicMock()
+        mock_site.get_modules = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_site.close = AsyncMock()
+
+        with (
+            patch("monitoring.service_settings", return_value=mock_settings),
+            patch("monitoring.initialize_logging"),
+            patch("monitoring.MonitoringSite", return_value=mock_site),
+            pytest.raises(RuntimeError),
+        ):
+            await monitoring._run("config")
+
+        mock_site.close.assert_called_once()

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -95,6 +95,7 @@ class TestMonitoringMain:
                 "solaredge2mqtt.core.settings.service_settings",
                 return_value=mock_settings,
             ),
+            patch("solaredge2mqtt.core.logging.initialize_logging"),
             patch.object(sys, "argv", ["monitoring.py"]),
         ):
             runpy.run_path(str(WORKSPACE_ROOT / "monitoring.py"), run_name="__main__")


### PR DESCRIPTION
SolarEdge retired the legacy layout/logical and playback endpoints (410 Gone). Switch to the new logical/generic/v2 structure endpoint, fetch per-inverter daily energy via the new by-inverter endpoint, and decode per-optimizer hourly power from the new optimizers-compact endpoint, replacing the fragile JS-object string-hack parser.

Site structure is now loaded once at startup and cached, since wiring rarely changes; only energy and power are refetched each loop.

Add monitoring.py as a single-shot CLI entry point (solaredge2mqtt-monitoring) for reading monitoring data without touching MQTT/InfluxDB/EventBus.