### PR TITLE
Phase 1: StorEdge Control Block register map + read support

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ modbus:
   # Check grid status (requires extra hardware)
   check_grid_status: false
 
+  # Read the StorEdge Control Block (battery charge/discharge control state).
+  # Off by default — only relevant for StorEdge/backup-capable systems.
+  storedge_control_enabled: false
+
   # Startup device detection retry (retries indefinitely, never gives up)
   startup_retry_delay: 30       # Initial delay between retries in seconds (default: 30)
   startup_retry_max_delay: 300  # Delay doubles after each retry, capped here (default: 300)

--- a/solaredge2mqtt/config/configuration.yml.example
+++ b/solaredge2mqtt/config/configuration.yml.example
@@ -36,9 +36,10 @@ modbus:
   
   # Check grid status (requires extra hardware like Export+Import meter)
   check_grid_status: false
-  
-  # Advanced power controls (enabled, disabled, or disable)
-  advanced_power_controls: disabled
+
+  # Read the StorEdge Control Block (battery charge/discharge control state).
+  # Off by default — only relevant for StorEdge/backup-capable systems.
+  storedge_control_enabled: false
 
   # Startup device detection retry (retries indefinitely on failure)
   # startup_retry_delay: 30      # Initial delay between retries in seconds

--- a/solaredge2mqtt/services/modbus/__init__.py
+++ b/solaredge2mqtt/services/modbus/__init__.py
@@ -41,6 +41,7 @@ from solaredge2mqtt.services.modbus.sunspec.inverter import (
     SunSpecGridStatusRegister,
     SunSpecInverterInfoRegister,
     SunSpecInverterRegister,
+    SunSpecStorEdgeControlRegister,
 )
 from solaredge2mqtt.services.modbus.sunspec.meter import (
     SunSpecMeterInfoRegister,
@@ -360,6 +361,15 @@ class Modbus:
                 client=client,
             )
             inverter_raw = {**inverter_raw, **grid_status_raw}
+
+        if self.settings.storedge_control_enabled:
+            storedge_control_raw = await self._read_from_modbus(
+                SunSpecStorEdgeControlRegister.request_bundles(),
+                unit_key,
+                unit,
+                client=client,
+            )
+            inverter_raw = {**inverter_raw, **storedge_control_raw}
 
         meters_raw = {}
         batteries_raw = {}

