### PR TITLE
ci: fine-tune setup-uv caching

### DIFF
--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -61,7 +61,9 @@ jobs:
           version: "0.12.3"
           python-version: "3.13"
           enable-cache: true
-          cache-suffix: "3.13"
+          # PR-branch caches are only ever read back within that same PR, so
+          # saving one is pure 10GB-repo-cache-quota spend for no reuse.
+          save-cache: ${{ github.event_name != 'pull_request' }}
 
       - name: Install package with dev dependencies
         run: uv sync --locked --extra dev --extra forecast
@@ -143,7 +145,9 @@ jobs:
           version: "0.12.3"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-          cache-suffix: ${{ matrix.python-version }}
+          # PR-branch caches are only ever read back within that same PR, so
+          # saving one is pure 10GB-repo-cache-quota spend for no reuse.
+          save-cache: ${{ github.event_name != 'pull_request' }}
 
       - name: Install package with dev dependencies
         run: uv sync --locked --extra dev --extra forecast


### PR DESCRIPTION
Small follow-up to #436, based on feedback pointing at `astral-sh/setup-uv`'s caching docs.

## What changed

- **Dropped `cache-suffix` on `build-check`/`build-compat`'s uv setup.** Verified against `docs/caching.md`: the auto-computed cache key already includes architecture, platform, OS version, Python version, and the dependency hash. Python version was already covered — the explicit suffix was redundant, not wrong.
- **Added `save-cache: ${{ github.event_name != 'pull_request' }}`.** GitHub Actions cache lookup is scoped to branch (falling back to the base branch), never to sibling PR branches — a cache written by a PR-branch run is never read by anything except that same PR. Saving one on every PR push is pure spend against the repo's 10GB cache quota with no reuse. Push/release runs on `main`/`storedge` keep saving, since those are the caches PRs actually fall back to.
- **`prune-cache` left at its default** (`false` as of `setup-uv` v9.0.0 — confirmed via the docs, this default itself flipped in a past release specifically to reduce load on PyPI's infrastructure). Every package in this project's dependency closure resolves to a wheel, nothing builds from source, so pruning would never remove anything here anyway — full cache persistence is already the right call.

## Verification

`ruff`/`pyright` clean, YAML syntax validated. This is a caching-behavior-only change to `build_project.yml` — nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE4H8rWdCx8Sn4pG1mx1J3