### PR TITLE
ci: drop the storedge branch from the build triggers

### DIFF
--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -9,9 +9,9 @@ on:
   # (used below to gate docker publish) -- GitHub Actions `on:` triggers can't
   # reference vars/expressions directly.
   push:
-    branches: [main, storedge]
+    branches: [main]
   pull_request:
-    branches: [main, storedge]
+    branches: [main]
   release:
     types: [published]
 


### PR DESCRIPTION
Follow-up to the `storedge` → `main` rebase-merge (#441).

`storedge` is gone as a line of development, so `build_project.yml` no longer needs to listen on it. Pushes can never arrive there again, and a stale entry drifts out of sync with the `PACKAGE_BRANCHES` repo variable that gates the docker publish — the comment above the triggers asks for both to be kept aligned.

- `push` and `pull_request` triggers narrowed to `[main]`
- `PACKAGE_BRANCHES` repo variable set to `["main"]` (done outside the repo, after the first post-merge `main` build has published its images)

The `storedge` mention in `docs/decisions/0004-drop-armv7-support.md` stays: decision records are append-only and that one describes history, not a live branch.