### PR TITLE
Phase 3: Home Assistant select/number entities for StorEdge control (issue #185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ The write topic suffixes are shorter than the read-back field names — the `sto
 
 If a published value already matches the last value read back from the inverter, the write is skipped — these registers don't need to be exercised more than necessary. To force a write anyway (e.g. if the cached value might be stale), publish a JSON object with `"force": true`, e.g. `{"mode": 4, "force": true}`. Force only bypasses this no-op check — it does not bypass the Remote Control gate above.
 
+**Home Assistant entities**
+
+When Home Assistant auto discovery is enabled (and `storedge_control_enabled: true`), all nine fields are also created as native HA entities on the inverter device:
+
+- **Select** entities for `control_mode`, `ac_charge_policy`, `default_mode`, and `command_mode` — the dropdown shows SolarEdge's own mode names (e.g. "Remote Control", "Maximize Self Consumption"); HA translates the selected label to the numeric value before publishing.
+- **Number** entities for `ac_charge_limit`, `backup_reserved_setting`, `command_timeout`, `charge_limit`, and `discharge_limit`.
+
+Each entity's command topic matches the write topics documented above, so changing a value in the HA UI is equivalent to publishing to MQTT directly. The five Remote-Control-gated fields are labeled accordingly in their entity name.
+
 ### Leader/follower setup
 
 SolarEdge inverters support a cascading setup, where one inverter acts as the leader and up to ten others act as followers.

--- a/solaredge2mqtt/services/homeassistant/models.py
+++ b/solaredge2mqtt/services/homeassistant/models.py
@@ -166,52 +166,17 @@ class HomeAssistantBinarySensorType(HomeAssistantEntityBaseType):
 
 
 class HomeAssistantNumberType(HomeAssistantEntityBaseType):
-    EV_CHARGE_LEVEL = "charge_level", None, "%", 0, 100, 100, "slider"
-    STOREDGE_AC_CHARGE_LIMIT = (
-        "storedge_ac_charge_limit",
-        None,
-        None,
-        0,
-        100000,
-        1,
-        "box",
-    )
-    STOREDGE_BACKUP_RESERVED = (
-        "storedge_backup_reserved",
-        None,
-        "%",
-        0,
-        100,
-        1,
-        "slider",
-    )
-    STOREDGE_COMMAND_TIMEOUT = (
-        "storedge_command_timeout",
-        None,
-        "s",
-        0,
-        86400,
-        1,
-        "box",
-    )
-    STOREDGE_CHARGE_LIMIT = (
-        "storedge_charge_limit",
-        "power",
-        "W",
-        0,
-        20000,
-        1,
-        "box",
-    )
-    STOREDGE_DISCHARGE_LIMIT = (
-        "storedge_discharge_limit",
-        "power",
-        "W",
-        0,
-        20000,
-        1,
-        "box",
-    )
+    """Generic writable-number presentation.
+
+    Deliberately holds no domain-specific members — device_class,
+    unit_of_measurement, min/max/step/mode are all supplied per call site via
+    field(), so callers don't need to register a new enum member here for
+    every numeric config value a service happens to expose. Keeps SolarEdge
+    (or any other domain's) presentation metadata in that domain's own
+    module instead of leaking into this generic HA layer.
+    """
+
+    GENERIC = "number", None, None, None, None, None, None
 
     def __init__(
         self,
@@ -255,60 +220,45 @@ class HomeAssistantNumberType(HomeAssistantEntityBaseType):
 
 
 class HomeAssistantSelectType(HomeAssistantEntityBaseType):
-    STOREDGE_CONTROL_MODE = (
-        "storedge_control_mode",
-        {
-            0: "Disabled",
-            1: "Maximize Self Consumption",
-            2: "Time of Use",
-            3: "Backup Only",
-            4: "Remote Control",
-        },
-    )
-    STOREDGE_AC_CHARGE_POLICY = (
-        "storedge_ac_charge_policy",
-        {
-            0: "Disabled",
-            1: "Always Allowed",
-            2: "Fixed Energy Limit",
-            3: "Percent of Production",
-        },
-    )
-    STOREDGE_CHARGE_DISCHARGE_MODE = (
-        "storedge_charge_discharge_mode",
-        {
-            0: "Off",
-            1: "Charge from Clipped Solar Power",
-            2: "Charge from Solar Power",
-            3: "Charge from Solar Power and Grid",
-            4: "Discharge to Maximize Export",
-            5: "Discharge to Minimize Import",
-            7: "Maximize Self Consumption",
-        },
-    )
+    """Generic writable-select presentation.
 
-    def __init__(self, key: str, options_map: dict[int, str]):
-        super().__init__(key, HomeAssistantType.SELECT, None, None, None)
+    Like HomeAssistantNumberType, holds no domain-specific members: the
+    options map (raw value -> human label) is supplied per call site via
+    field(options_map=...), not baked into an enum member here. The map
+    itself flows through to HomeAssistantEntity via json_schema_extra and
+    drives its value_template/command_template — this class only knows how
+    to render "a select with an optional label mapping", never what any
+    particular domain's labels actually are.
+    """
 
-        self._options_map: dict[int, str] = options_map
+    GENERIC = "select", None, None, None
 
-    @property
-    def options_map(self) -> dict[int, str]:
-        return self._options_map
-
-    @property
-    def options(self) -> list[str]:
-        return list(self._options_map.values())
+    def __init__(
+        self,
+        key: str,
+        device_class: str | None = None,
+        state_class: str | None = None,
+        unit_of_measurement: str | None = None,
+    ):
+        super().__init__(
+            key,
+            HomeAssistantType.SELECT,
+            device_class,
+            state_class,
+            unit_of_measurement,
+        )
 
     def field(
         self,
         title: str | None = None,
         input_field: BaseInputFieldEnumModel | None = None,
+        options_map: dict[Any, Any] | None = None,
         **json_schema_extra: Any,
     ) -> dict[str, Any]:
 
         json_schema_extra = {
-            "options": self.options,
+            "options": list(options_map.values()) if options_map else [],
+            "options_map": options_map,
             **json_schema_extra,
         }
 
@@ -372,7 +322,9 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
     path: list[str] | None = Field(None, exclude=True)
     ha_type: HomeAssistantEntityBaseType = Field(exclude=True)
     unit: str | None = Field(None, exclude=True)
+    device_class_override: str | None = Field(None, exclude=True)
     command_topic_override: str | None = Field(None, exclude=True)
+    options_map: dict[Any, Any] | None = Field(None, exclude=True)
 
     _icon: str | None = PrivateAttr(default=None)
     _additional_fields: dict[str, Any] = PrivateAttr(default_factory=dict)
@@ -430,8 +382,8 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
 
         value_expr = f"value_json.{'.'.join(self.path)}"
 
-        if isinstance(self.ha_type, HomeAssistantSelectType):
-            mapping = _jinja_dict_literal(self.ha_type.options_map)
+        if self.options_map:
+            mapping = _jinja_dict_literal(self.options_map)
             value_expr = f"{mapping}[{value_expr}]"
 
         return f"{{{{ {value_expr} }}}}"
@@ -439,10 +391,10 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
     @computed_field
     @property
     def command_template(self) -> str | None:
-        if not isinstance(self.ha_type, HomeAssistantSelectType):
+        if not self.options_map:
             return None
 
-        reverse_map = {label: code for code, label in self.ha_type.options_map.items()}
+        reverse_map = {label: code for code, label in self.options_map.items()}
         mapping = _jinja_dict_literal(reverse_map)
         return f"{{{{ {mapping}[value] }}}}"
 
@@ -454,6 +406,9 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
     @computed_field
     @property
     def device_class(self) -> str | None:
+        if self.device_class_override is not None:
+            return self.device_class_override
+
         return self.ha_type.device_class
 
     @computed_field

--- a/solaredge2mqtt/services/homeassistant/models.py
+++ b/solaredge2mqtt/services/homeassistant/models.py
@@ -74,6 +74,7 @@ class HomeAssistantDevice(HomeAssistantBaseModel):
 class HomeAssistantType(EnumModel):
     BINARY_SENSOR = "binary_sensor", False, []
     NUMBER = "number", True, ["min", "max", "step", "mode"]
+    SELECT = "select", True, ["options"]
     SENSOR = "sensor", False, []
 
     def __init__(
@@ -166,6 +167,51 @@ class HomeAssistantBinarySensorType(HomeAssistantEntityBaseType):
 
 class HomeAssistantNumberType(HomeAssistantEntityBaseType):
     EV_CHARGE_LEVEL = "charge_level", None, "%", 0, 100, 100, "slider"
+    STOREDGE_AC_CHARGE_LIMIT = (
+        "storedge_ac_charge_limit",
+        None,
+        None,
+        0,
+        100000,
+        1,
+        "box",
+    )
+    STOREDGE_BACKUP_RESERVED = (
+        "storedge_backup_reserved",
+        None,
+        "%",
+        0,
+        100,
+        1,
+        "slider",
+    )
+    STOREDGE_COMMAND_TIMEOUT = (
+        "storedge_command_timeout",
+        None,
+        "s",
+        0,
+        86400,
+        1,
+        "box",
+    )
+    STOREDGE_CHARGE_LIMIT = (
+        "storedge_charge_limit",
+        "power",
+        "W",
+        0,
+        20000,
+        1,
+        "box",
+    )
+    STOREDGE_DISCHARGE_LIMIT = (
+        "storedge_discharge_limit",
+        "power",
+        "W",
+        0,
+        20000,
+        1,
+        "box",
+    )
 
     def __init__(
         self,
@@ -198,6 +244,71 @@ class HomeAssistantNumberType(HomeAssistantEntityBaseType):
             "max": self._max,
             "step": self._step,
             "mode": self._mode,
+            **json_schema_extra,
+        }
+
+        return super().field(
+            title,
+            input_field,
+            **json_schema_extra,
+        )
+
+
+class HomeAssistantSelectType(HomeAssistantEntityBaseType):
+    STOREDGE_CONTROL_MODE = (
+        "storedge_control_mode",
+        {
+            0: "Disabled",
+            1: "Maximize Self Consumption",
+            2: "Time of Use",
+            3: "Backup Only",
+            4: "Remote Control",
+        },
+    )
+    STOREDGE_AC_CHARGE_POLICY = (
+        "storedge_ac_charge_policy",
+        {
+            0: "Disabled",
+            1: "Always Allowed",
+            2: "Fixed Energy Limit",
+            3: "Percent of Production",
+        },
+    )
+    STOREDGE_CHARGE_DISCHARGE_MODE = (
+        "storedge_charge_discharge_mode",
+        {
+            0: "Off",
+            1: "Charge from Clipped Solar Power",
+            2: "Charge from Solar Power",
+            3: "Charge from Solar Power and Grid",
+            4: "Discharge to Maximize Export",
+            5: "Discharge to Minimize Import",
+            7: "Maximize Self Consumption",
+        },
+    )
+
+    def __init__(self, key: str, options_map: dict[int, str]):
+        super().__init__(key, HomeAssistantType.SELECT, None, None, None)
+
+        self._options_map: dict[int, str] = options_map
+
+    @property
+    def options_map(self) -> dict[int, str]:
+        return self._options_map
+
+    @property
+    def options(self) -> list[str]:
+        return list(self._options_map.values())
+
+    def field(
+        self,
+        title: str | None = None,
+        input_field: BaseInputFieldEnumModel | None = None,
+        **json_schema_extra: Any,
+    ) -> dict[str, Any]:
+
+        json_schema_extra = {
+            "options": self.options,
             **json_schema_extra,
         }
 
@@ -249,6 +360,11 @@ class HomeAssistantSensorType(HomeAssistantEntityBaseType):
         )
 
 
+def _jinja_dict_literal(mapping: dict[Any, Any]) -> str:
+    items = ", ".join(f"{key!r}: {value!r}" for key, value in mapping.items())
+    return f"{{{items}}}"
+
+
 class HomeAssistantEntity(HomeAssistantBaseModel):
     name: str
     device: HomeAssistantDevice
@@ -256,6 +372,7 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
     path: list[str] | None = Field(None, exclude=True)
     ha_type: HomeAssistantEntityBaseType = Field(exclude=True)
     unit: str | None = Field(None, exclude=True)
+    command_topic_override: str | None = Field(None, exclude=True)
 
     _icon: str | None = PrivateAttr(default=None)
     _additional_fields: dict[str, Any] = PrivateAttr(default_factory=dict)
@@ -285,6 +402,9 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
         if not self.ha_type.typed.command_topic:
             return None
 
+        if self.command_topic_override:
+            return f"{self.device.state_topic}/{self.command_topic_override}"
+
         path = [self.device.state_topic]
 
         if self.path:
@@ -305,7 +425,26 @@ class HomeAssistantEntity(HomeAssistantBaseModel):
     @computed_field
     @property
     def value_template(self) -> str | None:
-        return f"{{{{ value_json.{'.'.join(self.path)} }}}}" if self.path else None
+        if not self.path:
+            return None
+
+        value_expr = f"value_json.{'.'.join(self.path)}"
+
+        if isinstance(self.ha_type, HomeAssistantSelectType):
+            mapping = _jinja_dict_literal(self.ha_type.options_map)
+            value_expr = f"{mapping}[{value_expr}]"
+
+        return f"{{{{ {value_expr} }}}}"
+
+    @computed_field
+    @property
+    def command_template(self) -> str | None:
+        if not isinstance(self.ha_type, HomeAssistantSelectType):
+            return None
+
+        reverse_map = {label: code for code, label in self.ha_type.options_map.items()}
+        mapping = _jinja_dict_literal(reverse_map)
+        return f"{{{{ {mapping}[value] }}}}"
 
     @computed_field
     @property

--- a/solaredge2mqtt/services/homeassistant/service.py
+++ b/solaredge2mqtt/services/homeassistant/service.py
@@ -244,4 +244,13 @@ class HomeAssistantDiscovery:
             if "command_topic" in prop:
                 entity["command_topic_override"] = prop["command_topic"]
 
+            if "options_map" in prop:
+                entity["options_map"] = prop["options_map"]
+
+            if "unit_of_measurement" in prop:
+                entity["unit"] = prop["unit_of_measurement"]
+
+            if "device_class" in prop:
+                entity["device_class_override"] = prop["device_class"]
+
         return entity

--- a/solaredge2mqtt/services/homeassistant/service.py
+++ b/solaredge2mqtt/services/homeassistant/service.py
@@ -23,6 +23,7 @@ from solaredge2mqtt.services.homeassistant.models import (
     HomeAssistantDevice,
     HomeAssistantEntity,
     HomeAssistantNumberType,
+    HomeAssistantSelectType,
     HomeAssistantSensorType,
     HomeAssistantStatus,
     HomeAssistantType,
@@ -147,6 +148,12 @@ class HomeAssistantDiscovery:
                 ):
                     continue
 
+                if (
+                    not self.settings.modbus.storedge_control_enabled
+                    and path[0] == "storedge_control"
+                ):
+                    continue
+
             if (
                 self.settings.prices.is_configured
                 and entity_info["ha_type"] == HomeAssistantSensorType.MONETARY
@@ -226,10 +233,15 @@ class HomeAssistantDiscovery:
                 entity["ha_type"] = HomeAssistantBinarySensorType.from_string(ha_type)
             elif typed == HomeAssistantType.NUMBER:
                 entity["ha_type"] = HomeAssistantNumberType.from_string(ha_type)
+            elif typed == HomeAssistantType.SELECT:
+                entity["ha_type"] = HomeAssistantSelectType.from_string(ha_type)
             elif typed == HomeAssistantType.SENSOR:
                 entity["ha_type"] = HomeAssistantSensorType.from_string(ha_type)
 
             for field in typed.additional_fields:
                 entity[field] = prop.get(field, None)
+
+            if "command_topic" in prop:
+                entity["command_topic_override"] = prop["command_topic"]
 
         return entity

--- a/solaredge2mqtt/services/modbus/models/inverter.py
+++ b/solaredge2mqtt/services/modbus/models/inverter.py
@@ -75,57 +75,113 @@ class ModbusInverter(ModbusComponent):
 
 REMOTE_CONTROL_MODE = 4
 
+STORAGE_CONTROL_MODE_OPTIONS = {
+    0: "Disabled",
+    1: "Maximize Self Consumption",
+    2: "Time of Use",
+    3: "Backup Only",
+    4: "Remote Control",
+}
+STORAGE_AC_CHARGE_POLICY_OPTIONS = {
+    0: "Disabled",
+    1: "Always Allowed",
+    2: "Fixed Energy Limit",
+    3: "Percent of Production",
+}
+STORAGE_CHARGE_DISCHARGE_MODE_OPTIONS = {
+    0: "Off",
+    1: "Charge from Clipped Solar Power",
+    2: "Charge from Solar Power",
+    3: "Charge from Solar Power and Grid",
+    4: "Discharge to Maximize Export",
+    5: "Discharge to Minimize Import",
+    7: "Maximize Self Consumption",
+}
+
 
 class ModbusStorEdgeControl(ModbusComponentValueGroup):
     storage_control_mode: int = Field(
-        **HASelect.STOREDGE_CONTROL_MODE.field(
-            "Storage control mode", command_topic="storedge/control_mode"
+        **HASelect.GENERIC.field(
+            "Storage control mode",
+            command_topic="storedge/control_mode",
+            options_map=STORAGE_CONTROL_MODE_OPTIONS,
         )
     )
     storage_ac_charge_policy: int = Field(
-        **HASelect.STOREDGE_AC_CHARGE_POLICY.field(
-            "Storage AC charge policy", command_topic="storedge/ac_charge_policy"
+        **HASelect.GENERIC.field(
+            "Storage AC charge policy",
+            command_topic="storedge/ac_charge_policy",
+            options_map=STORAGE_AC_CHARGE_POLICY_OPTIONS,
         )
     )
     storage_ac_charge_limit: float = Field(
-        **HANumber.STOREDGE_AC_CHARGE_LIMIT.field(
-            "Storage AC charge limit", command_topic="storedge/ac_charge_limit"
+        **HANumber.GENERIC.field(
+            "Storage AC charge limit",
+            command_topic="storedge/ac_charge_limit",
+            min=0,
+            max=100000,
+            step=1,
+            mode="box",
         )
     )
     storage_backup_reserved_setting: float = Field(
-        **HANumber.STOREDGE_BACKUP_RESERVED.field(
+        **HANumber.GENERIC.field(
             "Storage backup reserved setting",
             command_topic="storedge/backup_reserved_setting",
+            unit_of_measurement="%",
+            min=0,
+            max=100,
+            step=1,
+            mode="slider",
         )
     )
     storage_default_mode: int = Field(
-        **HASelect.STOREDGE_CHARGE_DISCHARGE_MODE.field(
+        **HASelect.GENERIC.field(
             "Storage default mode (Remote Control mode only)",
             command_topic="storedge/default_mode",
+            options_map=STORAGE_CHARGE_DISCHARGE_MODE_OPTIONS,
         )
     )
     remote_control_command_timeout: int = Field(
-        **HANumber.STOREDGE_COMMAND_TIMEOUT.field(
+        **HANumber.GENERIC.field(
             "Remote control command timeout (Remote Control mode only)",
             command_topic="storedge/command_timeout",
+            unit_of_measurement="s",
+            min=0,
+            max=86400,
+            step=1,
+            mode="box",
         )
     )
     remote_control_command_mode: int = Field(
-        **HASelect.STOREDGE_CHARGE_DISCHARGE_MODE.field(
+        **HASelect.GENERIC.field(
             "Remote control command mode (Remote Control mode only)",
             command_topic="storedge/command_mode",
+            options_map=STORAGE_CHARGE_DISCHARGE_MODE_OPTIONS,
         )
     )
     remote_control_charge_limit: float = Field(
-        **HANumber.STOREDGE_CHARGE_LIMIT.field(
+        **HANumber.GENERIC.field(
             "Remote control charge limit (Remote Control mode only)",
             command_topic="storedge/charge_limit",
+            device_class="power",
+            unit_of_measurement="W",
+            min=0,
+            max=20000,
+            step=1,
+            mode="box",
         )
     )
     remote_control_discharge_limit: float = Field(
-        **HANumber.STOREDGE_DISCHARGE_LIMIT.field(
+        **HANumber.GENERIC.field(
             "Remote control discharge limit (Remote Control mode only)",
             command_topic="storedge/discharge_limit",
+            device_class="power",
+            unit_of_measurement="W",
+            min=0,
+            max=20000,
+            step=1,
+            mode="box",
         )
     )
 

--- a/solaredge2mqtt/services/modbus/models/inverter.py
+++ b/solaredge2mqtt/services/modbus/models/inverter.py
@@ -8,6 +8,12 @@ from solaredge2mqtt.services.homeassistant.models import (
     HomeAssistantBinarySensorType as HABinarySensor,
 )
 from solaredge2mqtt.services.homeassistant.models import (
+    HomeAssistantNumberType as HANumber,
+)
+from solaredge2mqtt.services.homeassistant.models import (
+    HomeAssistantSelectType as HASelect,
+)
+from solaredge2mqtt.services.homeassistant.models import (
     HomeAssistantSensorType as HASensor,
 )
 from solaredge2mqtt.services.modbus.models.base import ModbusComponent
@@ -71,18 +77,56 @@ REMOTE_CONTROL_MODE = 4
 
 
 class ModbusStorEdgeControl(ModbusComponentValueGroup):
-    storage_control_mode: int = Field(title="Storage control mode")
-    storage_ac_charge_policy: int = Field(title="Storage AC charge policy")
-    storage_ac_charge_limit: float = Field(title="Storage AC charge limit")
-    storage_backup_reserved_setting: float = Field(
-        title="Storage backup reserved setting"
+    storage_control_mode: int = Field(
+        **HASelect.STOREDGE_CONTROL_MODE.field(
+            "Storage control mode", command_topic="storedge/control_mode"
+        )
     )
-    storage_default_mode: int = Field(title="Storage default mode")
-    remote_control_command_timeout: int = Field(title="Remote control command timeout")
-    remote_control_command_mode: int = Field(title="Remote control command mode")
-    remote_control_charge_limit: float = Field(title="Remote control charge limit")
+    storage_ac_charge_policy: int = Field(
+        **HASelect.STOREDGE_AC_CHARGE_POLICY.field(
+            "Storage AC charge policy", command_topic="storedge/ac_charge_policy"
+        )
+    )
+    storage_ac_charge_limit: float = Field(
+        **HANumber.STOREDGE_AC_CHARGE_LIMIT.field(
+            "Storage AC charge limit", command_topic="storedge/ac_charge_limit"
+        )
+    )
+    storage_backup_reserved_setting: float = Field(
+        **HANumber.STOREDGE_BACKUP_RESERVED.field(
+            "Storage backup reserved setting",
+            command_topic="storedge/backup_reserved_setting",
+        )
+    )
+    storage_default_mode: int = Field(
+        **HASelect.STOREDGE_CHARGE_DISCHARGE_MODE.field(
+            "Storage default mode (Remote Control mode only)",
+            command_topic="storedge/default_mode",
+        )
+    )
+    remote_control_command_timeout: int = Field(
+        **HANumber.STOREDGE_COMMAND_TIMEOUT.field(
+            "Remote control command timeout (Remote Control mode only)",
+            command_topic="storedge/command_timeout",
+        )
+    )
+    remote_control_command_mode: int = Field(
+        **HASelect.STOREDGE_CHARGE_DISCHARGE_MODE.field(
+            "Remote control command mode (Remote Control mode only)",
+            command_topic="storedge/command_mode",
+        )
+    )
+    remote_control_charge_limit: float = Field(
+        **HANumber.STOREDGE_CHARGE_LIMIT.field(
+            "Remote control charge limit (Remote Control mode only)",
+            command_topic="storedge/charge_limit",
+        )
+    )
     remote_control_discharge_limit: float = Field(
-        title="Remote control discharge limit"
+        **HANumber.STOREDGE_DISCHARGE_LIMIT.field(
+            "Remote control discharge limit (Remote Control mode only)",
+            command_topic="storedge/discharge_limit",
+        )
     )
 
     @classmethod

--- a/solaredge2mqtt/services/monitoring/models.py
+++ b/solaredge2mqtt/services/monitoring/models.py
@@ -131,8 +131,14 @@ class EVCharger(Component):
     info: SkipJsonSchema[EVChargerInfo]
 
     charge_level: int = Field(
-        **HANumber.EV_CHARGE_LEVEL.field(
-            "Charge level", input_field=EVChargerControlInput.CHARGE_LEVEL
+        **HANumber.GENERIC.field(
+            "Charge level",
+            input_field=EVChargerControlInput.CHARGE_LEVEL,
+            unit_of_measurement="%",
+            min=0,
+            max=100,
+            step=100,
+            mode="slider",
         )
     )
     charger_status: str = Field(**HASensor.STATUS.field("Charger status"))

--- a/tests/services/homeassistant/test_models.py
+++ b/tests/services/homeassistant/test_models.py
@@ -9,6 +9,7 @@ from solaredge2mqtt.services.homeassistant.models import (
     HomeAssistantDevice,
     HomeAssistantEntity,
     HomeAssistantNumberType,
+    HomeAssistantSelectType,
     HomeAssistantSensorType,
     HomeAssistantStatus,
     HomeAssistantStatusInput,
@@ -152,6 +153,39 @@ class TestHomeAssistantNumberType:
         assert number._max == 100
         assert number._step == 100
         assert number._mode == "slider"
+
+
+class TestHomeAssistantSelectType:
+    """Tests for HomeAssistantSelectType enum."""
+
+    def test_storedge_control_mode_type(self):
+        """Test STOREDGE_CONTROL_MODE select type."""
+        select = HomeAssistantSelectType.STOREDGE_CONTROL_MODE
+
+        assert select.typed == HomeAssistantType.SELECT
+        assert select.options_map[4] == "Remote Control"
+        assert select.options == [
+            "Disabled",
+            "Maximize Self Consumption",
+            "Time of Use",
+            "Backup Only",
+            "Remote Control",
+        ]
+
+    def test_storedge_charge_discharge_mode_skips_reserved_value(self):
+        """Test the shared charge/discharge mode map has no entry for value 6."""
+        select = HomeAssistantSelectType.STOREDGE_CHARGE_DISCHARGE_MODE
+
+        assert 6 not in select.options_map
+        assert select.options_map[7] == "Maximize Self Consumption"
+
+    def test_field_includes_options(self):
+        """Test field() injects the options list into json_schema_extra."""
+        select = HomeAssistantSelectType.STOREDGE_AC_CHARGE_POLICY
+
+        result = select.field("Storage AC charge policy")
+
+        assert result["json_schema_extra"]["options"] == select.options
 
 
 class TestHomeAssistantSensorType:
@@ -570,6 +604,86 @@ class TestHomeAssistantEntity:
         )
 
         assert entity.command_topic == "solaredge/inverter"
+
+    def test_entity_command_topic_uses_override(self):
+        """Test command_topic prefers command_topic_override over the schema path."""
+        device = HomeAssistantDevice(
+            client_id="test_client",
+            name="Test Device",
+            state_topic="solaredge/modbus/inverter",
+        )
+
+        entity = HomeAssistantEntity(
+            device=device,
+            name="Storage control mode",
+            path=["storedge_control", "storage_control_mode"],
+            ha_type=HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
+            options=HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+            command_topic_override="storedge/control_mode",
+        )
+
+        assert entity.command_topic == "solaredge/modbus/inverter/storedge/control_mode"
+
+    def test_entity_value_template_select_maps_int_to_label(self):
+        """Test value_template wraps the path in a dict lookup for select types."""
+        device = HomeAssistantDevice(
+            client_id="test_client",
+            name="Test Device",
+            state_topic="solaredge/modbus/inverter",
+        )
+
+        entity = HomeAssistantEntity(
+            device=device,
+            name="Storage control mode",
+            path=["storedge_control", "storage_control_mode"],
+            ha_type=HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
+            options=HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+        )
+
+        template = entity.value_template
+
+        assert template is not None
+        assert "value_json.storedge_control.storage_control_mode" in template
+        assert "'Remote Control'" in template
+
+    def test_entity_command_template_for_select(self):
+        """Test command_template reverses the options map for select types."""
+        device = HomeAssistantDevice(
+            client_id="test_client",
+            name="Test Device",
+            state_topic="solaredge/modbus/inverter",
+        )
+
+        entity = HomeAssistantEntity(
+            device=device,
+            name="Storage control mode",
+            path=["storedge_control", "storage_control_mode"],
+            ha_type=HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
+            options=HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+        )
+
+        template = entity.command_template
+
+        assert template is not None
+        assert "'Remote Control': 4" in template
+        assert "[value]" in template
+
+    def test_entity_command_template_none_for_non_select(self):
+        """Test command_template is None for non-select entity types."""
+        device = HomeAssistantDevice(
+            client_id="test_client",
+            name="Test Device",
+            state_topic="solaredge/inverter",
+        )
+
+        entity = HomeAssistantEntity(
+            device=device,
+            name="Power",
+            path=["power"],
+            ha_type=HomeAssistantSensorType.POWER_W,
+        )
+
+        assert entity.command_template is None
 
     def test_entity_model_dump_json(self):
         """Test model_dump_json includes additional fields."""

--- a/tests/services/homeassistant/test_models.py
+++ b/tests/services/homeassistant/test_models.py
@@ -16,6 +16,14 @@ from solaredge2mqtt.services.homeassistant.models import (
     HomeAssistantType,
 )
 
+STOREDGE_CONTROL_MODE_OPTIONS = {
+    0: "Disabled",
+    1: "Maximize Self Consumption",
+    2: "Time of Use",
+    3: "Backup Only",
+    4: "Remote Control",
+}
+
 
 class TestHomeAssistantStatus:
     """Tests for HomeAssistantStatus enum."""
@@ -143,49 +151,60 @@ class TestHomeAssistantBinarySensorType:
 class TestHomeAssistantNumberType:
     """Tests for HomeAssistantNumberType enum."""
 
-    def test_ev_charge_level_type(self):
-        """Test EV_CHARGE_LEVEL number type."""
-        number = HomeAssistantNumberType.EV_CHARGE_LEVEL
+    def test_generic_number_type_field_kwargs(self):
+        """Test GENERIC number type applies field() kwargs."""
+        number = HomeAssistantNumberType.GENERIC
 
         assert number.typed == HomeAssistantType.NUMBER
-        assert number.unit_of_measurement == "%"
-        assert number._min == 0
-        assert number._max == 100
-        assert number._step == 100
-        assert number._mode == "slider"
+
+        result = number.field(
+            "Charge level",
+            unit_of_measurement="%",
+            min=0,
+            max=100,
+            step=100,
+            mode="slider",
+        )
+
+        assert result["json_schema_extra"]["min"] == 0
+        assert result["json_schema_extra"]["max"] == 100
+        assert result["json_schema_extra"]["step"] == 100
+        assert result["json_schema_extra"]["mode"] == "slider"
+        assert result["json_schema_extra"]["unit_of_measurement"] == "%"
 
 
 class TestHomeAssistantSelectType:
     """Tests for HomeAssistantSelectType enum."""
 
-    def test_storedge_control_mode_type(self):
-        """Test STOREDGE_CONTROL_MODE select type."""
-        select = HomeAssistantSelectType.STOREDGE_CONTROL_MODE
+    def test_generic_select_type(self):
+        """Test GENERIC select type properties."""
+        select = HomeAssistantSelectType.GENERIC
 
         assert select.typed == HomeAssistantType.SELECT
-        assert select.options_map[4] == "Remote Control"
-        assert select.options == [
-            "Disabled",
-            "Maximize Self Consumption",
-            "Time of Use",
-            "Backup Only",
-            "Remote Control",
-        ]
 
-    def test_storedge_charge_discharge_mode_skips_reserved_value(self):
-        """Test the shared charge/discharge mode map has no entry for value 6."""
-        select = HomeAssistantSelectType.STOREDGE_CHARGE_DISCHARGE_MODE
+    def test_field_includes_options_map(self):
+        """Test field() injects options + options_map into json_schema_extra."""
+        select = HomeAssistantSelectType.GENERIC
+        options_map = {
+            0: "Disabled",
+            1: "Always Allowed",
+            2: "Fixed Energy Limit",
+            3: "Percent of Production",
+        }
 
-        assert 6 not in select.options_map
-        assert select.options_map[7] == "Maximize Self Consumption"
+        result = select.field("Storage AC charge policy", options_map=options_map)
 
-    def test_field_includes_options(self):
-        """Test field() injects the options list into json_schema_extra."""
-        select = HomeAssistantSelectType.STOREDGE_AC_CHARGE_POLICY
+        assert result["json_schema_extra"]["options"] == list(options_map.values())
+        assert result["json_schema_extra"]["options_map"] == options_map
 
-        result = select.field("Storage AC charge policy")
+    def test_field_without_options_map(self):
+        """Test field() defaults to empty options list without options_map."""
+        select = HomeAssistantSelectType.GENERIC
 
-        assert result["json_schema_extra"]["options"] == select.options
+        result = select.field("Some select")
+
+        assert result["json_schema_extra"]["options"] == []
+        assert result["json_schema_extra"]["options_map"] is None
 
 
 class TestHomeAssistantSensorType:
@@ -567,7 +586,7 @@ class TestHomeAssistantEntity:
             device=device,
             name="Power Limit",
             path=["power_limit"],
-            ha_type=HomeAssistantNumberType.EV_CHARGE_LEVEL,
+            ha_type=HomeAssistantNumberType.GENERIC,
         )
 
         assert entity.command_topic == "solaredge/inverter/power_limit"
@@ -600,7 +619,7 @@ class TestHomeAssistantEntity:
         entity = HomeAssistantEntity(
             device=device,
             name="Power Limit",
-            ha_type=HomeAssistantNumberType.EV_CHARGE_LEVEL,
+            ha_type=HomeAssistantNumberType.GENERIC,
         )
 
         assert entity.command_topic == "solaredge/inverter"
@@ -617,8 +636,8 @@ class TestHomeAssistantEntity:
             device=device,
             name="Storage control mode",
             path=["storedge_control", "storage_control_mode"],
-            ha_type=HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
-            options=HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+            ha_type=HomeAssistantSelectType.GENERIC,
+            options_map=STOREDGE_CONTROL_MODE_OPTIONS,
             command_topic_override="storedge/control_mode",
         )
 
@@ -636,8 +655,8 @@ class TestHomeAssistantEntity:
             device=device,
             name="Storage control mode",
             path=["storedge_control", "storage_control_mode"],
-            ha_type=HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
-            options=HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+            ha_type=HomeAssistantSelectType.GENERIC,
+            options_map=STOREDGE_CONTROL_MODE_OPTIONS,
         )
 
         template = entity.value_template
@@ -658,8 +677,8 @@ class TestHomeAssistantEntity:
             device=device,
             name="Storage control mode",
             path=["storedge_control", "storage_control_mode"],
-            ha_type=HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
-            options=HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+            ha_type=HomeAssistantSelectType.GENERIC,
+            options_map=STOREDGE_CONTROL_MODE_OPTIONS,
         )
 
         template = entity.command_template
@@ -697,7 +716,7 @@ class TestHomeAssistantEntity:
             device=device,
             name="Power Limit",
             path=["power_limit"],
-            ha_type=HomeAssistantNumberType.EV_CHARGE_LEVEL,
+            ha_type=HomeAssistantNumberType.GENERIC,
             min=0,
             max=100,
             step=1,

--- a/tests/services/homeassistant/test_service.py
+++ b/tests/services/homeassistant/test_service.py
@@ -180,7 +180,7 @@ class TestHomeAssistantDiscoveryPropertyParser:
     def test_property_parser_number_type(self):
         """Test property_parser with number type."""
         prop = {
-            "ha_type": "charge_level",
+            "ha_type": "number",
             "ha_typed": "number",
             "icon": "mdi:gauge",
         }
@@ -193,7 +193,7 @@ class TestHomeAssistantDiscoveryPropertyParser:
     def test_property_parser_select_type(self):
         """Test property_parser with select type."""
         prop = {
-            "ha_type": "storedge_control_mode",
+            "ha_type": "select",
             "ha_typed": "select",
             "icon": None,
             "options": ["Disabled", "Remote Control"],
@@ -210,7 +210,7 @@ class TestHomeAssistantDiscoveryPropertyParser:
     def test_property_parser_picks_up_command_topic_override(self):
         """Test property_parser carries a command_topic override into entity_info."""
         prop = {
-            "ha_type": "storedge_control_mode",
+            "ha_type": "select",
             "ha_typed": "select",
             "icon": None,
             "options": ["Disabled", "Remote Control"],
@@ -568,8 +568,14 @@ class TestHomeAssistantDiscoveryPublishComponent:
                 "name": "Storage control mode",
                 "path": ["storedge_control", "storage_control_mode"],
                 "icon": None,
-                "ha_type": HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
-                "options": HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+                "ha_type": HomeAssistantSelectType.GENERIC,
+                "options": [
+                    "Disabled",
+                    "Maximize Self Consumption",
+                    "Time of Use",
+                    "Backup Only",
+                    "Remote Control",
+                ],
                 "command_topic_override": "storedge/control_mode",
             },
             {
@@ -613,8 +619,14 @@ class TestHomeAssistantDiscoveryPublishComponent:
                 "name": "Storage control mode",
                 "path": ["storedge_control", "storage_control_mode"],
                 "icon": None,
-                "ha_type": HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
-                "options": HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+                "ha_type": HomeAssistantSelectType.GENERIC,
+                "options": [
+                    "Disabled",
+                    "Maximize Self Consumption",
+                    "Time of Use",
+                    "Backup Only",
+                    "Remote Control",
+                ],
                 "command_topic_override": "storedge/control_mode",
             },
         ]
@@ -668,7 +680,7 @@ class TestHomeAssistantPropertyParserAdditionalFields:
     def test_property_parser_number_type_with_additional_fields(self):
         """Test property_parser with number type and additional fields."""
         prop = {
-            "ha_type": "charge_level",
+            "ha_type": "number",
             "ha_typed": "number",
             "icon": "mdi:gauge",
             "min": 0,

--- a/tests/services/homeassistant/test_service.py
+++ b/tests/services/homeassistant/test_service.py
@@ -13,6 +13,7 @@ from solaredge2mqtt.services.homeassistant.events import HomeAssistantStatusEven
 from solaredge2mqtt.services.homeassistant.models import (
     HomeAssistantBinarySensorType,
     HomeAssistantNumberType,
+    HomeAssistantSelectType,
     HomeAssistantSensorType,
     HomeAssistantStatus,
     HomeAssistantStatusInput,
@@ -43,6 +44,7 @@ def mock_service_settings():
     settings.modbus = MagicMock()
     settings.modbus.has_followers = False
     settings.modbus.check_grid_status = True
+    settings.modbus.storedge_control_enabled = True
 
     settings.is_prices_configured = False
     settings.prices = MagicMock()
@@ -187,6 +189,53 @@ class TestHomeAssistantDiscoveryPropertyParser:
 
         assert result is not None
         assert isinstance(result["ha_type"], HomeAssistantNumberType)
+
+    def test_property_parser_select_type(self):
+        """Test property_parser with select type."""
+        prop = {
+            "ha_type": "storedge_control_mode",
+            "ha_typed": "select",
+            "icon": None,
+            "options": ["Disabled", "Remote Control"],
+        }
+
+        result = HomeAssistantDiscovery.property_parser(
+            prop, "Storage control mode", ["storedge_control", "storage_control_mode"]
+        )
+
+        assert result is not None
+        assert isinstance(result["ha_type"], HomeAssistantSelectType)
+        assert result["options"] == ["Disabled", "Remote Control"]
+
+    def test_property_parser_picks_up_command_topic_override(self):
+        """Test property_parser carries a command_topic override into entity_info."""
+        prop = {
+            "ha_type": "storedge_control_mode",
+            "ha_typed": "select",
+            "icon": None,
+            "options": ["Disabled", "Remote Control"],
+            "command_topic": "storedge/control_mode",
+        }
+
+        result = HomeAssistantDiscovery.property_parser(
+            prop, "Storage control mode", ["storedge_control", "storage_control_mode"]
+        )
+
+        assert result is not None
+        assert result["command_topic_override"] == "storedge/control_mode"
+
+    def test_property_parser_without_command_topic_override(self):
+        """Test property_parser omits command_topic_override when not present."""
+        prop = {
+            "ha_type": "power_w",
+            "ha_typed": "sensor",
+            "icon": None,
+        }
+
+        result = HomeAssistantDiscovery.property_parser(prop, "Power", ["power"])
+
+        assert result is not None
+        assert "command_topic_override" not in result
 
 
 class TestHomeAssistantDiscoveryComponentDiscovery:
@@ -498,6 +547,89 @@ class TestHomeAssistantDiscoveryPublishComponent:
         # Grid status should be filtered out
         # Check the emitted events
         assert mock_event_bus.emit.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_publish_component_filters_storedge_control_when_disabled(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test publish_component skips storedge_control fields when disabled."""
+        from solaredge2mqtt.services.modbus.models.inverter import (
+            ModbusInverter,
+        )
+
+        mock_service_settings.modbus.storedge_control_enabled = False
+
+        discovery = HomeAssistantDiscovery(mock_service_settings)
+
+        mock_inverter = MagicMock(spec=ModbusInverter)
+        mock_inverter.mqtt_topic.return_value = "modbus/inverter"
+        mock_inverter.parse_schema.return_value = [
+            {
+                "name": "Storage control mode",
+                "path": ["storedge_control", "storage_control_mode"],
+                "icon": None,
+                "ha_type": HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
+                "options": HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+                "command_topic_override": "storedge/control_mode",
+            },
+            {
+                "name": "Power",
+                "path": ["power"],
+                "icon": "mdi:lightning-bolt",
+                "ha_type": HomeAssistantSensorType.POWER_W,
+            },
+        ]
+
+        device_info = {"name": "Inverter"}
+        state_topic = "solaredge/modbus/inverter"
+
+        await discovery.publish_component(mock_inverter, device_info, state_topic)
+
+        published_names = [
+            call.args[0].payload.name
+            for call in mock_event_bus.emit.call_args_list
+            if call.args and hasattr(call.args[0], "payload")
+        ]
+        assert "Storage control mode" not in published_names
+        assert "Power" in published_names
+
+    @pytest.mark.asyncio
+    async def test_publish_component_includes_storedge_control_when_enabled(
+        self, mock_service_settings, mock_event_bus
+    ):
+        """Test publish_component includes storedge_control fields when enabled."""
+        from solaredge2mqtt.services.modbus.models.inverter import (
+            ModbusInverter,
+        )
+
+        mock_service_settings.modbus.storedge_control_enabled = True
+
+        discovery = HomeAssistantDiscovery(mock_service_settings)
+
+        mock_inverter = MagicMock(spec=ModbusInverter)
+        mock_inverter.mqtt_topic.return_value = "modbus/inverter"
+        mock_inverter.parse_schema.return_value = [
+            {
+                "name": "Storage control mode",
+                "path": ["storedge_control", "storage_control_mode"],
+                "icon": None,
+                "ha_type": HomeAssistantSelectType.STOREDGE_CONTROL_MODE,
+                "options": HomeAssistantSelectType.STOREDGE_CONTROL_MODE.options,
+                "command_topic_override": "storedge/control_mode",
+            },
+        ]
+
+        device_info = {"name": "Inverter"}
+        state_topic = "solaredge/modbus/inverter"
+
+        await discovery.publish_component(mock_inverter, device_info, state_topic)
+
+        published_names = [
+            call.args[0].payload.name
+            for call in mock_event_bus.emit.call_args_list
+            if call.args and hasattr(call.args[0], "payload")
+        ]
+        assert "Storage control mode" in published_names
 
     @pytest.mark.asyncio
     async def test_publish_component_with_monetary_type(

--- a/tests/services/modbus/test_inverter.py
+++ b/tests/services/modbus/test_inverter.py
@@ -254,3 +254,28 @@ class TestModbusStorEdgeControl:
         assert control.remote_control_command_mode == 0
         assert control.remote_control_charge_limit == pytest.approx(5000.0)
         assert control.remote_control_discharge_limit == pytest.approx(5000.0)
+
+    def test_storedge_control_fields_carry_ha_command_topics(self):
+        """Test each field exposes the short write-topic suffix from Phase 2."""
+        from solaredge2mqtt.services.homeassistant.service import (
+            HomeAssistantDiscovery,
+        )
+
+        entities = ModbusStorEdgeControl.parse_schema(
+            HomeAssistantDiscovery.property_parser
+        )
+        command_topics = {
+            entity["path"][0]: entity["command_topic_override"] for entity in entities
+        }
+
+        assert command_topics == {
+            "storage_control_mode": "storedge/control_mode",
+            "storage_ac_charge_policy": "storedge/ac_charge_policy",
+            "storage_ac_charge_limit": "storedge/ac_charge_limit",
+            "storage_backup_reserved_setting": "storedge/backup_reserved_setting",
+            "storage_default_mode": "storedge/default_mode",
+            "remote_control_command_timeout": "storedge/command_timeout",
+            "remote_control_command_mode": "storedge/command_mode",
+            "remote_control_charge_limit": "storedge/charge_limit",
+            "remote_control_discharge_limit": "storedge/discharge_limit",
+        }


### PR DESCRIPTION
## Summary
- New `HomeAssistantSelectType` (new `SELECT` entity type, mirrors the existing `NUMBER` machinery) for the 4 enum-valued StorEdge fields (`control_mode`, `ac_charge_policy`, `default_mode`, `command_mode`) — HA shows SolarEdge's own mode names ("Remote Control", "Maximize Self Consumption", ...) instead of raw integers.
- `value_template`/`command_template` on `HomeAssistantEntity` do the int↔label mapping via a Jinja dict-literal built from the same `options_map` used for `options` — the backend still only ever sees plain integers on the MQTT topics from Phase 2, no protocol change.
- 5 numeric fields (`ac_charge_limit`, `backup_reserved_setting`, `command_timeout`, `charge_limit`, `discharge_limit`) get `HomeAssistantNumberType` entries.
- **Command topic mismatch fix**: `HomeAssistantEntity.command_topic` normally derives from the schema path (`state_topic + path`), which would produce `modbus/inverter/storedge_control/storage_control_mode` — not the actual write topic from Phase 2 (`modbus/inverter/storedge/control_mode`, shortened per earlier review feedback). Added an explicit `command_topic_override` (relative to `state_topic`) that each StorEdge field now carries, verified byte-for-byte against the real subscribed topic.
- Entities gated behind `storedge_control_enabled`, mirroring the existing `check_grid_status` gate — nothing discovered unless the block is actually being read.

Completes the StorEdge battery control plan for issue #185:
- Phase 0 (merged, #428): remove legacy `advanced_power_controls` scaffolding
- Phase 1 (merged, #429): register map + read model + read wiring
- Phase 2 (merged, #430): MQTT write module
- **Phase 3 (this PR)**: Home Assistant discovery

## Test plan
- [x] `pytest -q` — 1449 passed (26 new)
- [x] `ruff check` — clean
- [x] pre-commit hooks (ruff, pyright) passed on commit
- [x] Manually verified generated discovery JSON for a select and a number entity (correct `command_topic`, `value_template`, `command_template`)
- [x] Verified end-to-end via `ModbusStorEdgeControl.parse_schema(HomeAssistantDiscovery.property_parser)` that all 9 fields produce the exact command topics Phase 2's `StorEdgeControl` module subscribes to
- [ ] Live check against a real Home Assistant instance (dropdown renders correctly, selecting an option actually writes) — not yet done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2qeDJSQwhLmT3UeVt2iJV