### PR TITLE
fix: limit optimal battery charge start time to the current day

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ forecast:
   battery_charge_efficiency: 0.92    # Charge efficiency used for the optimal charge start time
 ```
 
-If a battery is detected via Modbus, the forecast also publishes `battery_charge_optimal_start_time`: the earliest time today/tomorrow at which charging the battery from its strongest remaining forecasted production slots (sorted by output, accumulated until `battery_target_soc` is covered) should start.
+If a battery is detected via Modbus, the forecast also publishes `battery_charge_optimal_start_time`: the earliest time at which charging the battery from its strongest remaining forecasted production slots (sorted by output, accumulated until `battery_target_soc` is covered) should start. Only slots of the current day are considered; if today's remaining production cannot cover the need, no start time is published.
 
 **Prerequisites**:
 - Minimum 60 hours of training data must be collected before forecasting begins

--- a/solaredge2mqtt/services/forecast/models.py
+++ b/solaredge2mqtt/services/forecast/models.py
@@ -75,17 +75,22 @@ class Forecast(Component, ForecastResult):
         if not self.battery_charge_needed_wh or self.battery_charge_needed_wh <= 0:
             return None
 
-        now = self._hour_start(self._now_local())
-        upcoming_slots = [
-            (slot_time, slot_energy)
-            for slot_time, slot_energy in self.energy_period.items()
-            if slot_time >= now
+        now = self._now_local()
+        hour_start = self._instant(self._hour_start(now))
+        # Charging only makes sense within the current day, tomorrow's slots
+        # would be recomputed against tomorrow's state of charge anyway.
+        remaining_today = [
+            (period.instant, energy)
+            for period, energy in self._periods()
+            if period.local.date() == now.date() and period.instant >= hour_start
         ]
 
-        if not upcoming_slots:
+        if not remaining_today:
             return None
 
-        strongest_first = sorted(upcoming_slots, key=lambda slot: slot[1], reverse=True)
+        strongest_first = sorted(
+            remaining_today, key=lambda slot: slot[1], reverse=True
+        )
 
         accumulated = 0
         selected_times: list[datetime] = []

--- a/tests/services/forecast/test_models.py
+++ b/tests/services/forecast/test_models.py
@@ -153,11 +153,22 @@ class TestForecast:
     @patch("solaredge2mqtt.services.forecast.models.Forecast._now")
     def test_battery_charge_optimal_start_time_skips_passed_slots(self, mock_now):
         """Test optimal start time ignores slots that are already in the past."""
-        # Today's 12:00 peak (1000 Wh) has already passed at 13:00.
+        # Today's 12:00 peak (1000 Wh) has already passed at 13:00, so 13:00
+        # (920 Wh) and 14:00 (840 Wh) together cover the need.
         mock_now.return_value = self.at_local_hour(13)
         forecast = self.make_forecast(battery_charge_needed_wh=1000)
 
-        assert forecast.battery_charge_optimal_start_time == self.at_local_hour(36)
+        assert forecast.battery_charge_optimal_start_time == self.at_local_hour(13)
+
+    @patch("solaredge2mqtt.services.forecast.models.Forecast._now")
+    def test_battery_charge_optimal_start_time_ignores_tomorrow(self, mock_now):
+        """Tomorrow's production must not be proposed as today's start time."""
+        # After sunset today's remaining slots are all 0 Wh, while tomorrow
+        # would easily cover the need.
+        mock_now.return_value = self.at_local_hour(19)
+        forecast = self.make_forecast(battery_charge_needed_wh=1000)
+
+        assert forecast.battery_charge_optimal_start_time is None
 
     @patch("solaredge2mqtt.services.forecast.models.Forecast._now")
     def test_battery_charge_optimal_start_time_none_when_forecast_is_over(


### PR DESCRIPTION
## Problem

`battery_charge_optimal_start_time` filtered the forecast slots with `slot_time >= now` over the full 48 hour window. Whenever today's remaining slots were weaker than tomorrow's peak (or the peak had already passed), the strongest-first selection landed on tomorrow. A live system showed *tomorrow 10:00* although charging today was still possible.

## Fix

`solaredge2mqtt/services/forecast/models.py` now filters candidates the same way `energy_today_remaining` does:

- `period.local.date() == now.date()` — current day only (via `_periods()`, so UTC keys are split on the correct local date)
- `period.instant >= hour_start` — current hour onwards

If today's remaining production cannot cover `battery_charge_needed_wh`, no start time is published instead of pointing at tomorrow.

## Tests

- `test_battery_charge_optimal_start_time_skips_passed_slots` now expects 13:00 (13:00 + 14:00 cover the need) instead of tomorrow's noon peak
- new `test_battery_charge_optimal_start_time_ignores_tomorrow`: after sunset the result is `None`, even though tomorrow would cover the need

Full suite: 1442 passed. README wording updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)