--- a/solaredge2mqtt/services/modbus/models/inverter.py
+++ b/solaredge2mqtt/services/modbus/models/inverter.py
@@ -13,6 +13,7 @@ from solaredge2mqtt.services.homeassistant.models import (
 from solaredge2mqtt.services.modbus.models.base import ModbusComponent
 from solaredge2mqtt.services.modbus.models.values import (
     ModbusAC,
+    ModbusComponentValueGroup,
     ModbusDC,
 )
 from solaredge2mqtt.services.modbus.sunspec.values import (
@@ -33,6 +34,9 @@ class ModbusInverter(ModbusComponent):
     grid_status: bool | None = Field(
         default=None, **HABinarySensor.GRID_STATUS.field("Grid status")
     )
+    storedge_control: ModbusStorEdgeControl | None = Field(
+        default=None, title="StorEdge Control"
+    )
 
     @classmethod
     def extract_sunspec_payload(cls, payload: SunSpecPayload) -> dict[str, Any]:
@@ -52,7 +56,50 @@ class ModbusInverter(ModbusComponent):
         if "grid_status" in payload:
             values["grid_status"] = not payload["grid_status"]
 
+        if "storage_control_mode" in payload:
+            values["storedge_control"] = ModbusStorEdgeControl.extract_sunspec_payload(
+                payload
+            )
+
         return values
 
     def homeassistant_device_info(self) -> dict[str, Any]:
         return self.info.homeassistant_device_info("Inverter")
+
+
+class ModbusStorEdgeControl(ModbusComponentValueGroup):
+    storage_control_mode: int = Field(title="Storage control mode")
+    storage_ac_charge_policy: int = Field(title="Storage AC charge policy")
+    storage_ac_charge_limit: float = Field(title="Storage AC charge limit")
+    storage_backup_reserved_setting: float = Field(
+        title="Storage backup reserved setting"
+    )
+    storage_default_mode: int = Field(title="Storage default mode")
+    remote_control_command_timeout: int = Field(title="Remote control command timeout")
+    remote_control_command_mode: int = Field(title="Remote control command mode")
+    remote_control_charge_limit: float = Field(title="Remote control charge limit")
+    remote_control_discharge_limit: float = Field(
+        title="Remote control discharge limit"
+    )
+
+    @classmethod
+    def extract_sunspec_payload(cls, payload: SunSpecPayload) -> dict[str, Any]:
+        return {
+            "storage_control_mode": int(payload["storage_control_mode"]),
+            "storage_ac_charge_policy": int(payload["storage_ac_charge_policy"]),
+            "storage_ac_charge_limit": float(payload["storage_ac_charge_limit"]),
+            "storage_backup_reserved_setting": float(
+                payload["storage_backup_reserved_setting"]
+            ),
+            "storage_default_mode": int(payload["storage_default_mode"]),
+            "remote_control_command_timeout": int(
+                payload["remote_control_command_timeout"]
+            ),
+            "remote_control_command_mode": int(payload["remote_control_command_mode"]),
+            "remote_control_charge_limit": float(
+                payload["remote_control_charge_limit"]
+            ),
+            "remote_control_discharge_limit": float(
+                payload["remote_control_discharge_limit"]
+            ),
+        }

--- a/solaredge2mqtt/services/modbus/settings.py
+++ b/solaredge2mqtt/services/modbus/settings.py
@@ -80,6 +80,7 @@ class ModbusSettings(ModbusUnitSettings):
     timeout: int = Field(default=1)
 
     check_grid_status: bool = Field(default=False)
+    storedge_control_enabled: bool = Field(default=False)
 
     follower: list[ModbusFollowerSettings] = Field(default_factory=list)
 

--- a/solaredge2mqtt/services/modbus/sunspec/inverter.py
+++ b/solaredge2mqtt/services/modbus/sunspec/inverter.py
@@ -172,3 +172,79 @@ class SunSpecSiteLimitRegister(SunSpecRegister):
     @staticmethod
     def wordorder() -> SunSpecWordOrder:
         return "little"
+
+
+class SunSpecStorEdgeControlRegister(SunSpecRegister):
+    STORAGE_CONTROL_MODE = (
+        "storage_control_mode",
+        57348,
+        SunSpecValueType.UINT16,
+        True,
+    )
+    STORAGE_AC_CHARGE_POLICY = (
+        "storage_ac_charge_policy",
+        57349,
+        SunSpecValueType.UINT16,
+        True,
+    )
+    STORAGE_AC_CHARGE_LIMIT = (
+        "storage_ac_charge_limit",
+        57350,
+        SunSpecValueType.FLOAT32,
+        True,
+    )
+    STORAGE_BACKUP_RESERVED_SETTING = (
+        "storage_backup_reserved_setting",
+        57352,
+        SunSpecValueType.FLOAT32,
+        True,
+    )
+    STORAGE_DEFAULT_MODE = (
+        "storage_default_mode",
+        57354,
+        SunSpecValueType.UINT16,
+        True,
+    )
+    REMOTE_CONTROL_COMMAND_TIMEOUT = (
+        "remote_control_command_timeout",
+        57355,
+        SunSpecValueType.UINT32,
+        True,
+    )
+    REMOTE_CONTROL_COMMAND_MODE = (
+        "remote_control_command_mode",
+        57357,
+        SunSpecValueType.UINT16,
+        True,
+    )
+    REMOTE_CONTROL_CHARGE_LIMIT = (
+        "remote_control_charge_limit",
+        57358,
+        SunSpecValueType.FLOAT32,
+        True,
+    )
+    REMOTE_CONTROL_DISCHARGE_LIMIT = (
+        "remote_control_discharge_limit",
+        57360,
+        SunSpecValueType.FLOAT32,
+        True,
+    )
+
+    def decode_response(
+        self, registers: list[int], data: SunSpecPayload
+    ) -> SunSpecPayload:
+        data = super().decode_response(registers, data)
+
+        if self in (
+            SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_LIMIT,
+            SunSpecStorEdgeControlRegister.STORAGE_BACKUP_RESERVED_SETTING,
+            SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT,
+            SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT,
+        ):
+            data[self.identifier] = max(0.0, float(data[self.identifier]))
+
+        return data
+
+    @staticmethod
+    def wordorder() -> SunSpecWordOrder:
+        return "little"

--- a/tests/services/modbus/sunspec/test_inverter.py
+++ b/tests/services/modbus/sunspec/test_inverter.py
@@ -5,6 +5,7 @@ from solaredge2mqtt.services.modbus.sunspec.inverter import (
     SunSpecInverterInfoRegister,
     SunSpecInverterRegister,
     SunSpecSiteLimitRegister,
+    SunSpecStorEdgeControlRegister,
 )
 from solaredge2mqtt.services.modbus.sunspec.values import SunSpecValueType
 
@@ -222,3 +223,123 @@ class TestSunSpecSiteLimitRegister:
         result = reg.decode_response([2], data)
 
         assert result["export_control_limit_mode"] == 2
+
+
+class TestSunSpecStorEdgeControlRegister:
+    """Tests for SunSpecStorEdgeControlRegister class."""
+
+    def test_storage_control_mode_register(self):
+        """Test STORAGE_CONTROL_MODE register properties."""
+        reg = SunSpecStorEdgeControlRegister.STORAGE_CONTROL_MODE
+
+        assert reg.identifier == "storage_control_mode"
+        assert reg.address == 57348
+        assert reg.value_type == SunSpecValueType.UINT16
+        assert reg.required is True
+
+    def test_storage_ac_charge_policy_register(self):
+        """Test STORAGE_AC_CHARGE_POLICY register properties."""
+        reg = SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_POLICY
+
+        assert reg.identifier == "storage_ac_charge_policy"
+        assert reg.address == 57349
+        assert reg.value_type == SunSpecValueType.UINT16
+        assert reg.required is True
+
+    def test_storage_ac_charge_limit_register(self):
+        """Test STORAGE_AC_CHARGE_LIMIT register properties."""
+        reg = SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_LIMIT
+
+        assert reg.identifier == "storage_ac_charge_limit"
+        assert reg.address == 57350
+        assert reg.value_type == SunSpecValueType.FLOAT32
+        assert reg.required is True
+
+    def test_storage_backup_reserved_setting_register(self):
+        """Test STORAGE_BACKUP_RESERVED_SETTING register properties."""
+        reg = SunSpecStorEdgeControlRegister.STORAGE_BACKUP_RESERVED_SETTING
+
+        assert reg.identifier == "storage_backup_reserved_setting"
+        assert reg.address == 57352
+        assert reg.value_type == SunSpecValueType.FLOAT32
+        assert reg.required is True
+
+    def test_storage_default_mode_register(self):
+        """Test STORAGE_DEFAULT_MODE register properties."""
+        reg = SunSpecStorEdgeControlRegister.STORAGE_DEFAULT_MODE
+
+        assert reg.identifier == "storage_default_mode"
+        assert reg.address == 57354
+        assert reg.value_type == SunSpecValueType.UINT16
+        assert reg.required is True
+
+    def test_remote_control_command_timeout_register(self):
+        """Test REMOTE_CONTROL_COMMAND_TIMEOUT register properties."""
+        reg = SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_TIMEOUT
+
+        assert reg.identifier == "remote_control_command_timeout"
+        assert reg.address == 57355
+        assert reg.value_type == SunSpecValueType.UINT32
+        assert reg.required is True
+
+    def test_remote_control_command_mode_register(self):
+        """Test REMOTE_CONTROL_COMMAND_MODE register properties."""
+        reg = SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_MODE
+
+        assert reg.identifier == "remote_control_command_mode"
+        assert reg.address == 57357
+        assert reg.value_type == SunSpecValueType.UINT16
+        assert reg.required is True
+
+    def test_remote_control_charge_limit_register(self):
+        """Test REMOTE_CONTROL_CHARGE_LIMIT register properties."""
+        reg = SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT
+
+        assert reg.identifier == "remote_control_charge_limit"
+        assert reg.address == 57358
+        assert reg.value_type == SunSpecValueType.FLOAT32
+        assert reg.required is True
+
+    def test_remote_control_discharge_limit_register(self):
+        """Test REMOTE_CONTROL_DISCHARGE_LIMIT register properties."""
+        reg = SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT
+
+        assert reg.identifier == "remote_control_discharge_limit"
+        assert reg.address == 57360
+        assert reg.value_type == SunSpecValueType.FLOAT32
+        assert reg.required is True
+
+    def test_wordorder_little_endian(self):
+        """Test wordorder returns little for StorEdge control registers."""
+        assert SunSpecStorEdgeControlRegister.wordorder() == "little"
+
+    def test_decode_response_charge_limit_negative_clamped_to_zero(self):
+        """Test a FLOAT32 field is clamped to 0.0 when the raw value is negative."""
+        reg = SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT
+        data = {}
+
+        # FLOAT32 -5.0 in little word order: big endian words [0xC0A0, 0x0000]
+        # → little word order registers [0x0000, 0xC0A0]
+        result = reg.decode_response([0x0000, 0xC0A0], data)
+
+        assert result["remote_control_charge_limit"] == 0.0
+
+    def test_decode_response_charge_limit_positive_passes_through(self):
+        """Test a FLOAT32 field keeps its value when the raw value is positive."""
+        reg = SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT
+        data = {}
+
+        # FLOAT32 5.0 in little word order: big endian words [0x40A0, 0x0000]
+        # → little word order registers [0x0000, 0x40A0]
+        result = reg.decode_response([0x0000, 0x40A0], data)
+
+        assert result["remote_control_charge_limit"] == 5.0
+
+    def test_decode_response_storage_control_mode_not_clamped(self):
+        """Test a non-FLOAT32 field is unaffected by the clamp branch."""
+        reg = SunSpecStorEdgeControlRegister.STORAGE_CONTROL_MODE
+        data = {}
+
+        result = reg.decode_response([4], data)
+
+        assert result["storage_control_mode"] == 4

--- a/tests/services/modbus/test_inverter.py
+++ b/tests/services/modbus/test_inverter.py
@@ -7,7 +7,10 @@ from solaredge2mqtt.services.modbus.models.base import (
     ModbusUnitInfo,
     ModbusUnitRole,
 )
-from solaredge2mqtt.services.modbus.models.inverter import ModbusInverter
+from solaredge2mqtt.services.modbus.models.inverter import (
+    ModbusInverter,
+    ModbusStorEdgeControl,
+)
 from solaredge2mqtt.services.modbus.sunspec.values import SunSpecPayload
 
 
@@ -28,10 +31,26 @@ def make_device_info(with_unit: bool = False) -> ModbusDeviceInfo:
     )
 
 
+def make_storedge_control_data() -> dict:
+    """Create StorEdge control register payload for testing."""
+    return {
+        "storage_control_mode": 4,
+        "storage_ac_charge_policy": 1,
+        "storage_ac_charge_limit": 5000.0,
+        "storage_backup_reserved_setting": 10.0,
+        "storage_default_mode": 6,
+        "remote_control_command_timeout": 3600,
+        "remote_control_command_mode": 0,
+        "remote_control_charge_limit": 5000.0,
+        "remote_control_discharge_limit": 5000.0,
+    }
+
+
 def make_inverter_data(
     status: int = 4,
     with_grid_status: bool = False,
     grid_status: int = 0,
+    with_storedge_control: bool = False,
 ) -> dict:
     """Create inverter data for testing."""
     data = {
@@ -68,6 +87,9 @@ def make_inverter_data(
 
     if with_grid_status:
         data["grid_status"] = grid_status
+
+    if with_storedge_control:
+        data.update(make_storedge_control_data())
 
     return data
 
@@ -192,3 +214,43 @@ class TestModbusInverter:
             data = make_inverter_data(status=status)
             inverter = ModbusInverter.from_sunspec(info, data)
             assert inverter.status_text == expected_text
+
+    def test_inverter_without_storedge_control(self):
+        """Test inverter without StorEdge control data."""
+        info = make_device_info()
+        data = make_inverter_data(with_storedge_control=False)
+
+        inverter = ModbusInverter.from_sunspec(info, data)
+
+        assert inverter.storedge_control is None
+
+    def test_inverter_with_storedge_control(self):
+        """Test inverter attaches StorEdge control data when present."""
+        info = make_device_info()
+        data = make_inverter_data(with_storedge_control=True)
+
+        inverter = ModbusInverter.from_sunspec(info, data)
+
+        assert inverter.storedge_control is not None
+        assert inverter.storedge_control.storage_control_mode == 4
+        assert inverter.storedge_control.storage_default_mode == 6
+
+
+class TestModbusStorEdgeControl:
+    """Tests for ModbusStorEdgeControl class."""
+
+    def test_storedge_control_creation(self):
+        """Test ModbusStorEdgeControl creation from a full StorEdge payload."""
+        data = make_storedge_control_data()
+
+        control = ModbusStorEdgeControl.from_sunspec(data)
+
+        assert control.storage_control_mode == 4
+        assert control.storage_ac_charge_policy == 1
+        assert control.storage_ac_charge_limit == pytest.approx(5000.0)
+        assert control.storage_backup_reserved_setting == pytest.approx(10.0)
+        assert control.storage_default_mode == 6
+        assert control.remote_control_command_timeout == 3600
+        assert control.remote_control_command_mode == 0
+        assert control.remote_control_charge_limit == pytest.approx(5000.0)
+        assert control.remote_control_discharge_limit == pytest.approx(5000.0)

--- a/tests/services/modbus/test_service.py
+++ b/tests/services/modbus/test_service.py
@@ -26,6 +26,7 @@ def mock_service_settings():
     settings.modbus.unit = 1
     settings.modbus.has_followers = False
     settings.modbus.check_grid_status = True
+    settings.modbus.storedge_control_enabled = False
     settings.modbus.startup_retry_delay = 30
     settings.modbus.startup_retry_max_delay = 300
 
@@ -463,6 +464,7 @@ class TestModbusRawDataCollection:
     ):
         """_get_raw_data should include optional and detected payloads."""
         mock_service_settings.modbus.check_grid_status = True
+        mock_service_settings.modbus.storedge_control_enabled = True
 
         modbus = Modbus(mock_service_settings)
         modbus._device_info = {
@@ -483,6 +485,11 @@ class TestModbusRawDataCollection:
                 return_value=[MagicMock()],
             ),
             patch(
+                "solaredge2mqtt.services.modbus.SunSpecStorEdgeControlRegister"
+                ".request_bundles",
+                return_value=[MagicMock()],
+            ),
+            patch(
                 "solaredge2mqtt.services.modbus.SunSpecMeterRegister.request_bundles",
                 return_value=[MagicMock()],
             ),
@@ -495,6 +502,7 @@ class TestModbusRawDataCollection:
                 side_effect=[
                     {"status": 4},
                     {"grid_status": 0},
+                    {"storage_control_mode": 4},
                     {"power": 100},
                     {"soe": 80},
                 ]
@@ -506,6 +514,7 @@ class TestModbusRawDataCollection:
 
         assert "status" in inverter_raw
         assert "grid_status" in inverter_raw
+        assert "storage_control_mode" in inverter_raw
         assert "meter0" in meters_raw
         assert "battery0" in batteries_raw
 
@@ -515,6 +524,7 @@ class TestModbusRawDataCollection:
     ):
         """_get_raw_data should skip optional reads when disabled."""
         mock_service_settings.modbus.check_grid_status = False
+        mock_service_settings.modbus.storedge_control_enabled = False
 
         modbus = Modbus(mock_service_settings)
         modbus._device_info = {"leader": {"inverter": MagicMock()}}

--- a/tests/services/modbus/test_settings.py
+++ b/tests/services/modbus/test_settings.py
@@ -103,6 +103,7 @@ class TestModbusSettings:
         assert settings.port == 1502
         assert settings.timeout == 1
         assert settings.check_grid_status is False
+        assert settings.storedge_control_enabled is False
         assert settings.follower == []
         assert settings.retain is False
 


### PR DESCRIPTION
## Summary
- New `SunSpecStorEdgeControlRegister` (sunspec/inverter.py) covering the StorEdge Control Block, base 57348 / 0xE004: Storage Control Mode, AC Charge Policy, AC Charge Limit, Backup Reserved Setting, Storage Default Mode, and the Remote Control command mode/timeout/charge-limit/discharge-limit registers. FLOAT32 fields are clamped to `>= 0` on decode.
- New `ModbusStorEdgeControl` read model, attached to `ModbusInverter.storedge_control` (only when the register block actually decodes, so inverters without StorEdge hardware are unaffected).
- New `storedge_control_enabled` setting (default `False`) gating the read — separate from anything power-control related, since battery cycling is more consequential than a passive telemetry read.

Read-only. Part of the StorEdge battery control plan for issue #185:
- Phase 0 (merged, #428): remove legacy `advanced_power_controls` scaffolding
- **Phase 1 (this PR)**: register map + read model + read wiring
- Phase 2: `storedge_control` write module (MQTT → Modbus)

## Test plan
- [x] `pytest -q` — 1387 passed (16 new)
- [x] `ruff check` — clean
- [x] pre-commit hooks (ruff, pyright) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2qeDJSQwhLmT3UeVt2iJV