### PR TITLE
chore(deps): update pvlearn to 0.4.0

### DIFF
--- a/docs/decisions/0003-weather-provider-as-a-feature.md
+++ b/docs/decisions/0003-weather-provider-as-a-feature.md
@@ -1,0 +1,20 @@
+# 0003 — The weather provider is stamped onto every row
+
+**Status:** Accepted
+**Context:** pvlearn 0.4.0 removed `ForecasterConfig.weather_provider` and turned `weather_provider` into a categorical feature of `pvlearn.schema`. Which provider a row came from is a per-row fact of the training data, not a training-run setting, so the library expects the adapter to supply it with the data. The same release also dropped `feature_schema_version`, `pipeline_version` and `sklearn_version` from the model sidecar in favour of the pvlearn release segment ([pvlearn ADR 0003](https://github.com/LearningHouseService/pvlearn/blob/main/docs/adr/0003-one-version-decides-model-compatibility.md)).
+
+## Decision 1: the adapter stamps its own name, InfluxDB stores nothing
+
+**Decision:** `OpenWeatherMapBaseData.PROVIDER_NAME` is written into every row by `to_canonical()` and `to_canonical_frame()`, on the way to the model. The `forecast_training` measurement gains no `weather_provider` field.
+
+**Context:** Every stored snapshot was written by this adapter, so the provider of a row is derivable from where the row comes from, not something that has to be read back. Following [ADR 0002, Decision 1](0002-canonical-weather-schema.md), the measurement holds what the provider delivered; the provider's own name is not part of that payload.
+
+**Consequence:** The constant lives on the weather model next to the mapping table rather than in `forecast/service.py`, where `WEATHER_PROVIDER` used to sit: a second provider brings its own name along with its own mapping, and no code in the forecast service has to know which one produced a row. Rows stored before this change get the same stamp on read, which is correct — OpenWeatherMap wrote them.
+
+## Decision 2: nothing has to migrate for a pvlearn release
+
+**Decision:** No compatibility handling for the changed feature set. `ForecastService` never calls `Forecaster.save()` or `load()`: the model lives in memory and is trained from `forecast_training` on the first prediction after a start.
+
+**Context:** pvlearn's model sidecar and its version check exist for callers that persist a model across upgrades. A model trained on a different feature vocabulary keeps predicting plausible numbers, which is why loading one is a hard error there — a situation this service never reaches.
+
+**Consequence:** A pvlearn bump costs one retrain, on a path the service already takes at every start. The stored `forecast_training` history is untouched and remains that retrain's input. Persisting the model later means honouring the sidecar's `SchemaMismatchError` and retraining on it, not defeating the check.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
     "pyarrow==25.0.0",
 ]
 forecast = [
-    "pvlearn==0.2.2",
+    "pvlearn==0.4.0",
 ]
 
 [build-system]

--- a/solaredge2mqtt/services/forecast/service.py
+++ b/solaredge2mqtt/services/forecast/service.py
@@ -36,8 +36,6 @@ LOCAL_TZ = get_localzone()
 #: Resolution of the weather forecast, the training data and the prediction.
 INTERVAL_MINUTES = 60
 
-WEATHER_PROVIDER = "openweathermap"
-
 ENERGY_FIELD = "energy"
 POWER_FIELD = "power"
 
@@ -63,7 +61,6 @@ class ForecastService:
         )
         forecaster_config = ForecasterConfig(
             interval_minutes=INTERVAL_MINUTES,
-            weather_provider=WEATHER_PROVIDER,
             hyperparametertuning=settings.hyperparametertuning,
             cachingdir=settings.cachingdir,
             cache_size_limit_mb=settings.cache_size_limit_mb,

--- a/solaredge2mqtt/services/weather/models.py
+++ b/solaredge2mqtt/services/weather/models.py
@@ -142,6 +142,12 @@ class OpenWeatherMapBaseData(Solaredge2MQTTBaseModel):
 
     CONDITION_FIELD: ClassVar[str] = "weather_id"
 
+    #: Canonical feature naming the provider a row came from. pvlearn treats it
+    #: as a per-row categorical feature rather than a training-run setting, so
+    #: the adapter stamps its own name onto every row it hands over.
+    PROVIDER_FIELD: ClassVar[str] = "weather_provider"
+    PROVIDER_NAME: ClassVar[str] = "openweathermap"
+
     #: Columns of a `forecast_training` frame the forecaster needs under their
     #: stored names, next to the translated weather fields.
     TRAINING_FIELDS: ClassVar[tuple[str, ...]] = ("time", "energy")
@@ -219,7 +225,7 @@ class OpenWeatherMapBaseData(Solaredge2MQTTBaseModel):
     @classmethod
     def to_canonical(cls, estimation_data: Mapping[str, Any]) -> WeatherData:
         """Rename one weather snapshot onto the canonical schema."""
-        canonical: WeatherData = {}
+        canonical: WeatherData = {cls.PROVIDER_FIELD: cls.PROVIDER_NAME}
 
         for field, value in estimation_data.items():
             canonical_name = cls.CANONICAL_FIELDS.get(field)
@@ -242,7 +248,8 @@ class OpenWeatherMapBaseData(Solaredge2MQTTBaseModel):
         Columns without a canonical counterpart are dropped, except the
         `TRAINING_FIELDS`, which the forecaster needs under those exact names.
         Rows older than a field's introduction simply carry NaN, which the
-        forecaster tolerates.
+        forecaster tolerates. Every row is stamped with `PROVIDER_NAME`: the
+        stored snapshots all come from this adapter.
         """
         canonical = data.copy()
 
@@ -259,6 +266,7 @@ class OpenWeatherMapBaseData(Solaredge2MQTTBaseModel):
             "DataFrame", canonical[[col for col in canonical.columns if col in keep]]
         )
         canonical.columns = [keep[str(col)] for col in canonical.columns]
+        canonical[cls.PROVIDER_FIELD] = cls.PROVIDER_NAME
 
         return canonical
 

--- a/tests/services/forecast/test_service.py
+++ b/tests/services/forecast/test_service.py
@@ -115,7 +115,6 @@ class TestForecastServiceInit:
 
         assert isinstance(service.forecaster, Forecaster)
         assert service.forecaster.config.interval_minutes == 60
-        assert service.forecaster.config.weather_provider == "openweathermap"
 
     def test_forecast_service_subscribes_events(self, mock_event_bus):
         """Test ForecastService registers event handlers."""
@@ -815,8 +814,10 @@ class TestForecastServiceTrain:
             ENERGY_FIELD,
             "cloud_cover",
             "condition_code",
+            "weather_provider",
         ]
         assert trained_with["condition_code"].iloc[0] == 0
+        assert trained_with["weather_provider"].iloc[0] == "openweathermap"
 
     def test_training_wraps_pvlearn_errors(self):
         """pvlearn errors should surface as InvalidDataException."""

--- a/tests/services/weather/test_models.py
+++ b/tests/services/weather/test_models.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 
 import pytest
-from pandas import DataFrame, isna
+from pandas import DataFrame, concat, isna
 from pvlearn.schema import (
     CATEGORICAL_FEATURES,
     CYCLICAL_FEATURES,
@@ -346,6 +346,16 @@ class TestCanonicalMapping:
 
         assert not {"ghi", "dni", "dhi"} & mapped
 
+    def test_provider_field_is_a_canonical_categorical(self):
+        """pvlearn learns the provider per row, so the name has to match."""
+        assert OpenWeatherMapBaseData.PROVIDER_FIELD in CATEGORICAL_FEATURES
+
+    def test_provider_is_not_read_off_the_payload(self):
+        """The adapter stamps its own name; no provider field maps onto it."""
+        assert OpenWeatherMapBaseData.PROVIDER_FIELD not in (
+            OpenWeatherMapBaseData.CANONICAL_FIELDS.values()
+        )
+
 
 class TestToWmoCode:
     """Tests for translating condition ids to WMO codes."""
@@ -399,6 +409,7 @@ class TestToCanonical:
         )
 
         assert canonical == {
+            "weather_provider": "openweathermap",
             "cloud_cover": 20,
             "temperature": 25.0,
             "wind_direction": 180,
@@ -410,21 +421,33 @@ class TestToCanonical:
             {"weather_main": "Clear", "snow": 0.0, "temp": 25.0}
         )
 
-        assert canonical == {"temperature": 25.0}
+        assert canonical == {
+            "weather_provider": "openweathermap",
+            "temperature": 25.0,
+        }
 
     def test_translates_the_condition(self):
         canonical = OpenWeatherMapBaseData.to_canonical({"weather_id": 500})
 
-        assert canonical == {"condition_code": 61}
+        assert canonical == {
+            "weather_provider": "openweathermap",
+            "condition_code": 61,
+        }
 
     def test_non_numeric_condition_becomes_none(self):
         """A string where a code belongs is missing data, not overcast."""
         canonical = OpenWeatherMapBaseData.to_canonical({"weather_id": "Clear"})
 
-        assert canonical == {"condition_code": None}
+        assert canonical == {
+            "weather_provider": "openweathermap",
+            "condition_code": None,
+        }
 
-    def test_empty_input_yields_empty_output(self):
-        assert OpenWeatherMapBaseData.to_canonical({}) == {}
+    def test_empty_input_yields_only_the_provider(self):
+        """The provider is this adapter's own fact, not one of the payload's."""
+        assert OpenWeatherMapBaseData.to_canonical({}) == {
+            "weather_provider": "openweathermap"
+        }
 
 
 class TestToCanonicalFrame:
@@ -470,6 +493,13 @@ class TestToCanonicalFrame:
         )
 
         assert isna(canonical["condition_code"].iloc[0])
+
+    def test_stamps_the_provider_onto_every_row(self):
+        data = concat([make_training_frame(), make_training_frame()])
+
+        canonical = OpenWeatherMapBaseData.to_canonical_frame(data)
+
+        assert list(canonical["weather_provider"]) == ["openweathermap"] * 2
 
     def test_input_frame_is_not_modified(self):
         data = make_training_frame()

--- a/uv.lock
+++ b/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "pvlearn"
-version = "0.2.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astral" },
@@ -861,9 +861,9 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/44/aa0ae4ef59c134290de5bca4b0806a5a9ccb50366d77db13d308d99db70b/pvlearn-0.2.2.tar.gz", hash = "sha256:a093993eef72c37f2044ad41aa032538484e14adbc7a283a917ce16269d93b92", size = 375669, upload-time = "2026-08-08T11:57:10.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/91/49ec31322b40e6d697e7230558ad1dba53774c64da22524966d4048f4287/pvlearn-0.4.0.tar.gz", hash = "sha256:259ab80a6ff4b38b1e20034576b546ae061dead47cb896c4178eba1c4a58e1e1", size = 366043, upload-time = "2026-08-11T21:26:52.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/81/cf76d245085e0930cdad5ab4883ee37a0f9f8bc7d1f3899f41492f6f0916/pvlearn-0.2.2-py3-none-any.whl", hash = "sha256:7357c6aea48086a1ecf63f7919bd65b73e0a5ab40e3b4dce3eb206d43ccfaaec", size = 17744, upload-time = "2026-08-08T11:57:08.883Z" },
+    { url = "https://files.pythonhosted.org/packages/82/de/76cf2f9ac5e66c5123888d3adda23d9e0247382287d56da1be35ec6f374a/pvlearn-0.4.0-py3-none-any.whl", hash = "sha256:8fa36c40a0d1a876bfa0fbe0a5fa5308953caa1e6e8699d819a6f4775e62b341", size = 17679, upload-time = "2026-08-11T21:26:50.671Z" },
 ]
 
 [[package]]
@@ -1348,7 +1348,7 @@ requires-dist = [
     { name = "jsonref", specifier = "==1.1.0" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "platformdirs", specifier = "==4.11.0" },
-    { name = "pvlearn", marker = "extra == 'forecast'", specifier = "==0.2.2" },
+    { name = "pvlearn", marker = "extra == 'forecast'", specifier = "==0.4.0" },
     { name = "pyarrow", marker = "extra == 'dev'", specifier = "==25.0.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", specifier = "==2.13.0" },


### PR DESCRIPTION
## What changed

pvlearn 0.2.2 → 0.4.0. Two breaking changes in the library, one of them affecting this repo's code:

- `ForecasterConfig.weather_provider` is gone. `weather_provider` is a per-row categorical feature in `pvlearn.schema` now — which provider a row came from is a fact of the training data, not a training-run setting. `interval_minutes` gained a default of 60; the service keeps passing it explicitly.
- `FEATURE_SCHEMA_VERSION`, `PIPELINE_VERSION` and `sklearn_version` were removed from the model sidecar in favour of the pvlearn release segment ([pvlearn ADR 0003](https://github.com/LearningHouseService/pvlearn/blob/main/docs/adr/0003-one-version-decides-model-compatibility.md)). Nothing here referenced them.

On this side:

- `OpenWeatherMapBaseData` gains `PROVIDER_FIELD` / `PROVIDER_NAME`, and stamps the name onto every row in `to_canonical()` and `to_canonical_frame()`. The constant sits next to the mapping table rather than in `forecast/service.py`, where `WEATHER_PROVIDER` used to live: a second provider brings its own name along with its own mapping.
- `forecast_training` gains no field. Every stored snapshot was written by this adapter, so the provider is derivable from where the row comes from — consistent with ADR 0002's decision that the measurement holds what the provider delivered.
- `docs/decisions/0003-weather-provider-as-a-feature.md` records both decisions.
- `pyproject.toml` and `uv.lock` bumped; `requirements*.txt` regenerated (gitignored).

## No migration

`ForecastService` never calls `Forecaster.save()` or `load()` — the model lives in memory and is trained from `forecast_training` on the first prediction after a start. A pvlearn release therefore costs one retrain on a path the service already takes at every start. Stored history is untouched and remains that retrain's input.

## Verification

- Full suite green: 1455 passed, including the slow `test_pvlearn_wiring_regression.py`. MAE/R² stay inside the baseline tolerance — the stamped provider is constant across the reference dataset, so the feature selector drops it.
- `ruff check`, `ruff format --check`, `pyright`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE4H8rWdCx8Sn4pG1mx1J3