### PR TITLE
feat(mqtt): support client certificates for mutual TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,13 +281,22 @@ mqtt:
   topic_prefix: solaredge          # MQTT topic prefix
   use_tls: false                   # Enable TLS encryption (default: false)
   ca_certs: /path/to/ca.pem        # Path to CA certificate bundle
+  certfile: /path/to/client.pem    # Client certificate for mutual TLS
+  keyfile: /path/to/client.key     # Private key matching certfile
+  keyfile_password: !secret mqtt_keyfile_password  # Only if the private key is encrypted
   tls_verify: true                 # Verify TLS certificates (default: true)
 ```
+
+If your broker authenticates clients by certificate instead of (or in addition to) a
+password, set `certfile` and `keyfile` to the client keypair. They are only used when
+`use_tls` is enabled, and `keyfile_password` is needed only when the private key itself is
+encrypted. All three are unset by default.
 
 **Note**: Store your password securely in `secrets.yml`:
 ```yaml
 # secrets.yml
 mqtt_password: "your_actual_password"
+mqtt_keyfile_password: "your_actual_key_password"
 ```
 
 The service also publishes operational topics below the configured `topic_prefix`:

--- a/solaredge2mqtt/config/configuration.yml.example
+++ b/solaredge2mqtt/config/configuration.yml.example
@@ -73,6 +73,9 @@ mqtt:
   retain: false                 # Retain MQTT messages
 # use_tls: false                # MQTT over TLS
 # ca_certs: path_to_CA          # Path to trusted CA boundle - usefull for self sign certificates
+# certfile: path_to_client_cert # Client certificate, for brokers requiring mutual TLS
+# keyfile: path_to_client_key   # Private key matching certfile
+# keyfile_password: !secret mqtt_keyfile_password  # Only if the private key is encrypted
 # tls_verify: true              # Verify mqtt certificate. If set to false ignore certificate expiration, CN missmatch, etc.
 # logging_level: ERROR          # Minimum log level forwarded to MQTT logging topic (default: ERROR)
 

--- a/solaredge2mqtt/core/mqtt/settings.py
+++ b/solaredge2mqtt/core/mqtt/settings.py
@@ -22,6 +22,9 @@ class MQTTSettings(BaseModel):
     topic_prefix: str = Field(default="solaredge")
     use_tls: bool = Field(default=False)
     ca_certs: str | None = Field(default=None)
+    certfile: str | None = Field(default=None)
+    keyfile: str | None = Field(default=None)
+    keyfile_password: SecretStr | None = Field(default=None)
     tls_verify: bool = Field(default=True)
     logging_level: LoggingLevelEnum = Field(default=LoggingLevelEnum.ERROR)
 
@@ -39,6 +42,13 @@ class MQTTSettings(BaseModel):
         if self.use_tls:
             client_args["tls_params"] = TLSParameters(
                 ca_certs=self.ca_certs,
+                certfile=self.certfile,
+                keyfile=self.keyfile,
+                keyfile_password=(
+                    self.keyfile_password.get_secret_value()
+                    if self.keyfile_password is not None
+                    else None
+                ),
                 cert_reqs=ssl.CERT_REQUIRED if self.tls_verify else ssl.CERT_NONE,
             )
         else:

--- a/tests/core/mqtt/test_settings.py
+++ b/tests/core/mqtt/test_settings.py
@@ -95,6 +95,9 @@ class TestMQTTSettings:
 
         assert settings.use_tls is False
         assert settings.ca_certs is None
+        assert settings.certfile is None
+        assert settings.keyfile is None
+        assert settings.keyfile_password is None
         assert settings.tls_verify is True
 
     def test_mqtt_settings_kargs_without_tls(self):
@@ -117,6 +120,48 @@ class TestMQTTSettings:
         assert kargs["tls_params"] is not None
         assert kargs["tls_params"].ca_certs == "/tmp/ca.crt"
         assert kargs["tls_params"].cert_reqs == ssl.CERT_REQUIRED
+
+    def test_mqtt_settings_kargs_without_client_certificate(self):
+        """Test kargs property leaves client certificate unset by default."""
+        settings = MQTTSettings(
+            broker="localhost",
+            use_tls=True,
+            ca_certs="/tmp/ca.crt",
+        )
+        kargs = settings.kargs
+
+        assert kargs["tls_params"].certfile is None
+        assert kargs["tls_params"].keyfile is None
+        assert kargs["tls_params"].keyfile_password is None
+
+    def test_mqtt_settings_kargs_with_client_certificate(self):
+        """Test kargs property builds TLS params for mutual TLS."""
+        settings = MQTTSettings(
+            broker="localhost",
+            use_tls=True,
+            ca_certs="/tmp/ca.crt",
+            certfile="/tmp/client.crt",
+            keyfile="/tmp/client.key",
+        )
+        kargs = settings.kargs
+
+        assert kargs["tls_params"].ca_certs == "/tmp/ca.crt"
+        assert kargs["tls_params"].certfile == "/tmp/client.crt"
+        assert kargs["tls_params"].keyfile == "/tmp/client.key"
+        assert kargs["tls_params"].cert_reqs == ssl.CERT_REQUIRED
+
+    def test_mqtt_settings_kargs_unwraps_keyfile_password(self):
+        """Test kargs property passes the key password as a plain string."""
+        settings = MQTTSettings(
+            broker="localhost",
+            use_tls=True,
+            certfile="/tmp/client.crt",
+            keyfile="/tmp/client.key",
+            keyfile_password=SecretStr("s3cret"),
+        )
+        kargs = settings.kargs
+
+        assert kargs["tls_params"].keyfile_password == "s3cret"
 
     def test_mqtt_settings_kargs_with_tls_and_verify_disabled(self):
         """Test kargs property builds TLS params without cert verification."""


### PR DESCRIPTION
Brokers that authenticate clients by certificate rather than by password could not be used: the TLS parameters only carried a CA bundle, so there was no way to present a client keypair.

aiomqtt's TLSParameters already accepts certfile, keyfile and keyfile_password, so this just exposes them as MQTT settings and passes them through. The keyfile password is a SecretStr, matching how the broker password is handled, and is unwrapped at the same point.

All three default to None, so behaviour is unchanged unless they are set.