### PR TITLE
ci: stop pull requests from filling the Actions cache quota

### DIFF
--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -22,6 +22,7 @@ jobs:
   variables:
     outputs:
       ref_name: ${{ steps.var.outputs.ref_name}}
+      cache_ref_name: ${{ steps.var.outputs.cache_ref_name }}
       image_name: ${{ steps.var.outputs.image_name }}
       ghcr_image: ${{ steps.var.outputs.ghcr_image }}
       version: ${{ steps.var.outputs.version }}
@@ -34,8 +35,18 @@ jobs:
         id: var
         with:
           script: |
+            const slug = (value) => value.toLowerCase().replaceAll(/[/.]/g, '-').trim('-');
             const refName = '${{ github.ref_name || github.event.release.tag_name }}';
-            core.setOutput('ref_name', refName.toLowerCase().replaceAll(/[/.]/g, '-').trim('-'));
+            core.setOutput('ref_name', slug(refName));
+            // Docker layer cache scope. On a pull request this points at the
+            // base branch instead of the PR's own ref: a PR-scoped cache can
+            // only ever be read back by re-runs of that same PR, so scoping
+            // to the PR means every PR build starts cold and then writes a
+            // few hundred MB that nothing will ever read again. Reading the
+            // base branch's scope instead makes PR builds warm; build-docker
+            // correspondingly only writes the cache on push/release.
+            const baseRef = '${{ github.base_ref }}';
+            core.setOutput('cache_ref_name', slug(baseRef || refName));
             core.setOutput('image_name', '${{ github.repository }}'.toLowerCase());
             core.setOutput('ghcr_image', '${{ env.REGISTRY_GITHUB }}/${{ github.repository }}'.toLowerCase());
             const version = refName.replace(/^v/, '');
@@ -160,6 +171,7 @@ jobs:
     needs: [variables, build-check]
     env:
       REF_NAME: ${{ needs.variables.outputs.ref_name }}
+      CACHE_REF_NAME: ${{ needs.variables.outputs.cache_ref_name }}
       IMAGE_NAME: ${{ needs.variables.outputs.image_name }}
       GHCR_IMAGE: ${{ needs.variables.outputs.ghcr_image }}
       VERSION: ${{ needs.variables.outputs.version }}
@@ -241,8 +253,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ github.repository }}-${{ env.REF_NAME }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ env.REF_NAME }}-${{ matrix.arch }}
+          # CACHE_REF_NAME is the base branch on a pull request (see the
+          # variables job), so PR builds read the base branch's warm cache
+          # instead of starting cold in a PR-private scope.
+          cache-from: type=gha,scope=${{ github.repository }}-${{ env.CACHE_REF_NAME }}-${{ matrix.arch }}
+          # Written only on push/release. A cache written by a PR build is
+          # readable exclusively by re-runs of that same PR, so on a PR it is
+          # a few hundred MB of the repo's 10GB quota that nothing ever reads.
+          cache-to: ${{ (github.event_name == 'push' || github.event_name == 'release') && format('type=gha,mode=max,scope={0}-{1}-{2}', github.repository, env.CACHE_REF_NAME, matrix.arch) || '' }}
 
       # merge-manifest combines these per-arch builds by digest, not by the
       # mutable per-arch tags above: two overlapping workflow runs racing to

--- a/.github/workflows/cleanup_pr_caches.yml
+++ b/.github/workflows/cleanup_pr_caches.yml
@@ -1,0 +1,30 @@
+name: cleanup-pr-caches
+
+# A cache created by a pull request run is readable only by re-runs of that
+# same pull request - not by the base branch, not by other PRs. Once the PR
+# closes it is dead weight that still counts against the repository's 10GB
+# cache quota until GitHub's 7-day eviction gets to it, pushing genuinely
+# useful branch caches out in the meantime.
+#
+# build_project.yml already avoids writing the Docker layer cache on pull
+# requests, so in the normal case there is nothing here to delete. This runs
+# as a safety net for anything that does end up PR-scoped anyway.
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches scoped to this pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -eux
+          gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches


### PR DESCRIPTION
Follow-up to today's cache cleanup (494 → 109 entries, 10.76 GB → ~2.2 GB). This stops the backlog from rebuilding itself.

## Why

~6 GB of what we deleted was PR-scoped Docker layer cache from long-merged PRs. Per [GitHub's docs](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching), a cache written by a PR run *"can only be restored by re-runs of the pull request. It cannot be restored by the base branch or other pull requests targeting that base branch."* Every one of those was dead the moment its PR merged — but still occupied quota until the 7-day eviction, pushing genuinely useful branch caches out under the 10 GB LRU limit in the meantime.

## Preventive — `build_project.yml`

The Docker layer cache scope was `<repo>-<REF_NAME>-<arch>`, and `REF_NAME` on a PR is e.g. `436-merge`. That scope is private to the PR, so a PR build both **started cold** and then **wrote a few hundred MB nobody would ever read**.

`variables` now also emits `cache_ref_name` — the base branch on a pull request, the ref itself otherwise. `build-docker` reads from that scope and only writes on push/release.

Net effect: **PR builds consume zero cache quota and get faster**, since they finally read the base branch's warm cache instead of starting from scratch. Image tags are unaffected — those still come from `ref_name`.

## Safety net — `cleanup_pr_caches.yml` (new)

On `pull_request: closed`, deletes anything still scoped to `refs/pull/<N>/merge`. With the change above there should normally be nothing to delete; this covers anything that ends up PR-scoped anyway and collapses the 7-day eviction wait to zero.

## Verification

- Simulated the `variables` job's slug logic in node across all five event shapes (push to storedge/main, PR against storedge/main, release tag). A PR against `storedge` resolves `cache_ref_name` → `storedge`, while `ref_name` — which drives the image tags — correctly stays `440-merge`.
- Ran `actionlint` over both workflows: **no expression errors**. Only findings are two pre-existing shellcheck infos on lines this PR doesn't touch.
- `ruff`/`pyright`/`pytest` (1446) green.

This PR's own CI run is itself the live test of the read-from-base-branch path — worth a glance at whether `build-docker` shows cache hits and skips the cache export step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE4H8rWdCx8Sn4pG1mx1J3