### PR TITLE
fix: report offline status even before a service's first online event

### DIFF
--- a/solaredge2mqtt/core/status/__init__.py
+++ b/solaredge2mqtt/core/status/__init__.py
@@ -52,11 +52,7 @@ class ServiceStatusController:
 
     @EventBus.subscribe(ServiceOfflineEvent)
     async def handle_offline(self, event: ServiceOfflineEvent):
-        service_name = event.SERVICE_NAME
-        if service_name not in self._configurations:
-            return
-
-        await self._update_service_status(service_name, False)
+        await self._update_service_status(event.SERVICE_NAME, False)
 
     async def _update_service_status(self, service_name: str, is_online: bool):
         current_status = self._status.get(service_name, None)

--- a/tests/core/status/test_service_status_controller.py
+++ b/tests/core/status/test_service_status_controller.py
@@ -236,7 +236,14 @@ class TestServiceStatusControllerHandleOffline:
 
     @pytest.mark.asyncio
     async def test_handle_offline_unconfigured_service(self):
-        """Test handle_offline for an unconfigured service."""
+        """
+        Test handle_offline for a service never configured via handle_online.
+
+        Offline must be reported immediately even before the service's first
+        online event configured its debounce_cycles: an outage before startup
+        ever succeeded (e.g. modbus device detection retrying) must still be
+        visible over MQTT instead of being silently dropped.
+        """
         controller = ServiceStatusController()
 
         class TestEvent(ServiceOfflineEvent):
@@ -247,11 +254,72 @@ class TestServiceStatusControllerHandleOffline:
         with patch.object(EventBus, "emit", new_callable=AsyncMock) as mock_emit:
             await controller.handle_offline(event)
 
-            # Should not emit any events
-            assert len(mock_emit.call_args_list) == 0
+            assert controller._status["unknown_service"] is False
+            assert any(
+                isinstance(call[0][0], MQTTPublishEvent)
+                and call[0][0].topic == "status/unknown_service"
+                and call[0][0].payload == "offline"
+                for call in mock_emit.call_args_list
+            )
 
 
-class TestServiceStatusControllerDebouncing:
+class TestServiceStatusControllerOfflineBeforeOnline:
+    """
+    Regression tests for offline events preceding any successful online event.
+
+    Mirrors the modbus startup-retry scenario: detection keeps failing
+    (offline events) before it ever succeeds for the first time.
+    """
+
+    @pytest.mark.asyncio
+    async def test_repeated_offline_before_first_online_stays_offline(self):
+        """Repeated offline events before any online keep publishing offline."""
+        controller = ServiceStatusController()
+
+        class OfflineEvent(ServiceOfflineEvent):
+            SERVICE_NAME = "modbus"
+
+        with patch.object(EventBus, "emit", new_callable=AsyncMock) as mock_emit:
+            await controller.handle_offline(OfflineEvent())
+            await controller.handle_offline(OfflineEvent())
+            await controller.handle_offline(OfflineEvent())
+
+            assert controller._status["modbus"] is False
+            assert mock_emit.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_online_after_offline_still_respects_debounce(self):
+        """
+        The first online after a prior offline must still debounce normally.
+
+        Before the fix, an offline event before the first online never
+        touched `_status`, so the eventual online event saw
+        `current_status is None` and bypassed debouncing entirely.
+        """
+        controller = ServiceStatusController()
+
+        class OfflineEvent(ServiceOfflineEvent):
+            SERVICE_NAME = "modbus"
+
+        class OnlineEvent(ServiceOnlineEvent):
+            SERVICE_NAME = "modbus"
+
+        with patch.object(EventBus, "emit", new_callable=AsyncMock) as mock_emit:
+            await controller.handle_offline(OfflineEvent())
+            assert controller._status["modbus"] is False
+
+            mock_emit.reset_mock()
+
+            await controller.handle_online(OnlineEvent(debounce_cycles=2))
+            # First online signal after a known offline status must debounce,
+            # not flip immediately.
+            assert controller._status["modbus"] is False
+            assert controller._pending_status_changes["modbus"] is True
+            mock_emit.assert_not_called()
+
+            await controller.handle_online(OnlineEvent())
+            assert controller._status["modbus"] is True
+
     """Tests for debouncing logic."""
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Found while reviewing #422 (startup Modbus detection retry). `ServiceStatusController.handle_offline()` silently dropped every offline event for a service that had never sent a *configuring* online event yet:

```python
async def handle_offline(self, event: ServiceOfflineEvent):
    service_name = event.SERVICE_NAME
    if service_name not in self._configurations:
        return
    await self._update_service_status(service_name, False)
```

`_configurations[service_name]` (and its `debounce_cycles`) is only populated by a *successful* `ServiceOnlineEvent`. That's an in-memory dict, reset on every process start — so on every restart, any offline event that happens before the service's first-ever successful online transition is silently ignored.

This has two consequences, both applicable to any service using this controller (`modbus`, `wallbox`, `monitoring`, `weather`, `influxdb`):

1. **The outage itself never reaches MQTT.** In the #421 scenario, `_detect_devices_with_retry()` now emits `ModbusOfflineEvent()` on every retry attempt — all silently swallowed here as long as detection hasn't succeeded once. `status/modbus` stays untouched for the entire retry window.
2. **The eventual online transition skips debouncing.** `_update_service_status()` bypasses debounce when `current_status is None` (nothing to debounce against). Because the dropped offline events never touched `_status`, `current_status` was still `None` when detection finally succeeded — so the first online publish always skipped the configured `debounce_cycles` entirely, even with `debounce_cycles: 2` set.

Fix: `_update_service_status()` already handles an unconfigured service correctly on its own — it defaults missing `debounce_cycles` to `0` (immediate publish) and separately bypasses debounce on `current_status is None`. `handle_offline()` doesn't need its own gate; it can just call the same path `handle_online()` already uses. Now the first offline event for any service publishes immediately (matching how a first online already behaves), and a *subsequent* real online event has a known prior state to debounce against, so `debounce_cycles` is actually honored instead of being silently skipped the first time.

## Test plan

- [x] `uv run pytest tests/core/status -q` — 35 passed (updated the now-incorrect "unconfigured service is silently ignored" test, added two regression tests mirroring the modbus startup-retry scenario: repeated pre-configuration offline events all publish, and a subsequent online event correctly debounces instead of bypassing it)
- [x] `uv run pytest tests/core/status --cov=solaredge2mqtt.core.status --cov-report=term-missing` — 100% coverage
- [x] `uv run pytest tests --ignore=tests/services/forecast -q` — 1307 passed (forecast module skipped, pre-existing missing optional `numpy` dep in this environment, unrelated)
- [x] `uv run ruff check solaredge2mqtt tests` — clean
- [x] `uv run pyright solaredge2mqtt/core/status` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdW3s4ErYxGT9C5utc7R7r