### PR TITLE
docs: mount the cache directory in the container examples

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ghcr.io/deroetzi/solaredge2mqtt:latest
     volumes:
       - ./config:/app/config
+      - ./cache:/app/cache
     environment:
       - TZ=Europe/Berlin
     restart: unless-stopped

--- a/docs/configuration/forecast.md
+++ b/docs/configuration/forecast.md
@@ -70,6 +70,10 @@ The model is discarded and rebuilt from scratch whenever it no longer fits the c
 example after an update that ships a new pvlearn release or after a change of `location`. That is
 logged, needs no action and costs one training run.
 
+In a container the cache directory is `/app/cache`. Mount it, as the compose file and the
+[Docker deployment](../deployment/docker.md) do, or the model lives in the container's own layer
+and a `docker compose down` or `docker rm` throws it away.
+
 ## Optimal battery charge start time
 
 If a battery is detected over Modbus, the forecast also publishes

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -12,13 +12,18 @@ For a multi-container setup, see [Docker Compose](docker-compose.md).
 docker pull ghcr.io/deroetzi/solaredge2mqtt:latest
 ```
 
-## 2. Prepare the configuration directory
+## 2. Prepare the directories
 
 The container reads `/app/config`. Mount a host directory there. The SQLite history is written
 to the same place, so it has to survive container restarts.
 
+`/app/cache` holds the trained forecast model and the training cache. Mounting it is optional:
+without the mount both live in the container's own layer, which a `docker rm` or a
+`docker compose down` throws away, and the next start trains from scratch. Everything else keeps
+working.
+
 ```bash
-mkdir -p config
+mkdir -p config cache
 ```
 
 ## 3. Create the configuration
@@ -30,6 +35,7 @@ mkdir -p config
     ```bash
     docker run -d --name solaredge2mqtt \
         -v $(pwd)/config:/app/config \
+        -v $(pwd)/cache:/app/cache \
         -e "TZ=Europe/Berlin" \
         --restart unless-stopped \
         ghcr.io/deroetzi/solaredge2mqtt:latest
@@ -62,6 +68,7 @@ What goes in those files is covered in
 ```bash
 docker run -d --name solaredge2mqtt \
     -v $(pwd)/config:/app/config \
+    -v $(pwd)/cache:/app/cache \
     -e "TZ=Europe/Berlin" \
     --restart unless-stopped \
     ghcr.io/deroetzi/solaredge2mqtt:latest

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,10 +26,11 @@ directory holding `configuration.yml` and `secrets.yml`, which the
 === "Docker"
 
     ```bash
-    mkdir -p config
+    mkdir -p config cache
 
     docker run -d --name solaredge2mqtt \
         -v $(pwd)/config:/app/config \
+        -v $(pwd)/cache:/app/cache \
         -e "TZ=Europe/Berlin" \
         --restart unless-stopped \
         ghcr.io/deroetzi/solaredge2mqtt:latest
@@ -47,7 +48,7 @@ directory holding `configuration.yml` and `secrets.yml`, which the
     curl -o docker-compose.yml \
         https://raw.githubusercontent.com/DerOetzi/solaredge2mqtt/master/docker-compose.yml
 
-    mkdir -p config
+    mkdir -p config cache
     docker compose up -d
     ```
 

--- a/examples/docker-compose-full-stack.yaml
+++ b/examples/docker-compose-full-stack.yaml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/deroetzi/solaredge2mqtt:latest
     volumes:
       - ./config:/app/config
+      - ./cache:/app/cache
     environment:
       - TZ=Europe/Berlin
     restart: unless-stopped


### PR DESCRIPTION
Follow-up to #454, which landed the model persistence but left the directory it writes to unmounted.

`/app/cache` exists in the image and the entrypoint fixes its permissions, but no example mounted it. The trained forecast model therefore lived in the container's own layer, where a `docker rm` or a `docker compose down` throws it away and the next start trains from scratch.

## What changes

- `docker-compose.yml` and the full-stack example mount `./cache:/app/cache`.
- Both `docker run` recipes and the installation page do the same, with `mkdir -p config cache`.
- The Docker deployment page says what happens without the mount, since it stays optional and only the forecast depends on it.
- The forecast configuration page points at it from the persistence section.

No `VOLUME` declaration was added for it. Without an explicit mount that hands every new container a fresh anonymous volume, which persists nothing and leaves the previous ones behind as dangling volumes; with a mount it does nothing at all.

Existing installations that do not update their compose file keep losing the model on a `down`. That costs one training run and nothing else.

`mkdocs build --strict` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)