### PR TITLE
fix: make forecast weather_update test independent of local timezone

### DIFF
--- a/tests/services/forecast/test_service.py
+++ b/tests/services/forecast/test_service.py
@@ -235,7 +235,20 @@ class TestForecastServiceWeatherUpdate:
         service = ForecastService(settings, location, influxdb)
         service.write_new_training_data = AsyncMock()
 
-        hourly_data = [MockOpenWeatherMapForecastData(hour=11)]
+        # hour=11 must be the resulting *local* hour (see .hour property doing
+        # dt.astimezone()), so build dt from the local wall-clock time and
+        # convert to UTC for the mock constructor, instead of assuming
+        # UTC hour == local hour like a naive `hour=11` would.
+        local_dt = datetime(2024, 6, 15, 11, tzinfo=LOCAL_TZ)
+        utc_dt = local_dt.astimezone(timezone.utc)
+        hourly_data = [
+            MockOpenWeatherMapForecastData(
+                hour=utc_dt.hour,
+                year=utc_dt.year,
+                month=utc_dt.month,
+                day=utc_dt.day,
+            )
+        ]
         weather_data = MockWeatherData(hourly=hourly_data)
         event = MagicMock(spec=WeatherUpdateEvent)
         event.weather = weather_data


### PR DESCRIPTION
## Summary

Found while running the full test suite locally with the \`forecast\` extra installed (previously always excluded from my runs, so this was never exercised in this session before now) — this fails on any non-UTC machine, e.g. this dev machine (CEST, UTC+2):

\`\`\`
tests/services/forecast/test_service.py::TestForecastServiceWeatherUpdate::test_weather_update_writes_last_hour_training_data
AssertionError: Expected mock to have been awaited once. Awaited 0 times.
\`\`\`

Root cause: \`MockOpenWeatherMapForecastData(hour=11)\` builds \`dt=datetime(..., tzinfo=timezone.utc)\`, but \`OpenWeatherMapBaseData.hour\` (used by \`ForecastService.weather_update\`) returns \`self.localtime.hour\` where \`localtime = self.dt.astimezone()\` — i.e. the **local** hour, not the UTC hour passed in. On UTC+2, \`hour=11\` UTC becomes local hour 13, so \`weather_update\` stored the forecast under key 13 while the test's mocked \`now.hour=12\`/\`last_hour.hour=11\` only protects keys 12 and 11 from cleanup — the entry got popped as stale before \`write_new_training_data\` was ever called. Only passed by accident on UTC-based CI runners.

The neighboring \`test_weather_update_stores_current_hour\` already handles this correctly (converts through \`LOCAL_TZ\` deliberately) — applied the same pattern here: derive the UTC hour to pass into the mock constructor from the intended *local* hour (11), instead of assuming they're the same.

Unrelated to #421/#422/#423/#424 — pure pre-existing test bug in a module I hadn't touched, found purely because I happened to install the optional \`forecast\` extra and run the full suite for the first time in this environment.

## Test plan

- [x] \`uv run pytest tests/services/forecast -q\` — 111 passed (was 110 passed, 1 failed before the fix)
- [x] \`uv run pytest tests -q\` (full suite, forecast extra installed) — 1431 passed
- [x] \`uv run ruff check solaredge2mqtt tests\` — clean
- [x] \`uv run pyright solaredge2mqtt\` — clean (with forecast extra installed, no missing-import errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdW3s4ErYxGT9C5utc7R7r