### PR TITLE
ci: run build_project workflow on storedge branch too

### DIFF
--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -5,10 +5,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # Keep these branch lists in sync with the `PACKAGE_BRANCHES` repo variable
+  # (used below to gate docker publish) -- GitHub Actions `on:` triggers can't
+  # reference vars/expressions directly.
   push:
-    branches: [main]
+    branches: [main, storedge]
   pull_request:
-    branches: main
+    branches: [main, storedge]
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary
- Add `storedge` to `on.push.branches` and `on.pull_request.branches` in build_project.yml so CI runs for the storedge feature branch, same as main
- GitHub Actions triggers can't reference `vars.PACKAGE_BRANCHES` directly, so noted a comment to keep this list in sync manually

## Test plan
- [ ] Verify build-check/build-compat jobs trigger on this PR itself (targets storedge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2qeDJSQwhLmT3UeVt2iJV