### PR TITLE
perf: isolate the per-commit version file into its own Docker layer

### DIFF
--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -191,6 +191,14 @@ jobs:
         # environment instead - no system Python involved at all.
         run: uv run --no-project --with 'setuptools-scm[toml]>=8' python freeze_version.py
 
+      - name: Move _version.py out of the build context's source tree
+        # It bakes the exact commit, so it's different on every build -
+        # kept out of solaredge2mqtt/ here so the Dockerfile's bulk COPY of
+        # that directory stays cache-reusable across builds of the same
+        # code; the Dockerfile copies this back into place as its own,
+        # much smaller, always-fresh final layer.
+        run: mv solaredge2mqtt/_version.py _version.py
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c

--- a/.gitignore
+++ b/.gitignore
@@ -169,5 +169,6 @@ data.csv
 docker/container/
 
 solaredge2mqtt/_version.py
+/_version.py
 
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,14 @@ COPY --chown=root:solaredge2mqtt --chmod=755 \
 COPY --chown=root:solaredge2mqtt --chmod=755 \
     pyproject.toml README.md LICENSE ./
 COPY --chown=root:root --chmod=755 docker-entrypoint.sh /usr/local/bin/
+# solaredge2mqtt/_version.py bakes the exact git commit, so it differs on
+# every build - never at repo root when this build starts (see
+# build_project.yml's "Generate static solaredge2mqtt/_version.py" step,
+# which moves it there before `docker build` runs). Copied in as its own
+# layer, last, so the source tree above stays cache-reusable across builds
+# of the same code and only this ~1KB layer is ever new.
+COPY --chown=root:solaredge2mqtt --chmod=755 \
+    _version.py ./solaredge2mqtt/_version.py
 
 VOLUME ["/app/config"]
 


### PR DESCRIPTION
Follow-up from the cache cleanup discussion — the second factor behind storedge accumulating way more cache entries than main: every build's `solaredge2mqtt/_version.py` bakes the exact commit (and build date, via `node-and-date`), so it's unique per build.

## The problem

`_version.py` used to live inside `solaredge2mqtt/` before `docker build` even ran. The Dockerfile's single bulk `COPY solaredge2mqtt/ ./solaredge2mqtt/` layer — the actual application source, much larger than this one generated file — could therefore never be reused from cache across two different commits, even when the real code hadn't changed at all. Every `build-docker` run (two per push, one per arch) uploaded a fresh copy of the whole source tree to the GHA cache for that reason alone.

## The fix

`build_project.yml` now moves `_version.py` to the repo root right after generating it, before `docker build` runs — so it's not present inside `solaredge2mqtt/` when the Dockerfile's bulk `COPY` captures that directory. The Dockerfile copies it back into `./solaredge2mqtt/_version.py` as its own final layer instead.

Considered `COPY --exclude=` to do this in one Dockerfile instruction without touching the CI step — verified locally (plain syntax and `docker/dockerfile:1-labs`, current buildx) that it does **not** actually exclude the file on this BuildKit version, so not something to ship on faith. Went with the CI-side move instead, which needs no BuildKit feature at all.

## Verification

Not just reasoning — built the image twice with `SETUPTOOLS_SCM_PRETEND_VERSION` set to two different values, identical source both times, and confirmed via `docker build --progress=plain`:

```
[stage-1 5/8] COPY solaredge2mqtt/ ./solaredge2mqtt/   → CACHED (second build)
[stage-1 8/8] COPY _version.py ./solaredge2mqtt/_version.py → new (~1KB)
```

Everything before the version layer — including the `uv sync` build stage — showed `CACHED`. Both resulting images report their own correct version at runtime (`1.0.0` / `2.0.0` respectively).

`ruff`/`pyright`/`pytest` (1446 passed) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE4H8rWdCx8Sn4pG1mx1J3