### PR TITLE
Phase 2: StorEdge control MQTT write module (closes #185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ modbus/inverter/storedge_control/ac_charge_policy
 modbus/inverter/storedge_control/ac_charge_limit
 modbus/inverter/storedge_control/backup_reserved_setting
 modbus/inverter/storedge_control/default_mode
-modbus/inverter/storedge_control/remote_control_command_timeout
-modbus/inverter/storedge_control/remote_control_command_mode
-modbus/inverter/storedge_control/remote_control_charge_limit
-modbus/inverter/storedge_control/remote_control_discharge_limit
+modbus/inverter/storedge_control/command_timeout
+modbus/inverter/storedge_control/command_mode
+modbus/inverter/storedge_control/charge_limit
+modbus/inverter/storedge_control/discharge_limit
 ```
 
 Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}` to `control_mode` switches the battery to Remote Control mode:
@@ -241,12 +241,12 @@ Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}`
 | `ac_charge_limit` | `limit` | ≥ 0 (kWh or %, depending on policy) | `storage_ac_charge_limit` |
 | `backup_reserved_setting` | `percentage` | 0–100 | `storage_backup_reserved_setting` |
 | `default_mode` | `mode` | 0–7 (charge/discharge mode) | `storage_default_mode` |
-| `remote_control_command_timeout` | `seconds` | 0–86400 | `remote_control_command_timeout` |
-| `remote_control_command_mode` | `mode` | 0–7 | `remote_control_command_mode` |
-| `remote_control_charge_limit` | `limit` | ≥ 0 (W) | `remote_control_charge_limit` |
-| `remote_control_discharge_limit` | `limit` | ≥ 0 (W) | `remote_control_discharge_limit` |
+| `command_timeout` | `seconds` | 0–86400 | `remote_control_command_timeout` |
+| `command_mode` | `mode` | 0–7 | `remote_control_command_mode` |
+| `charge_limit` | `limit` | ≥ 0 (W) | `remote_control_charge_limit` |
+| `discharge_limit` | `limit` | ≥ 0 (W) | `remote_control_discharge_limit` |
 
-The write topic suffixes are shorter than the read-back field names for the first four — the `storedge_control/` path segment already says what block this is, so the write topic drops the redundant `storage_` prefix. The read-back payload (published under `storedge_control` on the inverter's state topic) keeps the full SolarEdge-protocol field name for the SunSpec register.
+The write topic suffixes are shorter than the read-back field names — the `storedge_control/` path segment already says what block this is, so the write topics drop the redundant `storage_`/`remote_control_` prefixes. The read-back payload (published under `storedge_control` on the inverter's state topic) keeps the full SolarEdge-protocol field name for the SunSpec register. Note `charge_limit`/`discharge_limit` here are the Remote Control power limits (W) — distinct from `ac_charge_limit` (the AC charging limit in kWh/%).
 
 `control_mode`, `ac_charge_policy`, `ac_charge_limit`, and `backup_reserved_setting` always take effect. The remaining five only take effect once `storage_control_mode` is `4` (Remote Control) — writing to them otherwise is rejected and logged, since SolarEdge ignores them outside Remote Control mode.
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}`
 
 `storage_control_mode`, `storage_ac_charge_policy`, `storage_ac_charge_limit`, and `storage_backup_reserved_setting` always take effect. The remaining five only take effect once `storage_control_mode` is `4` (Remote Control) — writing to them otherwise is rejected and logged, since SolarEdge ignores them outside Remote Control mode.
 
+If a published value already matches the last value read back from the inverter, the write is skipped — these registers don't need to be exercised more than necessary.
+
 ### Leader/follower setup
 
 SolarEdge inverters support a cascading setup, where one inverter acts as the leader and up to ten others act as followers.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}`
 
 `storage_control_mode`, `storage_ac_charge_policy`, `storage_ac_charge_limit`, and `storage_backup_reserved_setting` always take effect. The remaining five only take effect once `storage_control_mode` is `4` (Remote Control) — writing to them otherwise is rejected and logged, since SolarEdge ignores them outside Remote Control mode.
 
-If a published value already matches the last value read back from the inverter, the write is skipped — these registers don't need to be exercised more than necessary.
+If a published value already matches the last value read back from the inverter, the write is skipped — these registers don't need to be exercised more than necessary. To force a write anyway (e.g. if the cached value might be stale), publish a JSON object with `"force": true`, e.g. `{"mode": 4, "force": true}`. Force only bypasses this no-op check — it does not bypass the Remote Control gate above.
 
 ### Leader/follower setup
 

--- a/README.md
+++ b/README.md
@@ -221,15 +221,15 @@ This is off by default: changing these settings affects real battery cycling, un
 Once enabled, the current values are published as part of the inverter payload under `storedge_control`, and nine command topics accept writes:
 
 ```
-modbus/inverter/storedge_control/control_mode
-modbus/inverter/storedge_control/ac_charge_policy
-modbus/inverter/storedge_control/ac_charge_limit
-modbus/inverter/storedge_control/backup_reserved_setting
-modbus/inverter/storedge_control/default_mode
-modbus/inverter/storedge_control/command_timeout
-modbus/inverter/storedge_control/command_mode
-modbus/inverter/storedge_control/charge_limit
-modbus/inverter/storedge_control/discharge_limit
+modbus/inverter/storedge/control_mode
+modbus/inverter/storedge/ac_charge_policy
+modbus/inverter/storedge/ac_charge_limit
+modbus/inverter/storedge/backup_reserved_setting
+modbus/inverter/storedge/default_mode
+modbus/inverter/storedge/command_timeout
+modbus/inverter/storedge/command_mode
+modbus/inverter/storedge/charge_limit
+modbus/inverter/storedge/discharge_limit
 ```
 
 Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}` to `control_mode` switches the battery to Remote Control mode:
@@ -246,7 +246,7 @@ Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}`
 | `charge_limit` | `limit` | ≥ 0 (W) | `remote_control_charge_limit` |
 | `discharge_limit` | `limit` | ≥ 0 (W) | `remote_control_discharge_limit` |
 
-The write topic suffixes are shorter than the read-back field names — the `storedge_control/` path segment already says what block this is, so the write topics drop the redundant `storage_`/`remote_control_` prefixes. The read-back payload (published under `storedge_control` on the inverter's state topic) keeps the full SolarEdge-protocol field name for the SunSpec register. Note `charge_limit`/`discharge_limit` here are the Remote Control power limits (W) — distinct from `ac_charge_limit` (the AC charging limit in kWh/%).
+The write topic suffixes are shorter than the read-back field names — the `storedge/` path segment already says what block this is, so the write topics drop the redundant `storage_`/`remote_control_` prefixes. The read-back payload (published under `storedge_control` on the inverter's state topic) keeps the full SolarEdge-protocol field name for the SunSpec register. Note `charge_limit`/`discharge_limit` here are the Remote Control power limits (W) — distinct from `ac_charge_limit` (the AC charging limit in kWh/%).
 
 `control_mode`, `ac_charge_policy`, `ac_charge_limit`, and `backup_reserved_setting` always take effect. The remaining five only take effect once `storage_control_mode` is `4` (Remote Control) — writing to them otherwise is rejected and logged, since SolarEdge ignores them outside Remote Control mode.
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,47 @@ modbus:
 
 If the inverter is unreachable during startup device detection (e.g. a brief Modbus outage), the service retries with exponential backoff instead of crashing — the delay starts at `startup_retry_delay` and doubles on each attempt up to `startup_retry_max_delay`.
 
+#### StorEdge battery control
+
+For SolarEdge StorEdge/backup-capable systems, the battery's charge/discharge behavior (Storage Control Mode, AC charge policy, backup reserve, and — while in Remote Control mode — the default and timed charge/discharge command) can be read and written over Modbus.
+
+```yaml
+modbus:
+  storedge_control_enabled: true
+```
+
+This is off by default: changing these settings affects real battery cycling, unlike a passive telemetry read.
+
+Once enabled, the current values are published as part of the inverter payload under `storedge_control`, and nine command topics accept writes:
+
+```
+modbus/inverter/storedge_control/storage_control_mode
+modbus/inverter/storedge_control/storage_ac_charge_policy
+modbus/inverter/storedge_control/storage_ac_charge_limit
+modbus/inverter/storedge_control/storage_backup_reserved_setting
+modbus/inverter/storedge_control/storage_default_mode
+modbus/inverter/storedge_control/remote_control_command_timeout
+modbus/inverter/storedge_control/remote_control_command_mode
+modbus/inverter/storedge_control/remote_control_charge_limit
+modbus/inverter/storedge_control/remote_control_discharge_limit
+```
+
+Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}` to `storage_control_mode` switches the battery to Remote Control mode:
+
+| Topic suffix | Field | Range |
+|---|---|---|
+| `storage_control_mode` | `mode` | 0–4 (0 Disabled, 1 Maximize Self Consumption, 2 Time of Use, 3 Backup Only, 4 Remote Control) |
+| `storage_ac_charge_policy` | `policy` | 0–3 |
+| `storage_ac_charge_limit` | `limit` | ≥ 0 (kWh or %, depending on policy) |
+| `storage_backup_reserved_setting` | `percentage` | 0–100 |
+| `storage_default_mode` | `mode` | 0–7 (charge/discharge mode) |
+| `remote_control_command_timeout` | `seconds` | 0–86400 |
+| `remote_control_command_mode` | `mode` | 0–7 |
+| `remote_control_charge_limit` | `limit` | ≥ 0 (W) |
+| `remote_control_discharge_limit` | `limit` | ≥ 0 (W) |
+
+`storage_control_mode`, `storage_ac_charge_policy`, `storage_ac_charge_limit`, and `storage_backup_reserved_setting` always take effect. The remaining five only take effect once `storage_control_mode` is `4` (Remote Control) — writing to them otherwise is rejected and logged, since SolarEdge ignores them outside Remote Control mode.
+
 ### Leader/follower setup
 
 SolarEdge inverters support a cascading setup, where one inverter acts as the leader and up to ten others act as followers.

--- a/README.md
+++ b/README.md
@@ -221,32 +221,34 @@ This is off by default: changing these settings affects real battery cycling, un
 Once enabled, the current values are published as part of the inverter payload under `storedge_control`, and nine command topics accept writes:
 
 ```
-modbus/inverter/storedge_control/storage_control_mode
-modbus/inverter/storedge_control/storage_ac_charge_policy
-modbus/inverter/storedge_control/storage_ac_charge_limit
-modbus/inverter/storedge_control/storage_backup_reserved_setting
-modbus/inverter/storedge_control/storage_default_mode
+modbus/inverter/storedge_control/control_mode
+modbus/inverter/storedge_control/ac_charge_policy
+modbus/inverter/storedge_control/ac_charge_limit
+modbus/inverter/storedge_control/backup_reserved_setting
+modbus/inverter/storedge_control/default_mode
 modbus/inverter/storedge_control/remote_control_command_timeout
 modbus/inverter/storedge_control/remote_control_command_mode
 modbus/inverter/storedge_control/remote_control_charge_limit
 modbus/inverter/storedge_control/remote_control_discharge_limit
 ```
 
-Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}` to `storage_control_mode` switches the battery to Remote Control mode:
+Payloads are a bare value or a JSON object, e.g. publishing `4` or `{"mode": 4}` to `control_mode` switches the battery to Remote Control mode:
 
-| Topic suffix | Field | Range |
-|---|---|---|
-| `storage_control_mode` | `mode` | 0–4 (0 Disabled, 1 Maximize Self Consumption, 2 Time of Use, 3 Backup Only, 4 Remote Control) |
-| `storage_ac_charge_policy` | `policy` | 0–3 |
-| `storage_ac_charge_limit` | `limit` | ≥ 0 (kWh or %, depending on policy) |
-| `storage_backup_reserved_setting` | `percentage` | 0–100 |
-| `storage_default_mode` | `mode` | 0–7 (charge/discharge mode) |
-| `remote_control_command_timeout` | `seconds` | 0–86400 |
-| `remote_control_command_mode` | `mode` | 0–7 |
-| `remote_control_charge_limit` | `limit` | ≥ 0 (W) |
-| `remote_control_discharge_limit` | `limit` | ≥ 0 (W) |
+| Topic suffix | Field | Range | Read-back field (under `storedge_control`) |
+|---|---|---|---|
+| `control_mode` | `mode` | 0–4 (0 Disabled, 1 Maximize Self Consumption, 2 Time of Use, 3 Backup Only, 4 Remote Control) | `storage_control_mode` |
+| `ac_charge_policy` | `policy` | 0–3 | `storage_ac_charge_policy` |
+| `ac_charge_limit` | `limit` | ≥ 0 (kWh or %, depending on policy) | `storage_ac_charge_limit` |
+| `backup_reserved_setting` | `percentage` | 0–100 | `storage_backup_reserved_setting` |
+| `default_mode` | `mode` | 0–7 (charge/discharge mode) | `storage_default_mode` |
+| `remote_control_command_timeout` | `seconds` | 0–86400 | `remote_control_command_timeout` |
+| `remote_control_command_mode` | `mode` | 0–7 | `remote_control_command_mode` |
+| `remote_control_charge_limit` | `limit` | ≥ 0 (W) | `remote_control_charge_limit` |
+| `remote_control_discharge_limit` | `limit` | ≥ 0 (W) | `remote_control_discharge_limit` |
 
-`storage_control_mode`, `storage_ac_charge_policy`, `storage_ac_charge_limit`, and `storage_backup_reserved_setting` always take effect. The remaining five only take effect once `storage_control_mode` is `4` (Remote Control) — writing to them otherwise is rejected and logged, since SolarEdge ignores them outside Remote Control mode.
+The write topic suffixes are shorter than the read-back field names for the first four — the `storedge_control/` path segment already says what block this is, so the write topic drops the redundant `storage_` prefix. The read-back payload (published under `storedge_control` on the inverter's state topic) keeps the full SolarEdge-protocol field name for the SunSpec register.
+
+`control_mode`, `ac_charge_policy`, `ac_charge_limit`, and `backup_reserved_setting` always take effect. The remaining five only take effect once `storage_control_mode` is `4` (Remote Control) — writing to them otherwise is rejected and logged, since SolarEdge ignores them outside Remote Control mode.
 
 If a published value already matches the last value read back from the inverter, the write is skipped — these registers don't need to be exercised more than necessary. To force a write anyway (e.g. if the cached value might be stale), publish a JSON object with `"force": true`, e.g. `{"mode": 4, "force": true}`. Force only bypasses this no-op check — it does not bypass the Remote Control gate above.
 

--- a/solaredge2mqtt/services/modbus/__init__.py
+++ b/solaredge2mqtt/services/modbus/__init__.py
@@ -82,6 +82,7 @@ class Modbus:
         self._device_info: dict[str, dict[str, ModbusDeviceInfo]] = {}
 
         self._clients: dict[str, AsyncModbusTcpClient] = {}
+        self._client_locks: dict[str, asyncio.Lock] = {}
 
         EventBus.register(self)
 
@@ -101,6 +102,7 @@ class Modbus:
 
             leader_client = self._build_client(self.settings.host, self.settings.port)
             self._clients["leader"] = leader_client
+            self._client_locks["leader"] = asyncio.Lock()
 
             for i, follower in enumerate(self.settings.follower):
                 unit_key = f"follower{i}"
@@ -114,8 +116,12 @@ class Modbus:
                         port=port,
                     )
                     self._clients[unit_key] = self._build_client(host, port)
+                    self._client_locks[unit_key] = asyncio.Lock()
                 else:
+                    # Cascaded follower: shares the leader's TCP connection, so it
+                    # must also share the leader's lock to serialize access to it.
                     self._clients[unit_key] = leader_client
+                    self._client_locks[unit_key] = self._client_locks["leader"]
 
             await self._detect_devices_with_retry()
 
@@ -167,7 +173,10 @@ class Modbus:
 
             self._device_info[unit_key] = {}
 
-            async with self._clients[unit_key]:
+            async with (
+                self._client_locks[unit_key],
+                self._clients[unit_key],
+            ):
                 inverter_raw = await self.read_device_info(
                     SunSpecInverterInfoRegister,
                     unit_key,
@@ -309,7 +318,10 @@ class Modbus:
 
         try:
             for unit_key, unit_settings in self.settings.units.items():
-                async with self._clients[unit_key]:
+                async with (
+                    self._client_locks[unit_key],
+                    self._clients[unit_key],
+                ):
                     (
                         inverter_raw,
                         meters_raw,
@@ -580,6 +592,9 @@ class Modbus:
     async def _handle_write_event(self, event: ModbusWriteEvent) -> None:
         await self._write_to_modbus(event.register, event.payload, event.unit_key)
 
+    WRITE_RETRY_ATTEMPTS = 3
+    WRITE_RETRY_DELAY = 1
+
     async def _write_to_modbus(
         self,
         register: SunSpecRegister,
@@ -589,6 +604,7 @@ class Modbus:
         try:
             unit_settings = self.settings.units[unit_key]
             client = self._clients[unit_key]
+            lock = self._client_locks[unit_key]
         except KeyError as error:
             raise InvalidDataException(
                 f"Unknown modbus unit_key: {unit_key}"
@@ -601,14 +617,27 @@ class Modbus:
         value_decoded = register.encode_request(value)
         logger.trace(f"Encoded value: {value_decoded}")
 
-        try:
-            async with client:
-                await client.write_registers(
-                    register.address,
-                    value_decoded,
-                    device_id=unit_settings.unit,
-                )
+        for attempt in range(1, self.WRITE_RETRY_ATTEMPTS + 1):
+            try:
+                async with lock, client:
+                    await client.write_registers(
+                        register.address,
+                        value_decoded,
+                        device_id=unit_settings.unit,
+                    )
+                return
 
-        except ModbusException as error:
-            logger.debug(f"Modbus write exception: {error}")
-            logger.error(f"Unwriteable register {register.address}")
+            except ModbusException as error:
+                logger.debug(f"Modbus write exception: {error}")
+                if attempt < self.WRITE_RETRY_ATTEMPTS:
+                    logger.warning(
+                        f"Write to register {register.address} failed "
+                        f"(attempt {attempt}/{self.WRITE_RETRY_ATTEMPTS}), "
+                        f"retrying in {self.WRITE_RETRY_DELAY}s"
+                    )
+                    await asyncio.sleep(self.WRITE_RETRY_DELAY)
+                else:
+                    logger.error(
+                        f"Unwriteable register {register.address} "
+                        f"after {self.WRITE_RETRY_ATTEMPTS} attempts"
+                    )

--- a/solaredge2mqtt/services/modbus/models/inverter.py
+++ b/solaredge2mqtt/services/modbus/models/inverter.py
@@ -67,6 +67,9 @@ class ModbusInverter(ModbusComponent):
         return self.info.homeassistant_device_info("Inverter")
 
 
+REMOTE_CONTROL_MODE = 4
+
+
 class ModbusStorEdgeControl(ModbusComponentValueGroup):
     storage_control_mode: int = Field(title="Storage control mode")
     storage_ac_charge_policy: int = Field(title="Storage AC charge policy")

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -50,7 +50,7 @@ class StorEdgeControl:
             if self.settings.has_followers
             else ModbusInverter.generate_topic_prefix()
         )
-        self.topic_prefix = f"{inverter_topic}/storedge_control"
+        self.topic_prefix = f"{inverter_topic}/storedge"
 
         self._last_known: dict[str, ModbusStorEdgeControl] = {}
 

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -6,7 +6,10 @@ from solaredge2mqtt.core.events import EventBus
 from solaredge2mqtt.core.logging import logger
 from solaredge2mqtt.services.modbus.events import ModbusUnitsReadEvent, ModbusWriteEvent
 from solaredge2mqtt.services.modbus.models.base import ModbusUnitRole
-from solaredge2mqtt.services.modbus.models.inverter import ModbusInverter
+from solaredge2mqtt.services.modbus.models.inverter import (
+    ModbusInverter,
+    ModbusStorEdgeControl,
+)
 from solaredge2mqtt.services.modbus.storedge_control_events import (
     RemoteControlChargeLimitEvent,
     RemoteControlChargeLimitSubscribeEvent,
@@ -51,7 +54,7 @@ class StorEdgeControl:
         # so this must stay relative (no service_settings.mqtt.topic_prefix here).
         self.topic_prefix = f"{inverter_topic}/storedge_control"
 
-        self._storage_control_mode: dict[str, int] = {}
+        self._last_known: dict[str, ModbusStorEdgeControl] = {}
 
         EventBus.register(self)
 
@@ -106,15 +109,20 @@ class StorEdgeControl:
         )
 
     @EventBus.subscribe(ModbusUnitsReadEvent)
-    async def cache_storage_control_mode(self, event: ModbusUnitsReadEvent) -> None:
+    async def cache_storedge_control(self, event: ModbusUnitsReadEvent) -> None:
         for unit_key, unit in event.units.items():
             if unit.inverter.storedge_control is not None:
-                self._storage_control_mode[unit_key] = (
-                    unit.inverter.storedge_control.storage_control_mode
-                )
+                self._last_known[unit_key] = unit.inverter.storedge_control
 
     def _is_remote_control_active(self, unit_key: str = DEFAULT_UNIT_KEY) -> bool:
-        return self._storage_control_mode.get(unit_key) == REMOTE_CONTROL_MODE
+        last = self._last_known.get(unit_key)
+        return last is not None and last.storage_control_mode == REMOTE_CONTROL_MODE
+
+    def _is_noop_write(
+        self, field_name: str, value: int | float, unit_key: str
+    ) -> bool:
+        last = self._last_known.get(unit_key)
+        return last is not None and getattr(last, field_name) == value
 
     async def _write(
         self,
@@ -123,6 +131,16 @@ class StorEdgeControl:
         field_name: str,
         unit_key: str = DEFAULT_UNIT_KEY,
     ) -> None:
+        if self._is_noop_write(field_name, value, unit_key):
+            logger.debug(
+                "Skipping StorEdge control {field}: {value} already active "
+                "on unit {unit_key}",
+                field=field_name,
+                value=value,
+                unit_key=unit_key,
+            )
+            return
+
         logger.info(
             "Writing StorEdge control {field}: {value} (unit {unit_key})",
             field=field_name,
@@ -138,6 +156,16 @@ class StorEdgeControl:
         field_name: str,
         unit_key: str = DEFAULT_UNIT_KEY,
     ) -> None:
+        if self._is_noop_write(field_name, value, unit_key):
+            logger.debug(
+                "Skipping StorEdge control {field}: {value} already active "
+                "on unit {unit_key}",
+                field=field_name,
+                value=value,
+                unit_key=unit_key,
+            )
+            return
+
         if not self._is_remote_control_active(unit_key):
             logger.error(
                 "Cannot write StorEdge control {field}: Storage Control Mode is not "

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -47,9 +47,9 @@ class StorEdgeControl:
             if self.settings.has_followers
             else ModbusInverter.generate_topic_prefix()
         )
-        self.topic_prefix = (
-            f"{service_settings.mqtt.topic_prefix}/{inverter_topic}/storedge_control"
-        )
+        # The MQTT client prepends its own topic_prefix in _subscribe_topic,
+        # so this must stay relative (no service_settings.mqtt.topic_prefix here).
+        self.topic_prefix = f"{inverter_topic}/storedge_control"
 
         self._storage_control_mode: dict[str, int] = {}
 

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -7,28 +7,29 @@ from solaredge2mqtt.core.logging import logger
 from solaredge2mqtt.services.modbus.events import ModbusUnitsReadEvent, ModbusWriteEvent
 from solaredge2mqtt.services.modbus.models.base import ModbusUnitRole
 from solaredge2mqtt.services.modbus.models.inverter import (
+    REMOTE_CONTROL_MODE,
     ModbusInverter,
     ModbusStorEdgeControl,
 )
 from solaredge2mqtt.services.modbus.storedge_control_events import (
-    RemoteControlChargeLimitEvent,
-    RemoteControlChargeLimitSubscribeEvent,
-    RemoteControlCommandModeEvent,
-    RemoteControlCommandModeSubscribeEvent,
-    RemoteControlCommandTimeoutEvent,
-    RemoteControlCommandTimeoutSubscribeEvent,
-    RemoteControlDischargeLimitEvent,
-    RemoteControlDischargeLimitSubscribeEvent,
-    StorageAcChargeLimitEvent,
-    StorageAcChargeLimitSubscribeEvent,
-    StorageAcChargePolicyEvent,
-    StorageAcChargePolicySubscribeEvent,
-    StorageBackupReservedSettingEvent,
-    StorageBackupReservedSettingSubscribeEvent,
-    StorageControlModeEvent,
-    StorageControlModeSubscribeEvent,
-    StorageDefaultModeEvent,
-    StorageDefaultModeSubscribeEvent,
+    StoredgeAcChargeLimitEvent,
+    StoredgeAcChargeLimitSubscribeEvent,
+    StoredgeAcChargePolicyEvent,
+    StoredgeAcChargePolicySubscribeEvent,
+    StoredgeBackupReservedSettingEvent,
+    StoredgeBackupReservedSettingSubscribeEvent,
+    StoredgeControlModeEvent,
+    StoredgeControlModeSubscribeEvent,
+    StoredgeDefaultModeEvent,
+    StoredgeDefaultModeSubscribeEvent,
+    StoredgeRemoteControlChargeLimitEvent,
+    StoredgeRemoteControlChargeLimitSubscribeEvent,
+    StoredgeRemoteControlCommandModeEvent,
+    StoredgeRemoteControlCommandModeSubscribeEvent,
+    StoredgeRemoteControlCommandTimeoutEvent,
+    StoredgeRemoteControlCommandTimeoutSubscribeEvent,
+    StoredgeRemoteControlDischargeLimitEvent,
+    StoredgeRemoteControlDischargeLimitSubscribeEvent,
 )
 from solaredge2mqtt.services.modbus.sunspec.inverter import (
     SunSpecStorEdgeControlRegister,
@@ -37,7 +38,6 @@ from solaredge2mqtt.services.modbus.sunspec.inverter import (
 if TYPE_CHECKING:
     from solaredge2mqtt.core.settings.models import ServiceSettings
 
-REMOTE_CONTROL_MODE = 4
 DEFAULT_UNIT_KEY = "leader"
 
 
@@ -50,8 +50,6 @@ class StorEdgeControl:
             if self.settings.has_followers
             else ModbusInverter.generate_topic_prefix()
         )
-        # The MQTT client prepends its own topic_prefix in _subscribe_topic,
-        # so this must stay relative (no service_settings.mqtt.topic_prefix here).
         self.topic_prefix = f"{inverter_topic}/storedge_control"
 
         self._last_known: dict[str, ModbusStorEdgeControl] = {}
@@ -63,47 +61,47 @@ class StorEdgeControl:
             return
 
         await EventBus.emit(
-            StorageControlModeSubscribeEvent(
+            StoredgeControlModeSubscribeEvent(
                 f"{self.topic_prefix}/storage_control_mode"
             )
         )
         await EventBus.emit(
-            StorageAcChargePolicySubscribeEvent(
+            StoredgeAcChargePolicySubscribeEvent(
                 f"{self.topic_prefix}/storage_ac_charge_policy"
             )
         )
         await EventBus.emit(
-            StorageAcChargeLimitSubscribeEvent(
+            StoredgeAcChargeLimitSubscribeEvent(
                 f"{self.topic_prefix}/storage_ac_charge_limit"
             )
         )
         await EventBus.emit(
-            StorageBackupReservedSettingSubscribeEvent(
+            StoredgeBackupReservedSettingSubscribeEvent(
                 f"{self.topic_prefix}/storage_backup_reserved_setting"
             )
         )
         await EventBus.emit(
-            StorageDefaultModeSubscribeEvent(
+            StoredgeDefaultModeSubscribeEvent(
                 f"{self.topic_prefix}/storage_default_mode"
             )
         )
         await EventBus.emit(
-            RemoteControlCommandTimeoutSubscribeEvent(
+            StoredgeRemoteControlCommandTimeoutSubscribeEvent(
                 f"{self.topic_prefix}/remote_control_command_timeout"
             )
         )
         await EventBus.emit(
-            RemoteControlCommandModeSubscribeEvent(
+            StoredgeRemoteControlCommandModeSubscribeEvent(
                 f"{self.topic_prefix}/remote_control_command_mode"
             )
         )
         await EventBus.emit(
-            RemoteControlChargeLimitSubscribeEvent(
+            StoredgeRemoteControlChargeLimitSubscribeEvent(
                 f"{self.topic_prefix}/remote_control_charge_limit"
             )
         )
         await EventBus.emit(
-            RemoteControlDischargeLimitSubscribeEvent(
+            StoredgeRemoteControlDischargeLimitSubscribeEvent(
                 f"{self.topic_prefix}/remote_control_discharge_limit"
             )
         )
@@ -180,8 +178,10 @@ class StorEdgeControl:
 
         await self._write(register, value, field_name, unit_key, force=force)
 
-    @EventBus.subscribe(StorageControlModeEvent)
-    async def handle_storage_control_mode(self, event: StorageControlModeEvent) -> None:
+    @EventBus.subscribe(StoredgeControlModeEvent)
+    async def handle_storage_control_mode(
+        self, event: StoredgeControlModeEvent
+    ) -> None:
         await self._write(
             SunSpecStorEdgeControlRegister.STORAGE_CONTROL_MODE,
             event.input.mode,
@@ -189,9 +189,9 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StorageAcChargePolicyEvent)
+    @EventBus.subscribe(StoredgeAcChargePolicyEvent)
     async def handle_storage_ac_charge_policy(
-        self, event: StorageAcChargePolicyEvent
+        self, event: StoredgeAcChargePolicyEvent
     ) -> None:
         await self._write(
             SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_POLICY,
@@ -200,9 +200,9 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StorageAcChargeLimitEvent)
+    @EventBus.subscribe(StoredgeAcChargeLimitEvent)
     async def handle_storage_ac_charge_limit(
-        self, event: StorageAcChargeLimitEvent
+        self, event: StoredgeAcChargeLimitEvent
     ) -> None:
         await self._write(
             SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_LIMIT,
@@ -211,9 +211,9 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StorageBackupReservedSettingEvent)
+    @EventBus.subscribe(StoredgeBackupReservedSettingEvent)
     async def handle_storage_backup_reserved_setting(
-        self, event: StorageBackupReservedSettingEvent
+        self, event: StoredgeBackupReservedSettingEvent
     ) -> None:
         await self._write(
             SunSpecStorEdgeControlRegister.STORAGE_BACKUP_RESERVED_SETTING,
@@ -222,8 +222,10 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StorageDefaultModeEvent)
-    async def handle_storage_default_mode(self, event: StorageDefaultModeEvent) -> None:
+    @EventBus.subscribe(StoredgeDefaultModeEvent)
+    async def handle_storage_default_mode(
+        self, event: StoredgeDefaultModeEvent
+    ) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.STORAGE_DEFAULT_MODE,
             event.input.mode,
@@ -231,9 +233,9 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(RemoteControlCommandTimeoutEvent)
+    @EventBus.subscribe(StoredgeRemoteControlCommandTimeoutEvent)
     async def handle_remote_control_command_timeout(
-        self, event: RemoteControlCommandTimeoutEvent
+        self, event: StoredgeRemoteControlCommandTimeoutEvent
     ) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_TIMEOUT,
@@ -242,9 +244,9 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(RemoteControlCommandModeEvent)
+    @EventBus.subscribe(StoredgeRemoteControlCommandModeEvent)
     async def handle_remote_control_command_mode(
-        self, event: RemoteControlCommandModeEvent
+        self, event: StoredgeRemoteControlCommandModeEvent
     ) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_MODE,
@@ -253,9 +255,9 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(RemoteControlChargeLimitEvent)
+    @EventBus.subscribe(StoredgeRemoteControlChargeLimitEvent)
     async def handle_remote_control_charge_limit(
-        self, event: RemoteControlChargeLimitEvent
+        self, event: StoredgeRemoteControlChargeLimitEvent
     ) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT,
@@ -264,9 +266,9 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(RemoteControlDischargeLimitEvent)
+    @EventBus.subscribe(StoredgeRemoteControlDischargeLimitEvent)
     async def handle_remote_control_discharge_limit(
-        self, event: RemoteControlDischargeLimitEvent
+        self, event: StoredgeRemoteControlDischargeLimitEvent
     ) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT,

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -130,8 +130,9 @@ class StorEdgeControl:
         value: int | float,
         field_name: str,
         unit_key: str = DEFAULT_UNIT_KEY,
+        force: bool = False,
     ) -> None:
-        if self._is_noop_write(field_name, value, unit_key):
+        if not force and self._is_noop_write(field_name, value, unit_key):
             logger.debug(
                 "Skipping StorEdge control {field}: {value} already active "
                 "on unit {unit_key}",
@@ -155,8 +156,9 @@ class StorEdgeControl:
         value: int | float,
         field_name: str,
         unit_key: str = DEFAULT_UNIT_KEY,
+        force: bool = False,
     ) -> None:
-        if self._is_noop_write(field_name, value, unit_key):
+        if not force and self._is_noop_write(field_name, value, unit_key):
             logger.debug(
                 "Skipping StorEdge control {field}: {value} already active "
                 "on unit {unit_key}",
@@ -176,7 +178,7 @@ class StorEdgeControl:
             )
             return
 
-        await self._write(register, value, field_name, unit_key)
+        await self._write(register, value, field_name, unit_key, force=force)
 
     @EventBus.subscribe(StorageControlModeEvent)
     async def handle_storage_control_mode(self, event: StorageControlModeEvent) -> None:
@@ -184,6 +186,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.STORAGE_CONTROL_MODE,
             event.input.mode,
             "storage_control_mode",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(StorageAcChargePolicyEvent)
@@ -194,6 +197,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_POLICY,
             event.input.policy,
             "storage_ac_charge_policy",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(StorageAcChargeLimitEvent)
@@ -204,6 +208,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_LIMIT,
             event.input.limit,
             "storage_ac_charge_limit",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(StorageBackupReservedSettingEvent)
@@ -214,6 +219,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.STORAGE_BACKUP_RESERVED_SETTING,
             event.input.percentage,
             "storage_backup_reserved_setting",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(StorageDefaultModeEvent)
@@ -222,6 +228,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.STORAGE_DEFAULT_MODE,
             event.input.mode,
             "storage_default_mode",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(RemoteControlCommandTimeoutEvent)
@@ -232,6 +239,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_TIMEOUT,
             event.input.seconds,
             "remote_control_command_timeout",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(RemoteControlCommandModeEvent)
@@ -242,6 +250,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_MODE,
             event.input.mode,
             "remote_control_command_mode",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(RemoteControlChargeLimitEvent)
@@ -252,6 +261,7 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT,
             event.input.limit,
             "remote_control_charge_limit",
+            force=event.input.force,
         )
 
     @EventBus.subscribe(RemoteControlDischargeLimitEvent)
@@ -262,4 +272,5 @@ class StorEdgeControl:
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT,
             event.input.limit,
             "remote_control_discharge_limit",
+            force=event.input.force,
         )

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from solaredge2mqtt.core.events import EventBus
+from solaredge2mqtt.core.logging import logger
+from solaredge2mqtt.services.modbus.events import ModbusUnitsReadEvent, ModbusWriteEvent
+from solaredge2mqtt.services.modbus.models.base import ModbusUnitRole
+from solaredge2mqtt.services.modbus.models.inverter import ModbusInverter
+from solaredge2mqtt.services.modbus.storedge_control_events import (
+    RemoteControlChargeLimitEvent,
+    RemoteControlChargeLimitSubscribeEvent,
+    RemoteControlCommandModeEvent,
+    RemoteControlCommandModeSubscribeEvent,
+    RemoteControlCommandTimeoutEvent,
+    RemoteControlCommandTimeoutSubscribeEvent,
+    RemoteControlDischargeLimitEvent,
+    RemoteControlDischargeLimitSubscribeEvent,
+    StorageAcChargeLimitEvent,
+    StorageAcChargeLimitSubscribeEvent,
+    StorageAcChargePolicyEvent,
+    StorageAcChargePolicySubscribeEvent,
+    StorageBackupReservedSettingEvent,
+    StorageBackupReservedSettingSubscribeEvent,
+    StorageControlModeEvent,
+    StorageControlModeSubscribeEvent,
+    StorageDefaultModeEvent,
+    StorageDefaultModeSubscribeEvent,
+)
+from solaredge2mqtt.services.modbus.sunspec.inverter import (
+    SunSpecStorEdgeControlRegister,
+)
+
+if TYPE_CHECKING:
+    from solaredge2mqtt.core.settings.models import ServiceSettings
+
+REMOTE_CONTROL_MODE = 4
+DEFAULT_UNIT_KEY = "leader"
+
+
+class StorEdgeControl:
+    def __init__(self, service_settings: ServiceSettings):
+        self.settings = service_settings.modbus
+
+        inverter_topic = (
+            ModbusInverter.generate_topic_prefix(str(ModbusUnitRole.LEADER))
+            if self.settings.has_followers
+            else ModbusInverter.generate_topic_prefix()
+        )
+        self.topic_prefix = (
+            f"{service_settings.mqtt.topic_prefix}/{inverter_topic}/storedge_control"
+        )
+
+        self._storage_control_mode: dict[str, int] = {}
+
+        EventBus.register(self)
+
+    async def async_init(self) -> None:
+        if not self.settings.storedge_control_enabled:
+            return
+
+        await EventBus.emit(
+            StorageControlModeSubscribeEvent(
+                f"{self.topic_prefix}/storage_control_mode"
+            )
+        )
+        await EventBus.emit(
+            StorageAcChargePolicySubscribeEvent(
+                f"{self.topic_prefix}/storage_ac_charge_policy"
+            )
+        )
+        await EventBus.emit(
+            StorageAcChargeLimitSubscribeEvent(
+                f"{self.topic_prefix}/storage_ac_charge_limit"
+            )
+        )
+        await EventBus.emit(
+            StorageBackupReservedSettingSubscribeEvent(
+                f"{self.topic_prefix}/storage_backup_reserved_setting"
+            )
+        )
+        await EventBus.emit(
+            StorageDefaultModeSubscribeEvent(
+                f"{self.topic_prefix}/storage_default_mode"
+            )
+        )
+        await EventBus.emit(
+            RemoteControlCommandTimeoutSubscribeEvent(
+                f"{self.topic_prefix}/remote_control_command_timeout"
+            )
+        )
+        await EventBus.emit(
+            RemoteControlCommandModeSubscribeEvent(
+                f"{self.topic_prefix}/remote_control_command_mode"
+            )
+        )
+        await EventBus.emit(
+            RemoteControlChargeLimitSubscribeEvent(
+                f"{self.topic_prefix}/remote_control_charge_limit"
+            )
+        )
+        await EventBus.emit(
+            RemoteControlDischargeLimitSubscribeEvent(
+                f"{self.topic_prefix}/remote_control_discharge_limit"
+            )
+        )
+
+    @EventBus.subscribe(ModbusUnitsReadEvent)
+    async def cache_storage_control_mode(self, event: ModbusUnitsReadEvent) -> None:
+        for unit_key, unit in event.units.items():
+            if unit.inverter.storedge_control is not None:
+                self._storage_control_mode[unit_key] = (
+                    unit.inverter.storedge_control.storage_control_mode
+                )
+
+    def _is_remote_control_active(self, unit_key: str = DEFAULT_UNIT_KEY) -> bool:
+        return self._storage_control_mode.get(unit_key) == REMOTE_CONTROL_MODE
+
+    async def _write(
+        self,
+        register: SunSpecStorEdgeControlRegister,
+        value: int | float,
+        field_name: str,
+        unit_key: str = DEFAULT_UNIT_KEY,
+    ) -> None:
+        logger.info(
+            "Writing StorEdge control {field}: {value} (unit {unit_key})",
+            field=field_name,
+            value=value,
+            unit_key=unit_key,
+        )
+        await EventBus.emit(ModbusWriteEvent(register, value, unit_key=unit_key))
+
+    async def _write_remote_control_gated(
+        self,
+        register: SunSpecStorEdgeControlRegister,
+        value: int | float,
+        field_name: str,
+        unit_key: str = DEFAULT_UNIT_KEY,
+    ) -> None:
+        if not self._is_remote_control_active(unit_key):
+            logger.error(
+                "Cannot write StorEdge control {field}: Storage Control Mode is not "
+                "set to Remote Control on unit {unit_key}. "
+                "Set storage_control_mode to 4 first.",
+                field=field_name,
+                unit_key=unit_key,
+            )
+            return
+
+        await self._write(register, value, field_name, unit_key)
+
+    @EventBus.subscribe(StorageControlModeEvent)
+    async def handle_storage_control_mode(self, event: StorageControlModeEvent) -> None:
+        await self._write(
+            SunSpecStorEdgeControlRegister.STORAGE_CONTROL_MODE,
+            event.input.mode,
+            "storage_control_mode",
+        )
+
+    @EventBus.subscribe(StorageAcChargePolicyEvent)
+    async def handle_storage_ac_charge_policy(
+        self, event: StorageAcChargePolicyEvent
+    ) -> None:
+        await self._write(
+            SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_POLICY,
+            event.input.policy,
+            "storage_ac_charge_policy",
+        )
+
+    @EventBus.subscribe(StorageAcChargeLimitEvent)
+    async def handle_storage_ac_charge_limit(
+        self, event: StorageAcChargeLimitEvent
+    ) -> None:
+        await self._write(
+            SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_LIMIT,
+            event.input.limit,
+            "storage_ac_charge_limit",
+        )
+
+    @EventBus.subscribe(StorageBackupReservedSettingEvent)
+    async def handle_storage_backup_reserved_setting(
+        self, event: StorageBackupReservedSettingEvent
+    ) -> None:
+        await self._write(
+            SunSpecStorEdgeControlRegister.STORAGE_BACKUP_RESERVED_SETTING,
+            event.input.percentage,
+            "storage_backup_reserved_setting",
+        )
+
+    @EventBus.subscribe(StorageDefaultModeEvent)
+    async def handle_storage_default_mode(self, event: StorageDefaultModeEvent) -> None:
+        await self._write_remote_control_gated(
+            SunSpecStorEdgeControlRegister.STORAGE_DEFAULT_MODE,
+            event.input.mode,
+            "storage_default_mode",
+        )
+
+    @EventBus.subscribe(RemoteControlCommandTimeoutEvent)
+    async def handle_remote_control_command_timeout(
+        self, event: RemoteControlCommandTimeoutEvent
+    ) -> None:
+        await self._write_remote_control_gated(
+            SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_TIMEOUT,
+            event.input.seconds,
+            "remote_control_command_timeout",
+        )
+
+    @EventBus.subscribe(RemoteControlCommandModeEvent)
+    async def handle_remote_control_command_mode(
+        self, event: RemoteControlCommandModeEvent
+    ) -> None:
+        await self._write_remote_control_gated(
+            SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_MODE,
+            event.input.mode,
+            "remote_control_command_mode",
+        )
+
+    @EventBus.subscribe(RemoteControlChargeLimitEvent)
+    async def handle_remote_control_charge_limit(
+        self, event: RemoteControlChargeLimitEvent
+    ) -> None:
+        await self._write_remote_control_gated(
+            SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT,
+            event.input.limit,
+            "remote_control_charge_limit",
+        )
+
+    @EventBus.subscribe(RemoteControlDischargeLimitEvent)
+    async def handle_remote_control_discharge_limit(
+        self, event: RemoteControlDischargeLimitEvent
+    ) -> None:
+        await self._write_remote_control_gated(
+            SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT,
+            event.input.limit,
+            "remote_control_discharge_limit",
+        )

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -61,29 +61,23 @@ class StorEdgeControl:
             return
 
         await EventBus.emit(
-            StoredgeControlModeSubscribeEvent(
-                f"{self.topic_prefix}/storage_control_mode"
-            )
+            StoredgeControlModeSubscribeEvent(f"{self.topic_prefix}/control_mode")
         )
         await EventBus.emit(
             StoredgeAcChargePolicySubscribeEvent(
-                f"{self.topic_prefix}/storage_ac_charge_policy"
+                f"{self.topic_prefix}/ac_charge_policy"
             )
         )
         await EventBus.emit(
-            StoredgeAcChargeLimitSubscribeEvent(
-                f"{self.topic_prefix}/storage_ac_charge_limit"
-            )
+            StoredgeAcChargeLimitSubscribeEvent(f"{self.topic_prefix}/ac_charge_limit")
         )
         await EventBus.emit(
             StoredgeBackupReservedSettingSubscribeEvent(
-                f"{self.topic_prefix}/storage_backup_reserved_setting"
+                f"{self.topic_prefix}/backup_reserved_setting"
             )
         )
         await EventBus.emit(
-            StoredgeDefaultModeSubscribeEvent(
-                f"{self.topic_prefix}/storage_default_mode"
-            )
+            StoredgeDefaultModeSubscribeEvent(f"{self.topic_prefix}/default_mode")
         )
         await EventBus.emit(
             StoredgeRemoteControlCommandTimeoutSubscribeEvent(

--- a/solaredge2mqtt/services/modbus/storedge_control.py
+++ b/solaredge2mqtt/services/modbus/storedge_control.py
@@ -18,18 +18,18 @@ from solaredge2mqtt.services.modbus.storedge_control_events import (
     StoredgeAcChargePolicySubscribeEvent,
     StoredgeBackupReservedSettingEvent,
     StoredgeBackupReservedSettingSubscribeEvent,
+    StoredgeChargeLimitEvent,
+    StoredgeChargeLimitSubscribeEvent,
+    StoredgeCommandModeEvent,
+    StoredgeCommandModeSubscribeEvent,
+    StoredgeCommandTimeoutEvent,
+    StoredgeCommandTimeoutSubscribeEvent,
     StoredgeControlModeEvent,
     StoredgeControlModeSubscribeEvent,
     StoredgeDefaultModeEvent,
     StoredgeDefaultModeSubscribeEvent,
-    StoredgeRemoteControlChargeLimitEvent,
-    StoredgeRemoteControlChargeLimitSubscribeEvent,
-    StoredgeRemoteControlCommandModeEvent,
-    StoredgeRemoteControlCommandModeSubscribeEvent,
-    StoredgeRemoteControlCommandTimeoutEvent,
-    StoredgeRemoteControlCommandTimeoutSubscribeEvent,
-    StoredgeRemoteControlDischargeLimitEvent,
-    StoredgeRemoteControlDischargeLimitSubscribeEvent,
+    StoredgeDischargeLimitEvent,
+    StoredgeDischargeLimitSubscribeEvent,
 )
 from solaredge2mqtt.services.modbus.sunspec.inverter import (
     SunSpecStorEdgeControlRegister,
@@ -80,24 +80,16 @@ class StorEdgeControl:
             StoredgeDefaultModeSubscribeEvent(f"{self.topic_prefix}/default_mode")
         )
         await EventBus.emit(
-            StoredgeRemoteControlCommandTimeoutSubscribeEvent(
-                f"{self.topic_prefix}/remote_control_command_timeout"
-            )
+            StoredgeCommandTimeoutSubscribeEvent(f"{self.topic_prefix}/command_timeout")
         )
         await EventBus.emit(
-            StoredgeRemoteControlCommandModeSubscribeEvent(
-                f"{self.topic_prefix}/remote_control_command_mode"
-            )
+            StoredgeCommandModeSubscribeEvent(f"{self.topic_prefix}/command_mode")
         )
         await EventBus.emit(
-            StoredgeRemoteControlChargeLimitSubscribeEvent(
-                f"{self.topic_prefix}/remote_control_charge_limit"
-            )
+            StoredgeChargeLimitSubscribeEvent(f"{self.topic_prefix}/charge_limit")
         )
         await EventBus.emit(
-            StoredgeRemoteControlDischargeLimitSubscribeEvent(
-                f"{self.topic_prefix}/remote_control_discharge_limit"
-            )
+            StoredgeDischargeLimitSubscribeEvent(f"{self.topic_prefix}/discharge_limit")
         )
 
     @EventBus.subscribe(ModbusUnitsReadEvent)
@@ -227,10 +219,8 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StoredgeRemoteControlCommandTimeoutEvent)
-    async def handle_remote_control_command_timeout(
-        self, event: StoredgeRemoteControlCommandTimeoutEvent
-    ) -> None:
+    @EventBus.subscribe(StoredgeCommandTimeoutEvent)
+    async def handle_command_timeout(self, event: StoredgeCommandTimeoutEvent) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_TIMEOUT,
             event.input.seconds,
@@ -238,10 +228,8 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StoredgeRemoteControlCommandModeEvent)
-    async def handle_remote_control_command_mode(
-        self, event: StoredgeRemoteControlCommandModeEvent
-    ) -> None:
+    @EventBus.subscribe(StoredgeCommandModeEvent)
+    async def handle_command_mode(self, event: StoredgeCommandModeEvent) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_MODE,
             event.input.mode,
@@ -249,10 +237,8 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StoredgeRemoteControlChargeLimitEvent)
-    async def handle_remote_control_charge_limit(
-        self, event: StoredgeRemoteControlChargeLimitEvent
-    ) -> None:
+    @EventBus.subscribe(StoredgeChargeLimitEvent)
+    async def handle_charge_limit(self, event: StoredgeChargeLimitEvent) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_CHARGE_LIMIT,
             event.input.limit,
@@ -260,10 +246,8 @@ class StorEdgeControl:
             force=event.input.force,
         )
 
-    @EventBus.subscribe(StoredgeRemoteControlDischargeLimitEvent)
-    async def handle_remote_control_discharge_limit(
-        self, event: StoredgeRemoteControlDischargeLimitEvent
-    ) -> None:
+    @EventBus.subscribe(StoredgeDischargeLimitEvent)
+    async def handle_discharge_limit(self, event: StoredgeDischargeLimitEvent) -> None:
         await self._write_remote_control_gated(
             SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT,
             event.input.limit,

--- a/solaredge2mqtt/services/modbus/storedge_control_events.py
+++ b/solaredge2mqtt/services/modbus/storedge_control_events.py
@@ -1,0 +1,102 @@
+from solaredge2mqtt.core.mqtt.events import MQTTReceivedEvent, MQTTSubscribeEvent
+from solaredge2mqtt.services.modbus.storedge_control_inputs import (
+    RemoteControlChargeLimitInput,
+    RemoteControlCommandModeInput,
+    RemoteControlCommandTimeoutInput,
+    RemoteControlDischargeLimitInput,
+    StorageAcChargeLimitInput,
+    StorageAcChargePolicyInput,
+    StorageBackupReservedSettingInput,
+    StorageControlModeInput,
+    StorageDefaultModeInput,
+)
+
+
+class StorageControlModeEvent(
+    MQTTReceivedEvent[StorageControlModeInput]
+): ...  # pragma: no cover
+
+
+class StorageControlModeSubscribeEvent(
+    MQTTSubscribeEvent[StorageControlModeEvent]
+): ...  # pragma: no cover
+
+
+class StorageAcChargePolicyEvent(
+    MQTTReceivedEvent[StorageAcChargePolicyInput]
+): ...  # pragma: no cover
+
+
+class StorageAcChargePolicySubscribeEvent(
+    MQTTSubscribeEvent[StorageAcChargePolicyEvent]
+): ...  # pragma: no cover
+
+
+class StorageAcChargeLimitEvent(
+    MQTTReceivedEvent[StorageAcChargeLimitInput]
+): ...  # pragma: no cover
+
+
+class StorageAcChargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[StorageAcChargeLimitEvent]
+): ...  # pragma: no cover
+
+
+class StorageBackupReservedSettingEvent(
+    MQTTReceivedEvent[StorageBackupReservedSettingInput]
+): ...  # pragma: no cover
+
+
+class StorageBackupReservedSettingSubscribeEvent(
+    MQTTSubscribeEvent[StorageBackupReservedSettingEvent]
+): ...  # pragma: no cover
+
+
+class StorageDefaultModeEvent(
+    MQTTReceivedEvent[StorageDefaultModeInput]
+): ...  # pragma: no cover
+
+
+class StorageDefaultModeSubscribeEvent(
+    MQTTSubscribeEvent[StorageDefaultModeEvent]
+): ...  # pragma: no cover
+
+
+class RemoteControlCommandTimeoutEvent(
+    MQTTReceivedEvent[RemoteControlCommandTimeoutInput]
+): ...  # pragma: no cover
+
+
+class RemoteControlCommandTimeoutSubscribeEvent(
+    MQTTSubscribeEvent[RemoteControlCommandTimeoutEvent]
+): ...  # pragma: no cover
+
+
+class RemoteControlCommandModeEvent(
+    MQTTReceivedEvent[RemoteControlCommandModeInput]
+): ...  # pragma: no cover
+
+
+class RemoteControlCommandModeSubscribeEvent(
+    MQTTSubscribeEvent[RemoteControlCommandModeEvent]
+): ...  # pragma: no cover
+
+
+class RemoteControlChargeLimitEvent(
+    MQTTReceivedEvent[RemoteControlChargeLimitInput]
+): ...  # pragma: no cover
+
+
+class RemoteControlChargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[RemoteControlChargeLimitEvent]
+): ...  # pragma: no cover
+
+
+class RemoteControlDischargeLimitEvent(
+    MQTTReceivedEvent[RemoteControlDischargeLimitInput]
+): ...  # pragma: no cover
+
+
+class RemoteControlDischargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[RemoteControlDischargeLimitEvent]
+): ...  # pragma: no cover

--- a/solaredge2mqtt/services/modbus/storedge_control_events.py
+++ b/solaredge2mqtt/services/modbus/storedge_control_events.py
@@ -1,102 +1,102 @@
 from solaredge2mqtt.core.mqtt.events import MQTTReceivedEvent, MQTTSubscribeEvent
 from solaredge2mqtt.services.modbus.storedge_control_inputs import (
-    RemoteControlChargeLimitInput,
-    RemoteControlCommandModeInput,
-    RemoteControlCommandTimeoutInput,
-    RemoteControlDischargeLimitInput,
-    StorageAcChargeLimitInput,
-    StorageAcChargePolicyInput,
-    StorageBackupReservedSettingInput,
-    StorageControlModeInput,
-    StorageDefaultModeInput,
+    StoredgeAcChargeLimitInput,
+    StoredgeAcChargePolicyInput,
+    StoredgeBackupReservedSettingInput,
+    StoredgeControlModeInput,
+    StoredgeDefaultModeInput,
+    StoredgeRemoteControlChargeLimitInput,
+    StoredgeRemoteControlCommandModeInput,
+    StoredgeRemoteControlCommandTimeoutInput,
+    StoredgeRemoteControlDischargeLimitInput,
 )
 
 
-class StorageControlModeEvent(
-    MQTTReceivedEvent[StorageControlModeInput]
+class StoredgeControlModeEvent(
+    MQTTReceivedEvent[StoredgeControlModeInput]
 ): ...  # pragma: no cover
 
 
-class StorageControlModeSubscribeEvent(
-    MQTTSubscribeEvent[StorageControlModeEvent]
+class StoredgeControlModeSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeControlModeEvent]
 ): ...  # pragma: no cover
 
 
-class StorageAcChargePolicyEvent(
-    MQTTReceivedEvent[StorageAcChargePolicyInput]
+class StoredgeAcChargePolicyEvent(
+    MQTTReceivedEvent[StoredgeAcChargePolicyInput]
 ): ...  # pragma: no cover
 
 
-class StorageAcChargePolicySubscribeEvent(
-    MQTTSubscribeEvent[StorageAcChargePolicyEvent]
+class StoredgeAcChargePolicySubscribeEvent(
+    MQTTSubscribeEvent[StoredgeAcChargePolicyEvent]
 ): ...  # pragma: no cover
 
 
-class StorageAcChargeLimitEvent(
-    MQTTReceivedEvent[StorageAcChargeLimitInput]
+class StoredgeAcChargeLimitEvent(
+    MQTTReceivedEvent[StoredgeAcChargeLimitInput]
 ): ...  # pragma: no cover
 
 
-class StorageAcChargeLimitSubscribeEvent(
-    MQTTSubscribeEvent[StorageAcChargeLimitEvent]
+class StoredgeAcChargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeAcChargeLimitEvent]
 ): ...  # pragma: no cover
 
 
-class StorageBackupReservedSettingEvent(
-    MQTTReceivedEvent[StorageBackupReservedSettingInput]
+class StoredgeBackupReservedSettingEvent(
+    MQTTReceivedEvent[StoredgeBackupReservedSettingInput]
 ): ...  # pragma: no cover
 
 
-class StorageBackupReservedSettingSubscribeEvent(
-    MQTTSubscribeEvent[StorageBackupReservedSettingEvent]
+class StoredgeBackupReservedSettingSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeBackupReservedSettingEvent]
 ): ...  # pragma: no cover
 
 
-class StorageDefaultModeEvent(
-    MQTTReceivedEvent[StorageDefaultModeInput]
+class StoredgeDefaultModeEvent(
+    MQTTReceivedEvent[StoredgeDefaultModeInput]
 ): ...  # pragma: no cover
 
 
-class StorageDefaultModeSubscribeEvent(
-    MQTTSubscribeEvent[StorageDefaultModeEvent]
+class StoredgeDefaultModeSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeDefaultModeEvent]
 ): ...  # pragma: no cover
 
 
-class RemoteControlCommandTimeoutEvent(
-    MQTTReceivedEvent[RemoteControlCommandTimeoutInput]
+class StoredgeRemoteControlCommandTimeoutEvent(
+    MQTTReceivedEvent[StoredgeRemoteControlCommandTimeoutInput]
 ): ...  # pragma: no cover
 
 
-class RemoteControlCommandTimeoutSubscribeEvent(
-    MQTTSubscribeEvent[RemoteControlCommandTimeoutEvent]
+class StoredgeRemoteControlCommandTimeoutSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeRemoteControlCommandTimeoutEvent]
 ): ...  # pragma: no cover
 
 
-class RemoteControlCommandModeEvent(
-    MQTTReceivedEvent[RemoteControlCommandModeInput]
+class StoredgeRemoteControlCommandModeEvent(
+    MQTTReceivedEvent[StoredgeRemoteControlCommandModeInput]
 ): ...  # pragma: no cover
 
 
-class RemoteControlCommandModeSubscribeEvent(
-    MQTTSubscribeEvent[RemoteControlCommandModeEvent]
+class StoredgeRemoteControlCommandModeSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeRemoteControlCommandModeEvent]
 ): ...  # pragma: no cover
 
 
-class RemoteControlChargeLimitEvent(
-    MQTTReceivedEvent[RemoteControlChargeLimitInput]
+class StoredgeRemoteControlChargeLimitEvent(
+    MQTTReceivedEvent[StoredgeRemoteControlChargeLimitInput]
 ): ...  # pragma: no cover
 
 
-class RemoteControlChargeLimitSubscribeEvent(
-    MQTTSubscribeEvent[RemoteControlChargeLimitEvent]
+class StoredgeRemoteControlChargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeRemoteControlChargeLimitEvent]
 ): ...  # pragma: no cover
 
 
-class RemoteControlDischargeLimitEvent(
-    MQTTReceivedEvent[RemoteControlDischargeLimitInput]
+class StoredgeRemoteControlDischargeLimitEvent(
+    MQTTReceivedEvent[StoredgeRemoteControlDischargeLimitInput]
 ): ...  # pragma: no cover
 
 
-class RemoteControlDischargeLimitSubscribeEvent(
-    MQTTSubscribeEvent[RemoteControlDischargeLimitEvent]
+class StoredgeRemoteControlDischargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeRemoteControlDischargeLimitEvent]
 ): ...  # pragma: no cover

--- a/solaredge2mqtt/services/modbus/storedge_control_events.py
+++ b/solaredge2mqtt/services/modbus/storedge_control_events.py
@@ -3,12 +3,12 @@ from solaredge2mqtt.services.modbus.storedge_control_inputs import (
     StoredgeAcChargeLimitInput,
     StoredgeAcChargePolicyInput,
     StoredgeBackupReservedSettingInput,
+    StoredgeChargeLimitInput,
+    StoredgeCommandModeInput,
+    StoredgeCommandTimeoutInput,
     StoredgeControlModeInput,
     StoredgeDefaultModeInput,
-    StoredgeRemoteControlChargeLimitInput,
-    StoredgeRemoteControlCommandModeInput,
-    StoredgeRemoteControlCommandTimeoutInput,
-    StoredgeRemoteControlDischargeLimitInput,
+    StoredgeDischargeLimitInput,
 )
 
 
@@ -62,41 +62,41 @@ class StoredgeDefaultModeSubscribeEvent(
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlCommandTimeoutEvent(
-    MQTTReceivedEvent[StoredgeRemoteControlCommandTimeoutInput]
+class StoredgeCommandTimeoutEvent(
+    MQTTReceivedEvent[StoredgeCommandTimeoutInput]
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlCommandTimeoutSubscribeEvent(
-    MQTTSubscribeEvent[StoredgeRemoteControlCommandTimeoutEvent]
+class StoredgeCommandTimeoutSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeCommandTimeoutEvent]
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlCommandModeEvent(
-    MQTTReceivedEvent[StoredgeRemoteControlCommandModeInput]
+class StoredgeCommandModeEvent(
+    MQTTReceivedEvent[StoredgeCommandModeInput]
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlCommandModeSubscribeEvent(
-    MQTTSubscribeEvent[StoredgeRemoteControlCommandModeEvent]
+class StoredgeCommandModeSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeCommandModeEvent]
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlChargeLimitEvent(
-    MQTTReceivedEvent[StoredgeRemoteControlChargeLimitInput]
+class StoredgeChargeLimitEvent(
+    MQTTReceivedEvent[StoredgeChargeLimitInput]
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlChargeLimitSubscribeEvent(
-    MQTTSubscribeEvent[StoredgeRemoteControlChargeLimitEvent]
+class StoredgeChargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeChargeLimitEvent]
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlDischargeLimitEvent(
-    MQTTReceivedEvent[StoredgeRemoteControlDischargeLimitInput]
+class StoredgeDischargeLimitEvent(
+    MQTTReceivedEvent[StoredgeDischargeLimitInput]
 ): ...  # pragma: no cover
 
 
-class StoredgeRemoteControlDischargeLimitSubscribeEvent(
-    MQTTSubscribeEvent[StoredgeRemoteControlDischargeLimitEvent]
+class StoredgeDischargeLimitSubscribeEvent(
+    MQTTSubscribeEvent[StoredgeDischargeLimitEvent]
 ): ...  # pragma: no cover

--- a/solaredge2mqtt/services/modbus/storedge_control_inputs.py
+++ b/solaredge2mqtt/services/modbus/storedge_control_inputs.py
@@ -42,17 +42,17 @@ class StoredgeDefaultModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=7)
 
 
-class StoredgeRemoteControlCommandTimeoutInput(ForceableScalarInput):
+class StoredgeCommandTimeoutInput(ForceableScalarInput):
     seconds: int = Field(ge=0, le=86400)
 
 
-class StoredgeRemoteControlCommandModeInput(ForceableScalarInput):
+class StoredgeCommandModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=7)
 
 
-class StoredgeRemoteControlChargeLimitInput(ForceableScalarInput):
+class StoredgeChargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)
 
 
-class StoredgeRemoteControlDischargeLimitInput(ForceableScalarInput):
+class StoredgeDischargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)

--- a/solaredge2mqtt/services/modbus/storedge_control_inputs.py
+++ b/solaredge2mqtt/services/modbus/storedge_control_inputs.py
@@ -22,37 +22,37 @@ class ForceableScalarInput(BaseInputScalarField):
         return {value_field: scalar}
 
 
-class StorageControlModeInput(ForceableScalarInput):
+class StoredgeControlModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=4)
 
 
-class StorageAcChargePolicyInput(ForceableScalarInput):
+class StoredgeAcChargePolicyInput(ForceableScalarInput):
     policy: int = Field(ge=0, le=3)
 
 
-class StorageAcChargeLimitInput(ForceableScalarInput):
+class StoredgeAcChargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)
 
 
-class StorageBackupReservedSettingInput(ForceableScalarInput):
+class StoredgeBackupReservedSettingInput(ForceableScalarInput):
     percentage: float = Field(ge=0, le=100)
 
 
-class StorageDefaultModeInput(ForceableScalarInput):
+class StoredgeDefaultModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=7)
 
 
-class RemoteControlCommandTimeoutInput(ForceableScalarInput):
+class StoredgeRemoteControlCommandTimeoutInput(ForceableScalarInput):
     seconds: int = Field(ge=0, le=86400)
 
 
-class RemoteControlCommandModeInput(ForceableScalarInput):
+class StoredgeRemoteControlCommandModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=7)
 
 
-class RemoteControlChargeLimitInput(ForceableScalarInput):
+class StoredgeRemoteControlChargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)
 
 
-class RemoteControlDischargeLimitInput(ForceableScalarInput):
+class StoredgeRemoteControlDischargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)

--- a/solaredge2mqtt/services/modbus/storedge_control_inputs.py
+++ b/solaredge2mqtt/services/modbus/storedge_control_inputs.py
@@ -1,39 +1,58 @@
+from typing import Any
+
 from pydantic import Field
 
 from solaredge2mqtt.core.models import BaseInputScalarField
 
 
-class StorageControlModeInput(BaseInputScalarField):
+class ForceableScalarInput(BaseInputScalarField):
+    """A scalar input with an optional force flag.
+
+    A bare scalar payload (e.g. publishing plain `4`) still maps to the
+    single value field, defaulting force to False. Publishing a JSON object
+    can additionally set `"force": true` to bypass no-op write skipping,
+    e.g. because the cached last-known value may be stale.
+    """
+
+    force: bool = Field(default=False)
+
+    @classmethod
+    def _wrap_scalar(cls, scalar: Any) -> dict[str, Any]:
+        value_field = next(name for name in cls.model_fields if name != "force")
+        return {value_field: scalar}
+
+
+class StorageControlModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=4)
 
 
-class StorageAcChargePolicyInput(BaseInputScalarField):
+class StorageAcChargePolicyInput(ForceableScalarInput):
     policy: int = Field(ge=0, le=3)
 
 
-class StorageAcChargeLimitInput(BaseInputScalarField):
+class StorageAcChargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)
 
 
-class StorageBackupReservedSettingInput(BaseInputScalarField):
+class StorageBackupReservedSettingInput(ForceableScalarInput):
     percentage: float = Field(ge=0, le=100)
 
 
-class StorageDefaultModeInput(BaseInputScalarField):
+class StorageDefaultModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=7)
 
 
-class RemoteControlCommandTimeoutInput(BaseInputScalarField):
+class RemoteControlCommandTimeoutInput(ForceableScalarInput):
     seconds: int = Field(ge=0, le=86400)
 
 
-class RemoteControlCommandModeInput(BaseInputScalarField):
+class RemoteControlCommandModeInput(ForceableScalarInput):
     mode: int = Field(ge=0, le=7)
 
 
-class RemoteControlChargeLimitInput(BaseInputScalarField):
+class RemoteControlChargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)
 
 
-class RemoteControlDischargeLimitInput(BaseInputScalarField):
+class RemoteControlDischargeLimitInput(ForceableScalarInput):
     limit: float = Field(ge=0)

--- a/solaredge2mqtt/services/modbus/storedge_control_inputs.py
+++ b/solaredge2mqtt/services/modbus/storedge_control_inputs.py
@@ -1,0 +1,39 @@
+from pydantic import Field
+
+from solaredge2mqtt.core.models import BaseInputScalarField
+
+
+class StorageControlModeInput(BaseInputScalarField):
+    mode: int = Field(ge=0, le=4)
+
+
+class StorageAcChargePolicyInput(BaseInputScalarField):
+    policy: int = Field(ge=0, le=3)
+
+
+class StorageAcChargeLimitInput(BaseInputScalarField):
+    limit: float = Field(ge=0)
+
+
+class StorageBackupReservedSettingInput(BaseInputScalarField):
+    percentage: float = Field(ge=0, le=100)
+
+
+class StorageDefaultModeInput(BaseInputScalarField):
+    mode: int = Field(ge=0, le=7)
+
+
+class RemoteControlCommandTimeoutInput(BaseInputScalarField):
+    seconds: int = Field(ge=0, le=86400)
+
+
+class RemoteControlCommandModeInput(BaseInputScalarField):
+    mode: int = Field(ge=0, le=7)
+
+
+class RemoteControlChargeLimitInput(BaseInputScalarField):
+    limit: float = Field(ge=0)
+
+
+class RemoteControlDischargeLimitInput(BaseInputScalarField):
+    limit: float = Field(ge=0)

--- a/solaredge2mqtt/services/powerflow/__init__.py
+++ b/solaredge2mqtt/services/powerflow/__init__.py
@@ -10,6 +10,7 @@ from solaredge2mqtt.core.mqtt.events import MQTTPublishEvent
 from solaredge2mqtt.core.timer.events import IntervalBaseTriggerEvent
 from solaredge2mqtt.services.modbus import Modbus
 from solaredge2mqtt.services.modbus.models.battery import ModbusBattery
+from solaredge2mqtt.services.modbus.storedge_control import StorEdgeControl
 from solaredge2mqtt.services.powerflow.events import PowerflowGeneratedEvent
 from solaredge2mqtt.services.powerflow.models import Powerflow
 from solaredge2mqtt.services.wallbox import WallboxClient
@@ -30,6 +31,7 @@ class PowerflowService:
         self.influxdb = influxdb
 
         self.modbus = Modbus(self.settings)
+        self.storedge_control = StorEdgeControl(self.settings)
 
         self.wallbox = (
             WallboxClient(self.settings.wallbox)
@@ -41,6 +43,7 @@ class PowerflowService:
 
     async def async_init(self) -> None:
         await self.modbus.async_init()
+        await self.storedge_control.async_init()
 
     @EventBus.subscribe(IntervalBaseTriggerEvent)
     async def calculate_powerflow(

--- a/tests/services/modbus/test_service.py
+++ b/tests/services/modbus/test_service.py
@@ -135,6 +135,7 @@ class TestModbusAsyncInit:
         """detect_devices should read inverter info and run detectors."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus.read_device_info = AsyncMock(return_value={"meter0": 1})
         modbus._detect_meters = AsyncMock()
         modbus._detect_batteries = AsyncMock()
@@ -152,6 +153,7 @@ class TestModbusAsyncInit:
         """get_data should set offline and re-raise on exception."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._device_info = {"leader": {"inverter": MagicMock()}}
         modbus._get_raw_data = AsyncMock(
             side_effect=InvalidDataException("Invalid data")
@@ -167,6 +169,7 @@ class TestModbusAsyncInit:
         """async_init should set offline state and re-raise on exception."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus.detect_devices = AsyncMock(
             side_effect=InvalidDataException("Invalid data")
         )
@@ -181,6 +184,7 @@ class TestModbusAsyncInit:
         """detect_devices should set offline state and re-raise on exception."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus.read_device_info = AsyncMock(
             side_effect=InvalidDataException("Invalid data")
         )
@@ -218,6 +222,7 @@ class TestModbusAsyncInit:
 
         mock_info = MagicMock()
         modbus._clients = {"leader": AsyncMock()}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         with patch(
             "solaredge2mqtt.services.modbus.ModbusDeviceInfo.from_sunspec",
             return_value=mock_info,
@@ -400,6 +405,7 @@ class TestModbusAsyncInitFollowerWithOwnIp:
         assert "leader" in modbus._clients
         assert "follower0" in modbus._clients
         assert modbus._clients["leader"] is not modbus._clients["follower0"]
+        assert modbus._client_locks["leader"] is not modbus._client_locks["follower0"]
 
     @pytest.mark.asyncio
     async def test_async_init_follower_without_host_reuses_leader_client(
@@ -425,6 +431,7 @@ class TestModbusAsyncInitFollowerWithOwnIp:
 
         assert client_cls.call_count == 1
         assert modbus._clients["leader"] is modbus._clients["follower0"]
+        assert modbus._client_locks["leader"] is modbus._client_locks["follower0"]
 
     @pytest.mark.asyncio
     async def test_async_init_follower_uses_custom_port(self, mock_event_bus):
@@ -564,6 +571,7 @@ class TestModbusReadFromModbus:
         """Test successful modbus read."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
 
         mock_bundle = MagicMock()
         mock_bundle.address = 40000
@@ -587,6 +595,7 @@ class TestModbusReadFromModbus:
         """Successful read should also work when service is already initialized."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = True
 
         mock_bundle = MagicMock()
@@ -610,6 +619,7 @@ class TestModbusReadFromModbus:
         """Test modbus read error blocks register."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = False
 
         mock_bundle = MagicMock()
@@ -631,6 +641,7 @@ class TestModbusReadFromModbus:
         """Test modbus exception blocks register."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = False
 
         mock_bundle = MagicMock()
@@ -652,6 +663,7 @@ class TestModbusReadFromModbus:
         """Test modbus read skips blocked registers."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._block_unreadable = {40000}
 
         mock_bundle = MagicMock()
@@ -669,6 +681,7 @@ class TestModbusReadFromModbus:
         """Repeated failures for the same register are debounced to DEBUG."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = True
 
         mock_bundle = MagicMock()
@@ -698,6 +711,7 @@ class TestModbusReadFromModbus:
         """A sustained failure re-escalates to ERROR every repeat threshold."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = True
         modbus._unreadable_streaks[40071] = 59
 
@@ -722,6 +736,7 @@ class TestModbusReadFromModbus:
         """A successful read after failures clears the streak and logs once."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = True
         modbus._unreadable_streaks[40071] = 5
 
@@ -748,6 +763,7 @@ class TestModbusReadFromModbus:
         """A single isolated failure followed by success doesn't log a recovery."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = True
         modbus._unreadable_streaks[40071] = 1
 
@@ -775,6 +791,7 @@ class TestModbusReadFromModbus:
         modbus = Modbus(mock_service_settings)
         stored_client = AsyncMock()
         modbus._clients = {"leader": stored_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
 
         mock_bundle = MagicMock()
         mock_bundle.address = 40000
@@ -804,6 +821,7 @@ class TestModbusGetData:
         """Test get_data returns units."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = True
 
         mock_info = MagicMock()
@@ -844,6 +862,7 @@ class TestModbusGetData:
         """Test get_data raises on KeyError."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
         modbus._initialized = True
         modbus._device_info = {}
 
@@ -929,6 +948,7 @@ class TestModbusWriteToModbus:
         """Test successful modbus write to leader."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
 
         mock_register = MagicMock()
         mock_register.address = 40000
@@ -957,6 +977,7 @@ class TestModbusWriteToModbus:
 
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client, "follower0": follower_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
 
         mock_register = MagicMock()
         mock_register.address = 40000
@@ -973,9 +994,10 @@ class TestModbusWriteToModbus:
     async def test_write_to_modbus_exception(
         self, mock_service_settings, mock_event_bus, mock_modbus_client
     ):
-        """Test modbus write handles exception."""
+        """Test modbus write retries and gives up after exhausting attempts."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
 
         mock_register = MagicMock()
         mock_register.address = 40000
@@ -984,7 +1006,41 @@ class TestModbusWriteToModbus:
 
         mock_modbus_client.write_registers.side_effect = ModbusException("Write error")
 
-        await modbus._write_to_modbus(mock_register, 100)
+        with patch(
+            "solaredge2mqtt.services.modbus.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await modbus._write_to_modbus(mock_register, 100)
+
+        assert (
+            mock_modbus_client.write_registers.call_count == Modbus.WRITE_RETRY_ATTEMPTS
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_to_modbus_retries_then_succeeds(
+        self, mock_service_settings, mock_event_bus, mock_modbus_client
+    ):
+        """Test a transient failure on the first attempt is retried and succeeds."""
+        modbus = Modbus(mock_service_settings)
+        modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
+
+        mock_register = MagicMock()
+        mock_register.address = 40000
+        mock_register.name = "test_register"
+        mock_register.encode_request.return_value = [1, 2, 3]
+
+        mock_modbus_client.write_registers.side_effect = [
+            ModbusException("Transient error"),
+            None,
+        ]
+
+        with patch(
+            "solaredge2mqtt.services.modbus.asyncio.sleep", new_callable=AsyncMock
+        ) as sleep_mock:
+            await modbus._write_to_modbus(mock_register, 100)
+
+        assert mock_modbus_client.write_registers.call_count == 2
+        sleep_mock.assert_called_once_with(Modbus.WRITE_RETRY_DELAY)
 
     @pytest.mark.asyncio
     async def test_write_to_modbus_unknown_unit_key(
@@ -993,6 +1049,7 @@ class TestModbusWriteToModbus:
         """Test _write_to_modbus raises InvalidDataException for unknown unit_key."""
         modbus = Modbus(mock_service_settings)
         modbus._clients = {"leader": mock_modbus_client}
+        modbus._client_locks = {key: asyncio.Lock() for key in modbus._clients}
 
         mock_register = MagicMock()
         mock_register.address = 40000
@@ -1036,3 +1093,57 @@ class TestModbusHandleWriteEvent:
         await modbus._handle_write_event(event)
 
         modbus._write_to_modbus.assert_called_once_with(mock_register, 50, "follower0")
+
+
+class TestModbusClientLockSerializesAccess:
+    """Regression tests for the per-unit client lock."""
+
+    @pytest.mark.asyncio
+    async def test_read_and_write_never_hold_client_concurrently(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """A concurrent read cycle and write must never overlap on the client."""
+        active = 0
+        max_active = 0
+
+        class TrackingClient:
+            async def __aenter__(self):
+                nonlocal active, max_active
+                active += 1
+                max_active = max(max_active, active)
+                await asyncio.sleep(0.02)
+                return self
+
+            async def __aexit__(self, *exc_info):
+                nonlocal active
+                active -= 1
+
+            async def write_registers(self, *args, **kwargs):
+                await asyncio.sleep(0.02)
+
+        modbus = Modbus(mock_service_settings)
+        modbus._clients = {"leader": TrackingClient()}  # pyright: ignore[reportAttributeAccessIssue]
+        modbus._client_locks = {"leader": asyncio.Lock()}
+        modbus._device_info = {"leader": {"inverter": MagicMock()}}
+
+        async def fake_get_raw_data(*args, **kwargs):
+            await asyncio.sleep(0.02)
+            return {}, {}, {}
+
+        modbus._get_raw_data = fake_get_raw_data
+        modbus._map_inverter = MagicMock(return_value=MagicMock())
+        modbus._map_meters = MagicMock(return_value={})
+        modbus._map_batteries = MagicMock(return_value={})
+
+        mock_register = MagicMock()
+        mock_register.address = 40000
+        mock_register.name = "test_register"
+        mock_register.encode_request.return_value = [1, 2, 3]
+
+        with patch("solaredge2mqtt.services.modbus.ModbusUnit"):
+            await asyncio.gather(
+                modbus.get_data(),
+                modbus._write_to_modbus(mock_register, 100),
+            )
+
+        assert max_active == 1

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -105,11 +105,11 @@ class TestStorEdgeControlAsyncInit:
         topics = {event.topic for event in emitted}
 
         assert topics == {
-            "modbus/inverter/storedge_control/storage_control_mode",
-            "modbus/inverter/storedge_control/storage_ac_charge_policy",
-            "modbus/inverter/storedge_control/storage_ac_charge_limit",
-            "modbus/inverter/storedge_control/storage_backup_reserved_setting",
-            "modbus/inverter/storedge_control/storage_default_mode",
+            "modbus/inverter/storedge_control/control_mode",
+            "modbus/inverter/storedge_control/ac_charge_policy",
+            "modbus/inverter/storedge_control/ac_charge_limit",
+            "modbus/inverter/storedge_control/backup_reserved_setting",
+            "modbus/inverter/storedge_control/default_mode",
             "modbus/inverter/storedge_control/remote_control_command_timeout",
             "modbus/inverter/storedge_control/remote_control_command_mode",
             "modbus/inverter/storedge_control/remote_control_charge_limit",
@@ -179,7 +179,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/storage_control_mode",
+            topic="modbus/inverter/storedge_control/control_mode",
             input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
@@ -198,7 +198,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeAcChargePolicyEvent(
-            topic="modbus/inverter/storedge_control/storage_ac_charge_policy",
+            topic="modbus/inverter/storedge_control/ac_charge_policy",
             input=StoredgeAcChargePolicyInput(policy=1),
         )
         await control.handle_storage_ac_charge_policy(event)
@@ -217,7 +217,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeAcChargeLimitEvent(
-            topic="modbus/inverter/storedge_control/storage_ac_charge_limit",
+            topic="modbus/inverter/storedge_control/ac_charge_limit",
             input=StoredgeAcChargeLimitInput(limit=2500.0),
         )
         await control.handle_storage_ac_charge_limit(event)
@@ -236,7 +236,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeBackupReservedSettingEvent(
-            topic=("modbus/inverter/storedge_control/storage_backup_reserved_setting"),
+            topic=("modbus/inverter/storedge_control/backup_reserved_setting"),
             input=StoredgeBackupReservedSettingInput(percentage=10.0),
         )
         await control.handle_storage_backup_reserved_setting(event)
@@ -260,7 +260,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/default_mode",
             input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -276,7 +276,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._last_known["leader"] = make_last_known()
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/default_mode",
             input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -380,7 +380,7 @@ class TestStorEdgeControlNoopWrites:
         control._last_known["leader"] = make_last_known(storage_control_mode=4)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/storage_control_mode",
+            topic="modbus/inverter/storedge_control/control_mode",
             input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
@@ -396,7 +396,7 @@ class TestStorEdgeControlNoopWrites:
         control._last_known["leader"] = make_last_known(storage_control_mode=1)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/storage_control_mode",
+            topic="modbus/inverter/storedge_control/control_mode",
             input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
@@ -414,7 +414,7 @@ class TestStorEdgeControlNoopWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/default_mode",
             input=StoredgeDefaultModeInput(mode=6),
         )
         await control.handle_storage_default_mode(event)
@@ -432,7 +432,7 @@ class TestStorEdgeControlNoopWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/default_mode",
             input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -452,7 +452,7 @@ class TestStorEdgeControlForceWrites:
         control._last_known["leader"] = make_last_known(storage_control_mode=4)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/storage_control_mode",
+            topic="modbus/inverter/storedge_control/control_mode",
             input=StoredgeControlModeInput(mode=4, force=True),
         )
         await control.handle_storage_control_mode(event)
@@ -472,7 +472,7 @@ class TestStorEdgeControlForceWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/default_mode",
             input=StoredgeDefaultModeInput(mode=6, force=True),
         )
         await control.handle_storage_default_mode(event)
@@ -492,7 +492,7 @@ class TestStorEdgeControlForceWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/default_mode",
             input=StoredgeDefaultModeInput(mode=6, force=True),
         )
         await control.handle_storage_default_mode(event)

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -1,0 +1,427 @@
+"""Tests for the storedge_control module."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from solaredge2mqtt.services.modbus.storedge_control import StorEdgeControl
+from solaredge2mqtt.services.modbus.storedge_control_events import (
+    RemoteControlChargeLimitEvent,
+    RemoteControlCommandModeEvent,
+    RemoteControlCommandTimeoutEvent,
+    RemoteControlDischargeLimitEvent,
+    StorageAcChargeLimitEvent,
+    StorageAcChargePolicyEvent,
+    StorageBackupReservedSettingEvent,
+    StorageControlModeEvent,
+    StorageDefaultModeEvent,
+)
+from solaredge2mqtt.services.modbus.storedge_control_inputs import (
+    RemoteControlChargeLimitInput,
+    RemoteControlCommandModeInput,
+    RemoteControlCommandTimeoutInput,
+    RemoteControlDischargeLimitInput,
+    StorageAcChargeLimitInput,
+    StorageAcChargePolicyInput,
+    StorageBackupReservedSettingInput,
+    StorageControlModeInput,
+    StorageDefaultModeInput,
+)
+from solaredge2mqtt.services.modbus.sunspec.inverter import (
+    SunSpecStorEdgeControlRegister,
+)
+
+
+@pytest.fixture
+def mock_service_settings():
+    """Create mock service settings."""
+    settings = MagicMock()
+    settings.modbus = MagicMock()
+    settings.modbus.has_followers = False
+    settings.modbus.storedge_control_enabled = True
+    settings.mqtt = MagicMock()
+    settings.mqtt.topic_prefix = "solaredge"
+    return settings
+
+
+class TestStorEdgeControlInit:
+    """Tests for StorEdgeControl initialization."""
+
+    def test_topic_prefix_without_followers(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test topic_prefix omits unit key when there are no followers."""
+        control = StorEdgeControl(mock_service_settings)
+
+        assert control.topic_prefix == "solaredge/modbus/inverter/storedge_control"
+
+    def test_topic_prefix_with_followers(self, mock_service_settings, mock_event_bus):
+        """Test topic_prefix includes the leader unit key when followers exist."""
+        mock_service_settings.modbus.has_followers = True
+
+        control = StorEdgeControl(mock_service_settings)
+
+        assert (
+            control.topic_prefix == "solaredge/modbus/leader/inverter/storedge_control"
+        )
+
+    def test_init_registers_with_event_bus(self, mock_service_settings, mock_event_bus):
+        """Test the instance registers itself with the EventBus."""
+        control = StorEdgeControl(mock_service_settings)
+
+        mock_event_bus.register.assert_called_once_with(control)
+
+
+class TestStorEdgeControlAsyncInit:
+    """Tests for StorEdgeControl.async_init."""
+
+    @pytest.mark.asyncio
+    async def test_async_init_subscribes_all_topics_when_enabled(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test async_init subscribes to all nine writable field topics."""
+        control = StorEdgeControl(mock_service_settings)
+
+        await control.async_init()
+
+        emitted = [c[0][0] for c in mock_event_bus.emit.call_args_list]
+        topics = {event.topic for event in emitted}
+
+        assert topics == {
+            "solaredge/modbus/inverter/storedge_control/storage_control_mode",
+            "solaredge/modbus/inverter/storedge_control/storage_ac_charge_policy",
+            "solaredge/modbus/inverter/storedge_control/storage_ac_charge_limit",
+            "solaredge/modbus/inverter/storedge_control/storage_backup_reserved_setting",
+            "solaredge/modbus/inverter/storedge_control/storage_default_mode",
+            "solaredge/modbus/inverter/storedge_control/remote_control_command_timeout",
+            "solaredge/modbus/inverter/storedge_control/remote_control_command_mode",
+            "solaredge/modbus/inverter/storedge_control/remote_control_charge_limit",
+            "solaredge/modbus/inverter/storedge_control/remote_control_discharge_limit",
+        }
+
+    @pytest.mark.asyncio
+    async def test_async_init_does_nothing_when_disabled(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test async_init emits nothing when storedge control is disabled."""
+        mock_service_settings.modbus.storedge_control_enabled = False
+
+        control = StorEdgeControl(mock_service_settings)
+        await control.async_init()
+
+        mock_event_bus.emit.assert_not_called()
+
+
+class TestStorEdgeControlCacheStorageControlMode:
+    """Tests for StorEdgeControl.cache_storage_control_mode."""
+
+    @pytest.mark.asyncio
+    async def test_caches_mode_from_units_with_storedge_control(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test the current storage_control_mode is cached per unit."""
+        control = StorEdgeControl(mock_service_settings)
+
+        unit = MagicMock()
+        unit.inverter.storedge_control.storage_control_mode = 4
+        event = MagicMock()
+        event.units = {"leader": unit}
+
+        await control.cache_storage_control_mode(event)
+
+        assert control._is_remote_control_active("leader") is True
+
+    @pytest.mark.asyncio
+    async def test_skips_units_without_storedge_control(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test units without a decoded StorEdge block are skipped, not cached as 0."""
+        control = StorEdgeControl(mock_service_settings)
+
+        unit = MagicMock()
+        unit.inverter.storedge_control = None
+        event = MagicMock()
+        event.units = {"leader": unit}
+
+        await control.cache_storage_control_mode(event)
+
+        assert control._is_remote_control_active("leader") is False
+        assert "leader" not in control._storage_control_mode
+
+
+class TestStorEdgeControlAlwaysAllowedWriteHandlers:
+    """Tests for the write handlers that don't require Remote Control mode."""
+
+    @pytest.mark.asyncio
+    async def test_handle_storage_control_mode_writes(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test storage_control_mode writes even without Remote Control active."""
+        control = StorEdgeControl(mock_service_settings)
+
+        event = StorageControlModeEvent(
+            topic="solaredge/modbus/inverter/storedge_control/storage_control_mode",
+            input=StorageControlModeInput(mode=4),
+        )
+        await control.handle_storage_control_mode(event)
+
+        mock_event_bus.emit.assert_called_once()
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert written.register == SunSpecStorEdgeControlRegister.STORAGE_CONTROL_MODE
+        assert written.payload == 4
+        assert written.unit_key == "leader"
+
+    @pytest.mark.asyncio
+    async def test_handle_storage_ac_charge_policy_writes(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test storage_ac_charge_policy writes unconditionally."""
+        control = StorEdgeControl(mock_service_settings)
+
+        event = StorageAcChargePolicyEvent(
+            topic="solaredge/modbus/inverter/storedge_control/storage_ac_charge_policy",
+            input=StorageAcChargePolicyInput(policy=1),
+        )
+        await control.handle_storage_ac_charge_policy(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert (
+            written.register == SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_POLICY
+        )
+        assert written.payload == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_storage_ac_charge_limit_writes(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test storage_ac_charge_limit writes unconditionally."""
+        control = StorEdgeControl(mock_service_settings)
+
+        event = StorageAcChargeLimitEvent(
+            topic="solaredge/modbus/inverter/storedge_control/storage_ac_charge_limit",
+            input=StorageAcChargeLimitInput(limit=2500.0),
+        )
+        await control.handle_storage_ac_charge_limit(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert (
+            written.register == SunSpecStorEdgeControlRegister.STORAGE_AC_CHARGE_LIMIT
+        )
+        assert written.payload == pytest.approx(2500.0)
+
+    @pytest.mark.asyncio
+    async def test_handle_storage_backup_reserved_setting_writes(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test storage_backup_reserved_setting writes unconditionally."""
+        control = StorEdgeControl(mock_service_settings)
+
+        event = StorageBackupReservedSettingEvent(
+            topic=(
+                "solaredge/modbus/inverter/storedge_control/"
+                "storage_backup_reserved_setting"
+            ),
+            input=StorageBackupReservedSettingInput(percentage=10.0),
+        )
+        await control.handle_storage_backup_reserved_setting(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert (
+            written.register
+            == SunSpecStorEdgeControlRegister.STORAGE_BACKUP_RESERVED_SETTING
+        )
+        assert written.payload == pytest.approx(10.0)
+
+
+class TestStorEdgeControlRemoteControlGatedWriteHandlers:
+    """Tests for the write handlers gated behind Remote Control mode."""
+
+    @pytest.mark.asyncio
+    async def test_handle_storage_default_mode_rejected_when_not_remote_control(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test the write is rejected when storage_control_mode isn't cached as 4."""
+        control = StorEdgeControl(mock_service_settings)
+
+        event = StorageDefaultModeEvent(
+            topic="solaredge/modbus/inverter/storedge_control/storage_default_mode",
+            input=StorageDefaultModeInput(mode=0),
+        )
+        await control.handle_storage_default_mode(event)
+
+        mock_event_bus.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_storage_default_mode_writes_when_remote_control_active(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test the write goes through once Remote Control mode is cached."""
+        control = StorEdgeControl(mock_service_settings)
+        control._storage_control_mode["leader"] = 4
+
+        event = StorageDefaultModeEvent(
+            topic="solaredge/modbus/inverter/storedge_control/storage_default_mode",
+            input=StorageDefaultModeInput(mode=0),
+        )
+        await control.handle_storage_default_mode(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert written.register == SunSpecStorEdgeControlRegister.STORAGE_DEFAULT_MODE
+        assert written.payload == 0
+
+    @pytest.mark.asyncio
+    async def test_handle_remote_control_command_timeout_gated(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test remote_control_command_timeout is gated behind Remote Control mode."""
+        control = StorEdgeControl(mock_service_settings)
+
+        event = RemoteControlCommandTimeoutEvent(
+            topic=(
+                "solaredge/modbus/inverter/storedge_control/"
+                "remote_control_command_timeout"
+            ),
+            input=RemoteControlCommandTimeoutInput(seconds=3600),
+        )
+        await control.handle_remote_control_command_timeout(event)
+        mock_event_bus.emit.assert_not_called()
+
+        control._storage_control_mode["leader"] = 4
+        await control.handle_remote_control_command_timeout(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert (
+            written.register
+            == SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_TIMEOUT
+        )
+        assert written.payload == 3600
+
+    @pytest.mark.asyncio
+    async def test_handle_remote_control_command_mode_gated(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test remote_control_command_mode is gated behind Remote Control mode."""
+        control = StorEdgeControl(mock_service_settings)
+        control._storage_control_mode["leader"] = 4
+
+        event = RemoteControlCommandModeEvent(
+            topic=(
+                "solaredge/modbus/inverter/storedge_control/remote_control_command_mode"
+            ),
+            input=RemoteControlCommandModeInput(mode=1),
+        )
+        await control.handle_remote_control_command_mode(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert (
+            written.register
+            == SunSpecStorEdgeControlRegister.REMOTE_CONTROL_COMMAND_MODE
+        )
+        assert written.payload == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_remote_control_charge_limit_gated(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test remote_control_charge_limit is rejected when mode isn't 4."""
+        control = StorEdgeControl(mock_service_settings)
+        control._storage_control_mode["leader"] = 1
+
+        event = RemoteControlChargeLimitEvent(
+            topic=(
+                "solaredge/modbus/inverter/storedge_control/remote_control_charge_limit"
+            ),
+            input=RemoteControlChargeLimitInput(limit=5000.0),
+        )
+        await control.handle_remote_control_charge_limit(event)
+
+        mock_event_bus.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_remote_control_discharge_limit_writes_when_active(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test remote_control_discharge_limit writes once mode is 4."""
+        control = StorEdgeControl(mock_service_settings)
+        control._storage_control_mode["leader"] = 4
+
+        event = RemoteControlDischargeLimitEvent(
+            topic=(
+                "solaredge/modbus/inverter/storedge_control/"
+                "remote_control_discharge_limit"
+            ),
+            input=RemoteControlDischargeLimitInput(limit=5000.0),
+        )
+        await control.handle_remote_control_discharge_limit(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert (
+            written.register
+            == SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT
+        )
+        assert written.payload == pytest.approx(5000.0)
+
+
+class TestStorEdgeControlInputValidation:
+    """Tests for the input model validation ranges."""
+
+    @pytest.mark.parametrize("value", [0, 4])
+    def test_storage_control_mode_valid_bounds(self, value):
+        """Test StorageControlModeInput accepts its documented bounds."""
+        assert StorageControlModeInput(mode=value).mode == value
+
+    @pytest.mark.parametrize("value", [-1, 5])
+    def test_storage_control_mode_rejects_out_of_range(self, value):
+        """Test StorageControlModeInput rejects out-of-range values."""
+        with pytest.raises(ValidationError):
+            StorageControlModeInput(mode=value)
+
+    @pytest.mark.parametrize("value", [-1, 4])
+    def test_storage_ac_charge_policy_rejects_out_of_range(self, value):
+        """Test StorageAcChargePolicyInput rejects out-of-range values."""
+        with pytest.raises(ValidationError):
+            StorageAcChargePolicyInput(policy=value)
+
+    def test_storage_ac_charge_limit_rejects_negative(self):
+        """Test StorageAcChargeLimitInput rejects negative values."""
+        with pytest.raises(ValidationError):
+            StorageAcChargeLimitInput(limit=-1.0)
+
+    @pytest.mark.parametrize("value", [-1, 101])
+    def test_storage_backup_reserved_setting_rejects_out_of_range(self, value):
+        """Test StorageBackupReservedSettingInput rejects out-of-range values."""
+        with pytest.raises(ValidationError):
+            StorageBackupReservedSettingInput(percentage=value)
+
+    @pytest.mark.parametrize("value", [-1, 8])
+    def test_storage_default_mode_rejects_out_of_range(self, value):
+        """Test StorageDefaultModeInput rejects out-of-range values."""
+        with pytest.raises(ValidationError):
+            StorageDefaultModeInput(mode=value)
+
+    @pytest.mark.parametrize("value", [-1, 86401])
+    def test_remote_control_command_timeout_rejects_out_of_range(self, value):
+        """Test RemoteControlCommandTimeoutInput rejects out-of-range values."""
+        with pytest.raises(ValidationError):
+            RemoteControlCommandTimeoutInput(seconds=value)
+
+    @pytest.mark.parametrize("value", [-1, 8])
+    def test_remote_control_command_mode_rejects_out_of_range(self, value):
+        """Test RemoteControlCommandModeInput rejects out-of-range values."""
+        with pytest.raises(ValidationError):
+            RemoteControlCommandModeInput(mode=value)
+
+    def test_remote_control_charge_limit_rejects_negative(self):
+        """Test RemoteControlChargeLimitInput rejects negative values."""
+        with pytest.raises(ValidationError):
+            RemoteControlChargeLimitInput(limit=-1.0)
+
+    def test_remote_control_discharge_limit_rejects_negative(self):
+        """Test RemoteControlDischargeLimitInput rejects negative values."""
+        with pytest.raises(ValidationError):
+            RemoteControlDischargeLimitInput(limit=-1.0)
+
+    def test_scalar_input_wraps_bare_value(self):
+        """Test a bare scalar MQTT payload (not a dict) still validates."""
+        assert StorageControlModeInput.model_validate(4).mode == 4

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
+from solaredge2mqtt.services.modbus.models.inverter import ModbusStorEdgeControl
 from solaredge2mqtt.services.modbus.storedge_control import StorEdgeControl
 from solaredge2mqtt.services.modbus.storedge_control_events import (
     RemoteControlChargeLimitEvent,
@@ -31,6 +32,23 @@ from solaredge2mqtt.services.modbus.storedge_control_inputs import (
 from solaredge2mqtt.services.modbus.sunspec.inverter import (
     SunSpecStorEdgeControlRegister,
 )
+
+
+def make_last_known(**overrides) -> ModbusStorEdgeControl:
+    """Build a ModbusStorEdgeControl to seed StorEdgeControl._last_known in tests."""
+    defaults = {
+        "storage_control_mode": 4,
+        "storage_ac_charge_policy": 1,
+        "storage_ac_charge_limit": 0.0,
+        "storage_backup_reserved_setting": 10.0,
+        "storage_default_mode": 6,
+        "remote_control_command_timeout": 1800,
+        "remote_control_command_mode": 6,
+        "remote_control_charge_limit": 4000.0,
+        "remote_control_discharge_limit": 4000.0,
+    }
+    defaults.update(overrides)
+    return ModbusStorEdgeControl(**defaults)
 
 
 @pytest.fixture
@@ -111,30 +129,32 @@ class TestStorEdgeControlAsyncInit:
         mock_event_bus.emit.assert_not_called()
 
 
-class TestStorEdgeControlCacheStorageControlMode:
-    """Tests for StorEdgeControl.cache_storage_control_mode."""
+class TestStorEdgeControlCacheStoredgeControl:
+    """Tests for StorEdgeControl.cache_storedge_control."""
 
     @pytest.mark.asyncio
-    async def test_caches_mode_from_units_with_storedge_control(
+    async def test_caches_last_known_from_units_with_storedge_control(
         self, mock_service_settings, mock_event_bus
     ):
-        """Test the current storage_control_mode is cached per unit."""
+        """Test the last known StorEdge state is cached per unit."""
         control = StorEdgeControl(mock_service_settings)
 
+        last_known = make_last_known(storage_control_mode=4)
         unit = MagicMock()
-        unit.inverter.storedge_control.storage_control_mode = 4
+        unit.inverter.storedge_control = last_known
         event = MagicMock()
         event.units = {"leader": unit}
 
-        await control.cache_storage_control_mode(event)
+        await control.cache_storedge_control(event)
 
         assert control._is_remote_control_active("leader") is True
+        assert control._last_known["leader"] is last_known
 
     @pytest.mark.asyncio
     async def test_skips_units_without_storedge_control(
         self, mock_service_settings, mock_event_bus
     ):
-        """Test units without a decoded StorEdge block are skipped, not cached as 0."""
+        """Test units without a decoded StorEdge block are skipped, not cached."""
         control = StorEdgeControl(mock_service_settings)
 
         unit = MagicMock()
@@ -142,10 +162,10 @@ class TestStorEdgeControlCacheStorageControlMode:
         event = MagicMock()
         event.units = {"leader": unit}
 
-        await control.cache_storage_control_mode(event)
+        await control.cache_storedge_control(event)
 
         assert control._is_remote_control_active("leader") is False
-        assert "leader" not in control._storage_control_mode
+        assert "leader" not in control._last_known
 
 
 class TestStorEdgeControlAlwaysAllowedWriteHandlers:
@@ -253,7 +273,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
     ):
         """Test the write goes through once Remote Control mode is cached."""
         control = StorEdgeControl(mock_service_settings)
-        control._storage_control_mode["leader"] = 4
+        control._last_known["leader"] = make_last_known()
 
         event = StorageDefaultModeEvent(
             topic="modbus/inverter/storedge_control/storage_default_mode",
@@ -279,7 +299,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         await control.handle_remote_control_command_timeout(event)
         mock_event_bus.emit.assert_not_called()
 
-        control._storage_control_mode["leader"] = 4
+        control._last_known["leader"] = make_last_known()
         await control.handle_remote_control_command_timeout(event)
 
         written = mock_event_bus.emit.call_args_list[0][0][0]
@@ -295,7 +315,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
     ):
         """Test remote_control_command_mode is gated behind Remote Control mode."""
         control = StorEdgeControl(mock_service_settings)
-        control._storage_control_mode["leader"] = 4
+        control._last_known["leader"] = make_last_known()
 
         event = RemoteControlCommandModeEvent(
             topic=("modbus/inverter/storedge_control/remote_control_command_mode"),
@@ -316,7 +336,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
     ):
         """Test remote_control_charge_limit is rejected when mode isn't 4."""
         control = StorEdgeControl(mock_service_settings)
-        control._storage_control_mode["leader"] = 1
+        control._last_known["leader"] = make_last_known(storage_control_mode=1)
 
         event = RemoteControlChargeLimitEvent(
             topic=("modbus/inverter/storedge_control/remote_control_charge_limit"),
@@ -332,7 +352,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
     ):
         """Test remote_control_discharge_limit writes once mode is 4."""
         control = StorEdgeControl(mock_service_settings)
-        control._storage_control_mode["leader"] = 4
+        control._last_known["leader"] = make_last_known()
 
         event = RemoteControlDischargeLimitEvent(
             topic=("modbus/inverter/storedge_control/remote_control_discharge_limit"),
@@ -346,6 +366,78 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
             == SunSpecStorEdgeControlRegister.REMOTE_CONTROL_DISCHARGE_LIMIT
         )
         assert written.payload == pytest.approx(5000.0)
+
+
+class TestStorEdgeControlNoopWrites:
+    """Tests that a write matching the last known value is skipped."""
+
+    @pytest.mark.asyncio
+    async def test_always_allowed_field_skips_when_value_unchanged(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test an always-allowed field is not rewritten when already at that value."""
+        control = StorEdgeControl(mock_service_settings)
+        control._last_known["leader"] = make_last_known(storage_control_mode=4)
+
+        event = StorageControlModeEvent(
+            topic="modbus/inverter/storedge_control/storage_control_mode",
+            input=StorageControlModeInput(mode=4),
+        )
+        await control.handle_storage_control_mode(event)
+
+        mock_event_bus.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_always_allowed_field_writes_when_value_changed(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test the same field still writes when the requested value differs."""
+        control = StorEdgeControl(mock_service_settings)
+        control._last_known["leader"] = make_last_known(storage_control_mode=1)
+
+        event = StorageControlModeEvent(
+            topic="modbus/inverter/storedge_control/storage_control_mode",
+            input=StorageControlModeInput(mode=4),
+        )
+        await control.handle_storage_control_mode(event)
+
+        mock_event_bus.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_gated_field_skips_when_value_unchanged_even_if_not_remote_control(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test a no-op write is skipped before the Remote Control gate is checked."""
+        control = StorEdgeControl(mock_service_settings)
+        control._last_known["leader"] = make_last_known(
+            storage_control_mode=1, storage_default_mode=6
+        )
+
+        event = StorageDefaultModeEvent(
+            topic="modbus/inverter/storedge_control/storage_default_mode",
+            input=StorageDefaultModeInput(mode=6),
+        )
+        await control.handle_storage_default_mode(event)
+
+        mock_event_bus.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gated_field_writes_when_value_changed_and_remote_control_active(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test a genuinely different value still writes once gated and unchanged."""
+        control = StorEdgeControl(mock_service_settings)
+        control._last_known["leader"] = make_last_known(
+            storage_control_mode=4, storage_default_mode=6
+        )
+
+        event = StorageDefaultModeEvent(
+            topic="modbus/inverter/storedge_control/storage_default_mode",
+            input=StorageDefaultModeInput(mode=0),
+        )
+        await control.handle_storage_default_mode(event)
+
+        mock_event_bus.emit.assert_called_once()
 
 
 class TestStorEdgeControlInputValidation:

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -440,6 +440,80 @@ class TestStorEdgeControlNoopWrites:
         mock_event_bus.emit.assert_called_once()
 
 
+class TestStorEdgeControlForceWrites:
+    """Tests for the force flag bypassing no-op write skipping."""
+
+    @pytest.mark.asyncio
+    async def test_always_allowed_field_force_writes_despite_unchanged_value(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test force=True re-sends an always-allowed field even if unchanged."""
+        control = StorEdgeControl(mock_service_settings)
+        control._last_known["leader"] = make_last_known(storage_control_mode=4)
+
+        event = StorageControlModeEvent(
+            topic="modbus/inverter/storedge_control/storage_control_mode",
+            input=StorageControlModeInput(mode=4, force=True),
+        )
+        await control.handle_storage_control_mode(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert written.register == SunSpecStorEdgeControlRegister.STORAGE_CONTROL_MODE
+        assert written.payload == 4
+
+    @pytest.mark.asyncio
+    async def test_gated_field_force_writes_despite_unchanged_value(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test force=True re-sends a gated field once Remote Control is active."""
+        control = StorEdgeControl(mock_service_settings)
+        control._last_known["leader"] = make_last_known(
+            storage_control_mode=4, storage_default_mode=6
+        )
+
+        event = StorageDefaultModeEvent(
+            topic="modbus/inverter/storedge_control/storage_default_mode",
+            input=StorageDefaultModeInput(mode=6, force=True),
+        )
+        await control.handle_storage_default_mode(event)
+
+        written = mock_event_bus.emit.call_args_list[0][0][0]
+        assert written.register == SunSpecStorEdgeControlRegister.STORAGE_DEFAULT_MODE
+        assert written.payload == 6
+
+    @pytest.mark.asyncio
+    async def test_force_does_not_bypass_remote_control_gate(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test force=True still respects the Remote Control gate."""
+        control = StorEdgeControl(mock_service_settings)
+        control._last_known["leader"] = make_last_known(
+            storage_control_mode=1, storage_default_mode=6
+        )
+
+        event = StorageDefaultModeEvent(
+            topic="modbus/inverter/storedge_control/storage_default_mode",
+            input=StorageDefaultModeInput(mode=6, force=True),
+        )
+        await control.handle_storage_default_mode(event)
+
+        mock_event_bus.emit.assert_not_called()
+
+    def test_bare_scalar_payload_still_wraps_with_force_false(self):
+        """Test a bare scalar payload keeps working and defaults force to False."""
+        input_model = StorageControlModeInput.model_validate(4)
+
+        assert input_model.mode == 4
+        assert input_model.force is False
+
+    def test_json_payload_can_set_force_true(self):
+        """Test a JSON object payload can opt into force."""
+        input_model = StorageControlModeInput.model_validate({"mode": 4, "force": True})
+
+        assert input_model.mode == 4
+        assert input_model.force is True
+
+
 class TestStorEdgeControlInputValidation:
     """Tests for the input model validation ranges."""
 

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -8,26 +8,26 @@ from pydantic import ValidationError
 from solaredge2mqtt.services.modbus.models.inverter import ModbusStorEdgeControl
 from solaredge2mqtt.services.modbus.storedge_control import StorEdgeControl
 from solaredge2mqtt.services.modbus.storedge_control_events import (
-    RemoteControlChargeLimitEvent,
-    RemoteControlCommandModeEvent,
-    RemoteControlCommandTimeoutEvent,
-    RemoteControlDischargeLimitEvent,
-    StorageAcChargeLimitEvent,
-    StorageAcChargePolicyEvent,
-    StorageBackupReservedSettingEvent,
-    StorageControlModeEvent,
-    StorageDefaultModeEvent,
+    StoredgeAcChargeLimitEvent,
+    StoredgeAcChargePolicyEvent,
+    StoredgeBackupReservedSettingEvent,
+    StoredgeControlModeEvent,
+    StoredgeDefaultModeEvent,
+    StoredgeRemoteControlChargeLimitEvent,
+    StoredgeRemoteControlCommandModeEvent,
+    StoredgeRemoteControlCommandTimeoutEvent,
+    StoredgeRemoteControlDischargeLimitEvent,
 )
 from solaredge2mqtt.services.modbus.storedge_control_inputs import (
-    RemoteControlChargeLimitInput,
-    RemoteControlCommandModeInput,
-    RemoteControlCommandTimeoutInput,
-    RemoteControlDischargeLimitInput,
-    StorageAcChargeLimitInput,
-    StorageAcChargePolicyInput,
-    StorageBackupReservedSettingInput,
-    StorageControlModeInput,
-    StorageDefaultModeInput,
+    StoredgeAcChargeLimitInput,
+    StoredgeAcChargePolicyInput,
+    StoredgeBackupReservedSettingInput,
+    StoredgeControlModeInput,
+    StoredgeDefaultModeInput,
+    StoredgeRemoteControlChargeLimitInput,
+    StoredgeRemoteControlCommandModeInput,
+    StoredgeRemoteControlCommandTimeoutInput,
+    StoredgeRemoteControlDischargeLimitInput,
 )
 from solaredge2mqtt.services.modbus.sunspec.inverter import (
     SunSpecStorEdgeControlRegister,
@@ -178,9 +178,9 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         """Test storage_control_mode writes even without Remote Control active."""
         control = StorEdgeControl(mock_service_settings)
 
-        event = StorageControlModeEvent(
+        event = StoredgeControlModeEvent(
             topic="modbus/inverter/storedge_control/storage_control_mode",
-            input=StorageControlModeInput(mode=4),
+            input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
 
@@ -197,9 +197,9 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         """Test storage_ac_charge_policy writes unconditionally."""
         control = StorEdgeControl(mock_service_settings)
 
-        event = StorageAcChargePolicyEvent(
+        event = StoredgeAcChargePolicyEvent(
             topic="modbus/inverter/storedge_control/storage_ac_charge_policy",
-            input=StorageAcChargePolicyInput(policy=1),
+            input=StoredgeAcChargePolicyInput(policy=1),
         )
         await control.handle_storage_ac_charge_policy(event)
 
@@ -216,9 +216,9 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         """Test storage_ac_charge_limit writes unconditionally."""
         control = StorEdgeControl(mock_service_settings)
 
-        event = StorageAcChargeLimitEvent(
+        event = StoredgeAcChargeLimitEvent(
             topic="modbus/inverter/storedge_control/storage_ac_charge_limit",
-            input=StorageAcChargeLimitInput(limit=2500.0),
+            input=StoredgeAcChargeLimitInput(limit=2500.0),
         )
         await control.handle_storage_ac_charge_limit(event)
 
@@ -235,9 +235,9 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         """Test storage_backup_reserved_setting writes unconditionally."""
         control = StorEdgeControl(mock_service_settings)
 
-        event = StorageBackupReservedSettingEvent(
+        event = StoredgeBackupReservedSettingEvent(
             topic=("modbus/inverter/storedge_control/storage_backup_reserved_setting"),
-            input=StorageBackupReservedSettingInput(percentage=10.0),
+            input=StoredgeBackupReservedSettingInput(percentage=10.0),
         )
         await control.handle_storage_backup_reserved_setting(event)
 
@@ -259,9 +259,9 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         """Test the write is rejected when storage_control_mode isn't cached as 4."""
         control = StorEdgeControl(mock_service_settings)
 
-        event = StorageDefaultModeEvent(
+        event = StoredgeDefaultModeEvent(
             topic="modbus/inverter/storedge_control/storage_default_mode",
-            input=StorageDefaultModeInput(mode=0),
+            input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
 
@@ -275,9 +275,9 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known()
 
-        event = StorageDefaultModeEvent(
+        event = StoredgeDefaultModeEvent(
             topic="modbus/inverter/storedge_control/storage_default_mode",
-            input=StorageDefaultModeInput(mode=0),
+            input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
 
@@ -292,9 +292,9 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         """Test remote_control_command_timeout is gated behind Remote Control mode."""
         control = StorEdgeControl(mock_service_settings)
 
-        event = RemoteControlCommandTimeoutEvent(
+        event = StoredgeRemoteControlCommandTimeoutEvent(
             topic=("modbus/inverter/storedge_control/remote_control_command_timeout"),
-            input=RemoteControlCommandTimeoutInput(seconds=3600),
+            input=StoredgeRemoteControlCommandTimeoutInput(seconds=3600),
         )
         await control.handle_remote_control_command_timeout(event)
         mock_event_bus.emit.assert_not_called()
@@ -317,9 +317,9 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known()
 
-        event = RemoteControlCommandModeEvent(
+        event = StoredgeRemoteControlCommandModeEvent(
             topic=("modbus/inverter/storedge_control/remote_control_command_mode"),
-            input=RemoteControlCommandModeInput(mode=1),
+            input=StoredgeRemoteControlCommandModeInput(mode=1),
         )
         await control.handle_remote_control_command_mode(event)
 
@@ -338,9 +338,9 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known(storage_control_mode=1)
 
-        event = RemoteControlChargeLimitEvent(
+        event = StoredgeRemoteControlChargeLimitEvent(
             topic=("modbus/inverter/storedge_control/remote_control_charge_limit"),
-            input=RemoteControlChargeLimitInput(limit=5000.0),
+            input=StoredgeRemoteControlChargeLimitInput(limit=5000.0),
         )
         await control.handle_remote_control_charge_limit(event)
 
@@ -354,9 +354,9 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known()
 
-        event = RemoteControlDischargeLimitEvent(
+        event = StoredgeRemoteControlDischargeLimitEvent(
             topic=("modbus/inverter/storedge_control/remote_control_discharge_limit"),
-            input=RemoteControlDischargeLimitInput(limit=5000.0),
+            input=StoredgeRemoteControlDischargeLimitInput(limit=5000.0),
         )
         await control.handle_remote_control_discharge_limit(event)
 
@@ -379,9 +379,9 @@ class TestStorEdgeControlNoopWrites:
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known(storage_control_mode=4)
 
-        event = StorageControlModeEvent(
+        event = StoredgeControlModeEvent(
             topic="modbus/inverter/storedge_control/storage_control_mode",
-            input=StorageControlModeInput(mode=4),
+            input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
 
@@ -395,9 +395,9 @@ class TestStorEdgeControlNoopWrites:
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known(storage_control_mode=1)
 
-        event = StorageControlModeEvent(
+        event = StoredgeControlModeEvent(
             topic="modbus/inverter/storedge_control/storage_control_mode",
-            input=StorageControlModeInput(mode=4),
+            input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
 
@@ -413,9 +413,9 @@ class TestStorEdgeControlNoopWrites:
             storage_control_mode=1, storage_default_mode=6
         )
 
-        event = StorageDefaultModeEvent(
+        event = StoredgeDefaultModeEvent(
             topic="modbus/inverter/storedge_control/storage_default_mode",
-            input=StorageDefaultModeInput(mode=6),
+            input=StoredgeDefaultModeInput(mode=6),
         )
         await control.handle_storage_default_mode(event)
 
@@ -431,9 +431,9 @@ class TestStorEdgeControlNoopWrites:
             storage_control_mode=4, storage_default_mode=6
         )
 
-        event = StorageDefaultModeEvent(
+        event = StoredgeDefaultModeEvent(
             topic="modbus/inverter/storedge_control/storage_default_mode",
-            input=StorageDefaultModeInput(mode=0),
+            input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
 
@@ -451,9 +451,9 @@ class TestStorEdgeControlForceWrites:
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known(storage_control_mode=4)
 
-        event = StorageControlModeEvent(
+        event = StoredgeControlModeEvent(
             topic="modbus/inverter/storedge_control/storage_control_mode",
-            input=StorageControlModeInput(mode=4, force=True),
+            input=StoredgeControlModeInput(mode=4, force=True),
         )
         await control.handle_storage_control_mode(event)
 
@@ -471,9 +471,9 @@ class TestStorEdgeControlForceWrites:
             storage_control_mode=4, storage_default_mode=6
         )
 
-        event = StorageDefaultModeEvent(
+        event = StoredgeDefaultModeEvent(
             topic="modbus/inverter/storedge_control/storage_default_mode",
-            input=StorageDefaultModeInput(mode=6, force=True),
+            input=StoredgeDefaultModeInput(mode=6, force=True),
         )
         await control.handle_storage_default_mode(event)
 
@@ -491,9 +491,9 @@ class TestStorEdgeControlForceWrites:
             storage_control_mode=1, storage_default_mode=6
         )
 
-        event = StorageDefaultModeEvent(
+        event = StoredgeDefaultModeEvent(
             topic="modbus/inverter/storedge_control/storage_default_mode",
-            input=StorageDefaultModeInput(mode=6, force=True),
+            input=StoredgeDefaultModeInput(mode=6, force=True),
         )
         await control.handle_storage_default_mode(event)
 
@@ -501,14 +501,16 @@ class TestStorEdgeControlForceWrites:
 
     def test_bare_scalar_payload_still_wraps_with_force_false(self):
         """Test a bare scalar payload keeps working and defaults force to False."""
-        input_model = StorageControlModeInput.model_validate(4)
+        input_model = StoredgeControlModeInput.model_validate(4)
 
         assert input_model.mode == 4
         assert input_model.force is False
 
     def test_json_payload_can_set_force_true(self):
         """Test a JSON object payload can opt into force."""
-        input_model = StorageControlModeInput.model_validate({"mode": 4, "force": True})
+        input_model = StoredgeControlModeInput.model_validate(
+            {"mode": 4, "force": True}
+        )
 
         assert input_model.mode == 4
         assert input_model.force is True
@@ -519,60 +521,60 @@ class TestStorEdgeControlInputValidation:
 
     @pytest.mark.parametrize("value", [0, 4])
     def test_storage_control_mode_valid_bounds(self, value):
-        """Test StorageControlModeInput accepts its documented bounds."""
-        assert StorageControlModeInput(mode=value).mode == value
+        """Test StoredgeControlModeInput accepts its documented bounds."""
+        assert StoredgeControlModeInput(mode=value).mode == value
 
     @pytest.mark.parametrize("value", [-1, 5])
     def test_storage_control_mode_rejects_out_of_range(self, value):
-        """Test StorageControlModeInput rejects out-of-range values."""
+        """Test StoredgeControlModeInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            StorageControlModeInput(mode=value)
+            StoredgeControlModeInput(mode=value)
 
     @pytest.mark.parametrize("value", [-1, 4])
     def test_storage_ac_charge_policy_rejects_out_of_range(self, value):
-        """Test StorageAcChargePolicyInput rejects out-of-range values."""
+        """Test StoredgeAcChargePolicyInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            StorageAcChargePolicyInput(policy=value)
+            StoredgeAcChargePolicyInput(policy=value)
 
     def test_storage_ac_charge_limit_rejects_negative(self):
-        """Test StorageAcChargeLimitInput rejects negative values."""
+        """Test StoredgeAcChargeLimitInput rejects negative values."""
         with pytest.raises(ValidationError):
-            StorageAcChargeLimitInput(limit=-1.0)
+            StoredgeAcChargeLimitInput(limit=-1.0)
 
     @pytest.mark.parametrize("value", [-1, 101])
     def test_storage_backup_reserved_setting_rejects_out_of_range(self, value):
-        """Test StorageBackupReservedSettingInput rejects out-of-range values."""
+        """Test StoredgeBackupReservedSettingInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            StorageBackupReservedSettingInput(percentage=value)
+            StoredgeBackupReservedSettingInput(percentage=value)
 
     @pytest.mark.parametrize("value", [-1, 8])
     def test_storage_default_mode_rejects_out_of_range(self, value):
-        """Test StorageDefaultModeInput rejects out-of-range values."""
+        """Test StoredgeDefaultModeInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            StorageDefaultModeInput(mode=value)
+            StoredgeDefaultModeInput(mode=value)
 
     @pytest.mark.parametrize("value", [-1, 86401])
     def test_remote_control_command_timeout_rejects_out_of_range(self, value):
-        """Test RemoteControlCommandTimeoutInput rejects out-of-range values."""
+        """Test StoredgeRemoteControlCommandTimeoutInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            RemoteControlCommandTimeoutInput(seconds=value)
+            StoredgeRemoteControlCommandTimeoutInput(seconds=value)
 
     @pytest.mark.parametrize("value", [-1, 8])
     def test_remote_control_command_mode_rejects_out_of_range(self, value):
-        """Test RemoteControlCommandModeInput rejects out-of-range values."""
+        """Test StoredgeRemoteControlCommandModeInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            RemoteControlCommandModeInput(mode=value)
+            StoredgeRemoteControlCommandModeInput(mode=value)
 
     def test_remote_control_charge_limit_rejects_negative(self):
-        """Test RemoteControlChargeLimitInput rejects negative values."""
+        """Test StoredgeRemoteControlChargeLimitInput rejects negative values."""
         with pytest.raises(ValidationError):
-            RemoteControlChargeLimitInput(limit=-1.0)
+            StoredgeRemoteControlChargeLimitInput(limit=-1.0)
 
     def test_remote_control_discharge_limit_rejects_negative(self):
-        """Test RemoteControlDischargeLimitInput rejects negative values."""
+        """Test StoredgeRemoteControlDischargeLimitInput rejects negative values."""
         with pytest.raises(ValidationError):
-            RemoteControlDischargeLimitInput(limit=-1.0)
+            StoredgeRemoteControlDischargeLimitInput(limit=-1.0)
 
     def test_scalar_input_wraps_bare_value(self):
         """Test a bare scalar MQTT payload (not a dict) still validates."""
-        assert StorageControlModeInput.model_validate(4).mode == 4
+        assert StoredgeControlModeInput.model_validate(4).mode == 4

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -11,23 +11,23 @@ from solaredge2mqtt.services.modbus.storedge_control_events import (
     StoredgeAcChargeLimitEvent,
     StoredgeAcChargePolicyEvent,
     StoredgeBackupReservedSettingEvent,
+    StoredgeChargeLimitEvent,
+    StoredgeCommandModeEvent,
+    StoredgeCommandTimeoutEvent,
     StoredgeControlModeEvent,
     StoredgeDefaultModeEvent,
-    StoredgeRemoteControlChargeLimitEvent,
-    StoredgeRemoteControlCommandModeEvent,
-    StoredgeRemoteControlCommandTimeoutEvent,
-    StoredgeRemoteControlDischargeLimitEvent,
+    StoredgeDischargeLimitEvent,
 )
 from solaredge2mqtt.services.modbus.storedge_control_inputs import (
     StoredgeAcChargeLimitInput,
     StoredgeAcChargePolicyInput,
     StoredgeBackupReservedSettingInput,
+    StoredgeChargeLimitInput,
+    StoredgeCommandModeInput,
+    StoredgeCommandTimeoutInput,
     StoredgeControlModeInput,
     StoredgeDefaultModeInput,
-    StoredgeRemoteControlChargeLimitInput,
-    StoredgeRemoteControlCommandModeInput,
-    StoredgeRemoteControlCommandTimeoutInput,
-    StoredgeRemoteControlDischargeLimitInput,
+    StoredgeDischargeLimitInput,
 )
 from solaredge2mqtt.services.modbus.sunspec.inverter import (
     SunSpecStorEdgeControlRegister,
@@ -110,10 +110,10 @@ class TestStorEdgeControlAsyncInit:
             "modbus/inverter/storedge_control/ac_charge_limit",
             "modbus/inverter/storedge_control/backup_reserved_setting",
             "modbus/inverter/storedge_control/default_mode",
-            "modbus/inverter/storedge_control/remote_control_command_timeout",
-            "modbus/inverter/storedge_control/remote_control_command_mode",
-            "modbus/inverter/storedge_control/remote_control_charge_limit",
-            "modbus/inverter/storedge_control/remote_control_discharge_limit",
+            "modbus/inverter/storedge_control/command_timeout",
+            "modbus/inverter/storedge_control/command_mode",
+            "modbus/inverter/storedge_control/charge_limit",
+            "modbus/inverter/storedge_control/discharge_limit",
         }
 
     @pytest.mark.asyncio
@@ -286,21 +286,21 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         assert written.payload == 0
 
     @pytest.mark.asyncio
-    async def test_handle_remote_control_command_timeout_gated(
+    async def test_handle_command_timeout_gated(
         self, mock_service_settings, mock_event_bus
     ):
         """Test remote_control_command_timeout is gated behind Remote Control mode."""
         control = StorEdgeControl(mock_service_settings)
 
-        event = StoredgeRemoteControlCommandTimeoutEvent(
-            topic=("modbus/inverter/storedge_control/remote_control_command_timeout"),
-            input=StoredgeRemoteControlCommandTimeoutInput(seconds=3600),
+        event = StoredgeCommandTimeoutEvent(
+            topic=("modbus/inverter/storedge_control/command_timeout"),
+            input=StoredgeCommandTimeoutInput(seconds=3600),
         )
-        await control.handle_remote_control_command_timeout(event)
+        await control.handle_command_timeout(event)
         mock_event_bus.emit.assert_not_called()
 
         control._last_known["leader"] = make_last_known()
-        await control.handle_remote_control_command_timeout(event)
+        await control.handle_command_timeout(event)
 
         written = mock_event_bus.emit.call_args_list[0][0][0]
         assert (
@@ -310,18 +310,18 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         assert written.payload == 3600
 
     @pytest.mark.asyncio
-    async def test_handle_remote_control_command_mode_gated(
+    async def test_handle_command_mode_gated(
         self, mock_service_settings, mock_event_bus
     ):
         """Test remote_control_command_mode is gated behind Remote Control mode."""
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known()
 
-        event = StoredgeRemoteControlCommandModeEvent(
-            topic=("modbus/inverter/storedge_control/remote_control_command_mode"),
-            input=StoredgeRemoteControlCommandModeInput(mode=1),
+        event = StoredgeCommandModeEvent(
+            topic=("modbus/inverter/storedge_control/command_mode"),
+            input=StoredgeCommandModeInput(mode=1),
         )
-        await control.handle_remote_control_command_mode(event)
+        await control.handle_command_mode(event)
 
         written = mock_event_bus.emit.call_args_list[0][0][0]
         assert (
@@ -331,34 +331,34 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         assert written.payload == 1
 
     @pytest.mark.asyncio
-    async def test_handle_remote_control_charge_limit_gated(
+    async def test_handle_charge_limit_gated(
         self, mock_service_settings, mock_event_bus
     ):
         """Test remote_control_charge_limit is rejected when mode isn't 4."""
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known(storage_control_mode=1)
 
-        event = StoredgeRemoteControlChargeLimitEvent(
-            topic=("modbus/inverter/storedge_control/remote_control_charge_limit"),
-            input=StoredgeRemoteControlChargeLimitInput(limit=5000.0),
+        event = StoredgeChargeLimitEvent(
+            topic=("modbus/inverter/storedge_control/charge_limit"),
+            input=StoredgeChargeLimitInput(limit=5000.0),
         )
-        await control.handle_remote_control_charge_limit(event)
+        await control.handle_charge_limit(event)
 
         mock_event_bus.emit.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_handle_remote_control_discharge_limit_writes_when_active(
+    async def test_handle_discharge_limit_writes_when_active(
         self, mock_service_settings, mock_event_bus
     ):
         """Test remote_control_discharge_limit writes once mode is 4."""
         control = StorEdgeControl(mock_service_settings)
         control._last_known["leader"] = make_last_known()
 
-        event = StoredgeRemoteControlDischargeLimitEvent(
-            topic=("modbus/inverter/storedge_control/remote_control_discharge_limit"),
-            input=StoredgeRemoteControlDischargeLimitInput(limit=5000.0),
+        event = StoredgeDischargeLimitEvent(
+            topic=("modbus/inverter/storedge_control/discharge_limit"),
+            input=StoredgeDischargeLimitInput(limit=5000.0),
         )
-        await control.handle_remote_control_discharge_limit(event)
+        await control.handle_discharge_limit(event)
 
         written = mock_event_bus.emit.call_args_list[0][0][0]
         assert (
@@ -554,26 +554,26 @@ class TestStorEdgeControlInputValidation:
             StoredgeDefaultModeInput(mode=value)
 
     @pytest.mark.parametrize("value", [-1, 86401])
-    def test_remote_control_command_timeout_rejects_out_of_range(self, value):
-        """Test StoredgeRemoteControlCommandTimeoutInput rejects out-of-range values."""
+    def test_command_timeout_rejects_out_of_range(self, value):
+        """Test StoredgeCommandTimeoutInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            StoredgeRemoteControlCommandTimeoutInput(seconds=value)
+            StoredgeCommandTimeoutInput(seconds=value)
 
     @pytest.mark.parametrize("value", [-1, 8])
-    def test_remote_control_command_mode_rejects_out_of_range(self, value):
-        """Test StoredgeRemoteControlCommandModeInput rejects out-of-range values."""
+    def test_command_mode_rejects_out_of_range(self, value):
+        """Test StoredgeCommandModeInput rejects out-of-range values."""
         with pytest.raises(ValidationError):
-            StoredgeRemoteControlCommandModeInput(mode=value)
+            StoredgeCommandModeInput(mode=value)
 
-    def test_remote_control_charge_limit_rejects_negative(self):
-        """Test StoredgeRemoteControlChargeLimitInput rejects negative values."""
+    def test_charge_limit_rejects_negative(self):
+        """Test StoredgeChargeLimitInput rejects negative values."""
         with pytest.raises(ValidationError):
-            StoredgeRemoteControlChargeLimitInput(limit=-1.0)
+            StoredgeChargeLimitInput(limit=-1.0)
 
-    def test_remote_control_discharge_limit_rejects_negative(self):
-        """Test StoredgeRemoteControlDischargeLimitInput rejects negative values."""
+    def test_discharge_limit_rejects_negative(self):
+        """Test StoredgeDischargeLimitInput rejects negative values."""
         with pytest.raises(ValidationError):
-            StoredgeRemoteControlDischargeLimitInput(limit=-1.0)
+            StoredgeDischargeLimitInput(limit=-1.0)
 
     def test_scalar_input_wraps_bare_value(self):
         """Test a bare scalar MQTT payload (not a dict) still validates."""

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -54,7 +54,7 @@ class TestStorEdgeControlInit:
         """Test topic_prefix omits unit key when there are no followers."""
         control = StorEdgeControl(mock_service_settings)
 
-        assert control.topic_prefix == "solaredge/modbus/inverter/storedge_control"
+        assert control.topic_prefix == "modbus/inverter/storedge_control"
 
     def test_topic_prefix_with_followers(self, mock_service_settings, mock_event_bus):
         """Test topic_prefix includes the leader unit key when followers exist."""
@@ -62,9 +62,7 @@ class TestStorEdgeControlInit:
 
         control = StorEdgeControl(mock_service_settings)
 
-        assert (
-            control.topic_prefix == "solaredge/modbus/leader/inverter/storedge_control"
-        )
+        assert control.topic_prefix == "modbus/leader/inverter/storedge_control"
 
     def test_init_registers_with_event_bus(self, mock_service_settings, mock_event_bus):
         """Test the instance registers itself with the EventBus."""
@@ -89,15 +87,15 @@ class TestStorEdgeControlAsyncInit:
         topics = {event.topic for event in emitted}
 
         assert topics == {
-            "solaredge/modbus/inverter/storedge_control/storage_control_mode",
-            "solaredge/modbus/inverter/storedge_control/storage_ac_charge_policy",
-            "solaredge/modbus/inverter/storedge_control/storage_ac_charge_limit",
-            "solaredge/modbus/inverter/storedge_control/storage_backup_reserved_setting",
-            "solaredge/modbus/inverter/storedge_control/storage_default_mode",
-            "solaredge/modbus/inverter/storedge_control/remote_control_command_timeout",
-            "solaredge/modbus/inverter/storedge_control/remote_control_command_mode",
-            "solaredge/modbus/inverter/storedge_control/remote_control_charge_limit",
-            "solaredge/modbus/inverter/storedge_control/remote_control_discharge_limit",
+            "modbus/inverter/storedge_control/storage_control_mode",
+            "modbus/inverter/storedge_control/storage_ac_charge_policy",
+            "modbus/inverter/storedge_control/storage_ac_charge_limit",
+            "modbus/inverter/storedge_control/storage_backup_reserved_setting",
+            "modbus/inverter/storedge_control/storage_default_mode",
+            "modbus/inverter/storedge_control/remote_control_command_timeout",
+            "modbus/inverter/storedge_control/remote_control_command_mode",
+            "modbus/inverter/storedge_control/remote_control_charge_limit",
+            "modbus/inverter/storedge_control/remote_control_discharge_limit",
         }
 
     @pytest.mark.asyncio
@@ -161,7 +159,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StorageControlModeEvent(
-            topic="solaredge/modbus/inverter/storedge_control/storage_control_mode",
+            topic="modbus/inverter/storedge_control/storage_control_mode",
             input=StorageControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
@@ -180,7 +178,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StorageAcChargePolicyEvent(
-            topic="solaredge/modbus/inverter/storedge_control/storage_ac_charge_policy",
+            topic="modbus/inverter/storedge_control/storage_ac_charge_policy",
             input=StorageAcChargePolicyInput(policy=1),
         )
         await control.handle_storage_ac_charge_policy(event)
@@ -199,7 +197,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StorageAcChargeLimitEvent(
-            topic="solaredge/modbus/inverter/storedge_control/storage_ac_charge_limit",
+            topic="modbus/inverter/storedge_control/storage_ac_charge_limit",
             input=StorageAcChargeLimitInput(limit=2500.0),
         )
         await control.handle_storage_ac_charge_limit(event)
@@ -218,10 +216,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StorageBackupReservedSettingEvent(
-            topic=(
-                "solaredge/modbus/inverter/storedge_control/"
-                "storage_backup_reserved_setting"
-            ),
+            topic=("modbus/inverter/storedge_control/storage_backup_reserved_setting"),
             input=StorageBackupReservedSettingInput(percentage=10.0),
         )
         await control.handle_storage_backup_reserved_setting(event)
@@ -245,7 +240,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StorageDefaultModeEvent(
-            topic="solaredge/modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/storage_default_mode",
             input=StorageDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -261,7 +256,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._storage_control_mode["leader"] = 4
 
         event = StorageDefaultModeEvent(
-            topic="solaredge/modbus/inverter/storedge_control/storage_default_mode",
+            topic="modbus/inverter/storedge_control/storage_default_mode",
             input=StorageDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -278,10 +273,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = RemoteControlCommandTimeoutEvent(
-            topic=(
-                "solaredge/modbus/inverter/storedge_control/"
-                "remote_control_command_timeout"
-            ),
+            topic=("modbus/inverter/storedge_control/remote_control_command_timeout"),
             input=RemoteControlCommandTimeoutInput(seconds=3600),
         )
         await control.handle_remote_control_command_timeout(event)
@@ -306,9 +298,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._storage_control_mode["leader"] = 4
 
         event = RemoteControlCommandModeEvent(
-            topic=(
-                "solaredge/modbus/inverter/storedge_control/remote_control_command_mode"
-            ),
+            topic=("modbus/inverter/storedge_control/remote_control_command_mode"),
             input=RemoteControlCommandModeInput(mode=1),
         )
         await control.handle_remote_control_command_mode(event)
@@ -329,9 +319,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._storage_control_mode["leader"] = 1
 
         event = RemoteControlChargeLimitEvent(
-            topic=(
-                "solaredge/modbus/inverter/storedge_control/remote_control_charge_limit"
-            ),
+            topic=("modbus/inverter/storedge_control/remote_control_charge_limit"),
             input=RemoteControlChargeLimitInput(limit=5000.0),
         )
         await control.handle_remote_control_charge_limit(event)
@@ -347,10 +335,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._storage_control_mode["leader"] = 4
 
         event = RemoteControlDischargeLimitEvent(
-            topic=(
-                "solaredge/modbus/inverter/storedge_control/"
-                "remote_control_discharge_limit"
-            ),
+            topic=("modbus/inverter/storedge_control/remote_control_discharge_limit"),
             input=RemoteControlDischargeLimitInput(limit=5000.0),
         )
         await control.handle_remote_control_discharge_limit(event)

--- a/tests/services/modbus/test_storedge_control.py
+++ b/tests/services/modbus/test_storedge_control.py
@@ -72,7 +72,7 @@ class TestStorEdgeControlInit:
         """Test topic_prefix omits unit key when there are no followers."""
         control = StorEdgeControl(mock_service_settings)
 
-        assert control.topic_prefix == "modbus/inverter/storedge_control"
+        assert control.topic_prefix == "modbus/inverter/storedge"
 
     def test_topic_prefix_with_followers(self, mock_service_settings, mock_event_bus):
         """Test topic_prefix includes the leader unit key when followers exist."""
@@ -80,7 +80,7 @@ class TestStorEdgeControlInit:
 
         control = StorEdgeControl(mock_service_settings)
 
-        assert control.topic_prefix == "modbus/leader/inverter/storedge_control"
+        assert control.topic_prefix == "modbus/leader/inverter/storedge"
 
     def test_init_registers_with_event_bus(self, mock_service_settings, mock_event_bus):
         """Test the instance registers itself with the EventBus."""
@@ -105,15 +105,15 @@ class TestStorEdgeControlAsyncInit:
         topics = {event.topic for event in emitted}
 
         assert topics == {
-            "modbus/inverter/storedge_control/control_mode",
-            "modbus/inverter/storedge_control/ac_charge_policy",
-            "modbus/inverter/storedge_control/ac_charge_limit",
-            "modbus/inverter/storedge_control/backup_reserved_setting",
-            "modbus/inverter/storedge_control/default_mode",
-            "modbus/inverter/storedge_control/command_timeout",
-            "modbus/inverter/storedge_control/command_mode",
-            "modbus/inverter/storedge_control/charge_limit",
-            "modbus/inverter/storedge_control/discharge_limit",
+            "modbus/inverter/storedge/control_mode",
+            "modbus/inverter/storedge/ac_charge_policy",
+            "modbus/inverter/storedge/ac_charge_limit",
+            "modbus/inverter/storedge/backup_reserved_setting",
+            "modbus/inverter/storedge/default_mode",
+            "modbus/inverter/storedge/command_timeout",
+            "modbus/inverter/storedge/command_mode",
+            "modbus/inverter/storedge/charge_limit",
+            "modbus/inverter/storedge/discharge_limit",
         }
 
     @pytest.mark.asyncio
@@ -179,7 +179,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/control_mode",
+            topic="modbus/inverter/storedge/control_mode",
             input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
@@ -198,7 +198,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeAcChargePolicyEvent(
-            topic="modbus/inverter/storedge_control/ac_charge_policy",
+            topic="modbus/inverter/storedge/ac_charge_policy",
             input=StoredgeAcChargePolicyInput(policy=1),
         )
         await control.handle_storage_ac_charge_policy(event)
@@ -217,7 +217,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeAcChargeLimitEvent(
-            topic="modbus/inverter/storedge_control/ac_charge_limit",
+            topic="modbus/inverter/storedge/ac_charge_limit",
             input=StoredgeAcChargeLimitInput(limit=2500.0),
         )
         await control.handle_storage_ac_charge_limit(event)
@@ -236,7 +236,7 @@ class TestStorEdgeControlAlwaysAllowedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeBackupReservedSettingEvent(
-            topic=("modbus/inverter/storedge_control/backup_reserved_setting"),
+            topic=("modbus/inverter/storedge/backup_reserved_setting"),
             input=StoredgeBackupReservedSettingInput(percentage=10.0),
         )
         await control.handle_storage_backup_reserved_setting(event)
@@ -260,7 +260,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/default_mode",
+            topic="modbus/inverter/storedge/default_mode",
             input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -276,7 +276,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._last_known["leader"] = make_last_known()
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/default_mode",
+            topic="modbus/inverter/storedge/default_mode",
             input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -293,7 +293,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control = StorEdgeControl(mock_service_settings)
 
         event = StoredgeCommandTimeoutEvent(
-            topic=("modbus/inverter/storedge_control/command_timeout"),
+            topic=("modbus/inverter/storedge/command_timeout"),
             input=StoredgeCommandTimeoutInput(seconds=3600),
         )
         await control.handle_command_timeout(event)
@@ -318,7 +318,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._last_known["leader"] = make_last_known()
 
         event = StoredgeCommandModeEvent(
-            topic=("modbus/inverter/storedge_control/command_mode"),
+            topic=("modbus/inverter/storedge/command_mode"),
             input=StoredgeCommandModeInput(mode=1),
         )
         await control.handle_command_mode(event)
@@ -339,7 +339,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._last_known["leader"] = make_last_known(storage_control_mode=1)
 
         event = StoredgeChargeLimitEvent(
-            topic=("modbus/inverter/storedge_control/charge_limit"),
+            topic=("modbus/inverter/storedge/charge_limit"),
             input=StoredgeChargeLimitInput(limit=5000.0),
         )
         await control.handle_charge_limit(event)
@@ -355,7 +355,7 @@ class TestStorEdgeControlRemoteControlGatedWriteHandlers:
         control._last_known["leader"] = make_last_known()
 
         event = StoredgeDischargeLimitEvent(
-            topic=("modbus/inverter/storedge_control/discharge_limit"),
+            topic=("modbus/inverter/storedge/discharge_limit"),
             input=StoredgeDischargeLimitInput(limit=5000.0),
         )
         await control.handle_discharge_limit(event)
@@ -380,7 +380,7 @@ class TestStorEdgeControlNoopWrites:
         control._last_known["leader"] = make_last_known(storage_control_mode=4)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/control_mode",
+            topic="modbus/inverter/storedge/control_mode",
             input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
@@ -396,7 +396,7 @@ class TestStorEdgeControlNoopWrites:
         control._last_known["leader"] = make_last_known(storage_control_mode=1)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/control_mode",
+            topic="modbus/inverter/storedge/control_mode",
             input=StoredgeControlModeInput(mode=4),
         )
         await control.handle_storage_control_mode(event)
@@ -414,7 +414,7 @@ class TestStorEdgeControlNoopWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/default_mode",
+            topic="modbus/inverter/storedge/default_mode",
             input=StoredgeDefaultModeInput(mode=6),
         )
         await control.handle_storage_default_mode(event)
@@ -432,7 +432,7 @@ class TestStorEdgeControlNoopWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/default_mode",
+            topic="modbus/inverter/storedge/default_mode",
             input=StoredgeDefaultModeInput(mode=0),
         )
         await control.handle_storage_default_mode(event)
@@ -452,7 +452,7 @@ class TestStorEdgeControlForceWrites:
         control._last_known["leader"] = make_last_known(storage_control_mode=4)
 
         event = StoredgeControlModeEvent(
-            topic="modbus/inverter/storedge_control/control_mode",
+            topic="modbus/inverter/storedge/control_mode",
             input=StoredgeControlModeInput(mode=4, force=True),
         )
         await control.handle_storage_control_mode(event)
@@ -472,7 +472,7 @@ class TestStorEdgeControlForceWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/default_mode",
+            topic="modbus/inverter/storedge/default_mode",
             input=StoredgeDefaultModeInput(mode=6, force=True),
         )
         await control.handle_storage_default_mode(event)
@@ -492,7 +492,7 @@ class TestStorEdgeControlForceWrites:
         )
 
         event = StoredgeDefaultModeEvent(
-            topic="modbus/inverter/storedge_control/default_mode",
+            topic="modbus/inverter/storedge/default_mode",
             input=StoredgeDefaultModeInput(mode=6, force=True),
         )
         await control.handle_storage_default_mode(event)

--- a/tests/services/powerflow/test_service.py
+++ b/tests/services/powerflow/test_service.py
@@ -108,13 +108,16 @@ class TestPowerflowServiceInit:
 
     def test_powerflow_service_init(self, mock_service_settings, mock_event_bus):
         """Test PowerflowService initialization."""
-        with patch("solaredge2mqtt.services.powerflow.Modbus"):
+        with (
+            patch("solaredge2mqtt.services.powerflow.Modbus"),
+            patch("solaredge2mqtt.services.powerflow.StorEdgeControl"),
+        ):
             service = PowerflowService(mock_service_settings, None)
 
             assert service.settings is mock_service_settings
             assert service.influxdb is None
             assert service.wallbox is None
-            mock_event_bus.register.assert_called_once_with(service)
+            mock_event_bus.register.assert_any_call(service)
 
     def test_powerflow_service_init_with_wallbox(
         self, mock_service_settings, mock_event_bus
@@ -145,15 +148,24 @@ class TestPowerflowServiceAsyncInit:
 
     @pytest.mark.asyncio
     async def test_async_init(self, mock_service_settings, mock_event_bus):
-        """Test async_init initializes modbus."""
-        with patch("solaredge2mqtt.services.powerflow.Modbus") as mock_modbus_class:
+        """Test async_init initializes modbus and storedge control."""
+        with (
+            patch("solaredge2mqtt.services.powerflow.Modbus") as mock_modbus_class,
+            patch(
+                "solaredge2mqtt.services.powerflow.StorEdgeControl"
+            ) as mock_storedge_control_class,
+        ):
             mock_modbus = AsyncMock()
             mock_modbus_class.return_value = mock_modbus
+
+            mock_storedge_control = AsyncMock()
+            mock_storedge_control_class.return_value = mock_storedge_control
 
             service = PowerflowService(mock_service_settings, None)
             await service.async_init()
 
             mock_modbus.async_init.assert_called_once()
+            mock_storedge_control.async_init.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_async_init_propagates_error(


### PR DESCRIPTION
## Summary
- New `solaredge2mqtt/services/modbus/storedge_control.py`: dedicated MQTT→Modbus write path for the StorEdge Control Block — its own module, not a reuse of the removed generic scaffolding, not a copy of the EV charger pattern verbatim (though it follows the same proven one-event-class-per-field style).
- 9 writable fields, each with its own `MQTTReceivedEvent`/`MQTTSubscribeEvent` pair and a range-validated input model (`storedge_control_inputs.py` / `storedge_control_events.py`).
- `storage_control_mode`, `storage_ac_charge_policy`, `storage_ac_charge_limit`, `storage_backup_reserved_setting` always take effect. `storage_default_mode`, `remote_control_command_mode/timeout/charge_limit/discharge_limit` only take effect once `storage_control_mode` is `4` (Remote Control) — writes to those are rejected and logged otherwise, since SolarEdge itself ignores them outside Remote Control mode.
- No commit-register or `AdvancedPwrControlEn`/`ReactivePwrConfig` involvement — confirmed unnecessary against a real StorEdge inverter in Phase 1.
- Wired into `PowerflowService` next to `Modbus`, gated behind the existing `storedge_control_enabled` setting (default off).
- README documents all 9 topics, payload shape, and the Remote Control gating.

Closes #185 — resolves the original ask (MQTT-controllable battery charge/discharge, e.g. `storage_default_mode` → `Off` overnight while an EV charges, without draining the battery for grid relief).

Part of the StorEdge battery control plan:
- Phase 0 (merged, #428): remove legacy `advanced_power_controls` scaffolding
- Phase 1 (merged, #429): register map + read model + read wiring
- **Phase 2 (this PR)**: MQTT write module

## Test plan
- [x] `pytest -q` — 1422 passed (35 new)
- [x] `ruff check` — clean
- [x] pre-commit hooks (ruff, pyright) passed on commit
- [ ] Live write verification against a real StorEdge inverter — not yet done, since writes actually change battery charge/discharge behavior. Happy to do this together if wanted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2qeDJSQwhLmT3UeVt2iJV